### PR TITLE
chore: remove cookie name environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ The following need to be installed/configured for local use:
 
 ### Environment Variables
 
-| Name             | Description                                                     | Default Value | Required           |
-| ---------------- | --------------------------------------------------------------- | ------------- | ------------------ |
-| FIDC_URL         | ForgeRock Identity Cloud URL.                                   | N/A           | :white_check_mark: |
-| FIDC_COOKIE_NAME | ForgeRock Identity Cloud Cookie Name(found in tenant settings). | N/A           | :white_check_mark: |
-| PHASE            | Phase number (0-4). Controls which config is used.              | 0             |                    |
+| Name     | Description                                        | Default Value | Required           |
+| -------- | -------------------------------------------------- | ------------- | ------------------ |
+| FIDC_URL | ForgeRock Identity Cloud URL.                      | N/A           | :white_check_mark: |
+| PHASE    | Phase number (0-4). Controls which config is used. | 0             |                    |
 
 ### Install Dependencies
 

--- a/helpers/get-session-token.js
+++ b/helpers/get-session-token.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch')
 
 const getSessionToken = async (argv) => {
-  const { username, password } = argv
+  const { username, password, realm } = argv
 
   // Check environment variables
   const { FIDC_URL } = process.env
@@ -11,7 +11,7 @@ const getSessionToken = async (argv) => {
   }
 
   // Get session token
-  const requestUrl = `${FIDC_URL}/am/json/authenticate`
+  const requestUrl = `${FIDC_URL}/am/json${realm}/authenticate`
 
   const topLevelRequestOptions = {
     method: 'post',
@@ -84,8 +84,7 @@ const getSessionToken = async (argv) => {
         `${sessionTokenResponse.status}: ${sessionTokenResponse.statusText}`
       )
     }
-    const { tokenId } = await sessionTokenResponse.json()
-    return Promise.resolve(tokenId)
+    return Promise.resolve(sessionTokenResponse.headers.get('set-cookie'))
   } catch (error) {
     return Promise.reject(error)
   }

--- a/scripts/update-auth-trees/update-auth-trees.js
+++ b/scripts/update-auth-trees/update-auth-trees.js
@@ -8,10 +8,10 @@ const updateAuthTrees = async (argv) => {
   const { realm } = argv
 
   // Check environment variables
-  const { FIDC_URL, FIDC_COOKIE_NAME, PHASE = '0' } = process.env
+  const { FIDC_URL, PHASE = '0' } = process.env
 
-  if (!FIDC_URL || !FIDC_COOKIE_NAME) {
-    console.error('Missing required environment variable(s)')
+  if (!FIDC_URL) {
+    console.error('Missing FIDC_URL environment variable')
     return process.exit(1)
   }
 
@@ -38,10 +38,9 @@ const updateAuthTrees = async (argv) => {
           return Promise.reject(new Error('Missing _id in auth tree config'))
         }
         const baseUrl = `${FIDC_URL}/am/json${realm}/realm-config/authentication/authenticationtrees`
-        const cookieHeader = `${FIDC_COOKIE_NAME}=${sessionToken}`
         await Promise.all(
           authTreeFile.nodes.map(async (node) => {
-            return await updateNode(baseUrl, cookieHeader, node)
+            return await updateNode(baseUrl, sessionToken, node)
           })
         )
         console.log('nodes updated')
@@ -52,7 +51,7 @@ const updateAuthTrees = async (argv) => {
           headers: {
             'content-type': 'application/json',
             'x-requested-with': 'ForgeRock CREST.js',
-            cookie: cookieHeader
+            cookie: sessionToken
           }
         }
         const { status, statusText } = await fetch(requestUrl, requestOptions)

--- a/tests/helpers/get-session-token.test.js
+++ b/tests/helpers/get-session-token.test.js
@@ -8,11 +8,12 @@ describe('get-session-token', () => {
     fidcUrl: 'https://fidc-test.forgerock.com',
     username: 'test-user',
     password: 'SecurePassword123',
+    realm: '/realms/root/realms/alpha',
     authId: 'auth-1234',
-    sessionToken: 'session-1234'
+    sessionToken: 'session=1234'
   }
 
-  const expectedUrl = `${mockValues.fidcUrl}/am/json/authenticate`
+  const expectedUrl = `${mockValues.fidcUrl}/am/json${mockValues.realm}/authenticate`
 
   const expectedTopLevelOptions = {
     method: 'post',
@@ -94,7 +95,9 @@ describe('get-session-token', () => {
         Promise.resolve({
           status: 200,
           statusText: 'OK',
-          json: () => Promise.resolve({ tokenId: mockValues.sessionToken })
+          headers: {
+            get: () => Promise.resolve(mockValues.sessionToken)
+          }
         })
       )
     await expect(getSessionToken(mockValues)).resolves.toEqual(

--- a/tests/scripts/update-auth-trees.test.js
+++ b/tests/scripts/update-auth-trees.test.js
@@ -16,8 +16,7 @@ describe('update-auth-trees', () => {
 
   const mockValues = {
     fidcUrl: 'https://fidc-test.forgerock.com',
-    fidcCookieName: 'frcookie',
-    sessionToken: 'forgerock-token',
+    sessionToken: 'session=1234',
     realm: '/realms/root/realms/alpha'
   }
 
@@ -108,7 +107,6 @@ describe('update-auth-trees', () => {
     )
     updateNode.mockImplementation(() => Promise.resolve())
     process.env.FIDC_URL = mockValues.fidcUrl
-    process.env.FIDC_COOKIE_NAME = mockValues.fidcCookieName
     delete process.env.PHASE
     fs.readdirSync.mockReturnValue(['login-tree.json'])
     jest.mock(mockPhase0ConfigFile, () => mockPhase0Config, { virtual: true })
@@ -134,17 +132,7 @@ describe('update-auth-trees', () => {
     delete process.env.FIDC_URL
     await updateAuthTrees(mockValues)
     expect(console.error).toHaveBeenCalledWith(
-      'Missing required environment variable(s)'
-    )
-    expect(process.exit).toHaveBeenCalledWith(1)
-  })
-
-  it('should error if missing FIDC_COOKIE_NAME environment variable', async () => {
-    expect.assertions(2)
-    delete process.env.FIDC_COOKIE_NAME
-    await updateAuthTrees(mockValues)
-    expect(console.error).toHaveBeenCalledWith(
-      'Missing required environment variable(s)'
+      'Missing FIDC_URL environment variable'
     )
     expect(process.exit).toHaveBeenCalledWith(1)
   })
@@ -177,7 +165,7 @@ describe('update-auth-trees', () => {
       headers: {
         'content-type': 'application/json',
         'x-requested-with': 'ForgeRock CREST.js',
-        cookie: `${mockValues.fidcCookieName}=${mockValues.sessionToken}`
+        cookie: mockValues.sessionToken
       },
       body: JSON.stringify(mockPhase0Config.tree)
     }
@@ -198,7 +186,7 @@ describe('update-auth-trees', () => {
       headers: {
         'content-type': 'application/json',
         'x-requested-with': 'ForgeRock CREST.js',
-        cookie: `${mockValues.fidcCookieName}=${mockValues.sessionToken}`
+        cookie: mockValues.sessionToken
       },
       body: JSON.stringify(mockPhase1Config.tree)
     }
@@ -217,7 +205,7 @@ describe('update-auth-trees', () => {
       headers: {
         'content-type': 'application/json',
         'x-requested-with': 'ForgeRock CREST.js',
-        cookie: `${mockValues.fidcCookieName}=${mockValues.sessionToken}`
+        cookie: mockValues.sessionToken
       },
       body: JSON.stringify(mockPhase0Config.tree)
     }


### PR DESCRIPTION
Realised we can get the cookie name from the existing API calls so removing the environment variable requirement