### PR TITLE
feature: internal roles script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All scripts can also be ran locally with the correct arguments and environment v
 
 ### Update Managed Objects
 
-Calls the Identity Management endpoint to get update Managed Objects. The configuration is store in JSON files in the `config/managed-objects` directory.
+Calls the Identity Management endpoint to get update Managed Objects. The configuration is stored in JSON files in the `config/managed-objects` directory.
 
 **This command will update all Managed Objects and delete any not present in the directory.**
 
@@ -38,9 +38,21 @@ Calls the Identity Management endpoint to get update Managed Objects. The config
 
 ### Update Auth Trees
 
-Calls the Access Management endpoint to get update Authentication Trees. The configuration is store in JSON files in the `config/auth-trees` directory.
-
-**This command will update all Managed Objects and delete any not present in the directory.**
+Calls the Access Management endpoint to get update Authentication Trees. The configuration is stored in JSON files in the `config/auth-trees` directory.
 
 **Help Message:**
 `update-auth-trees -h`
+
+### User Roles
+
+Calls the Identity Management endpoint to get update User Roles. The configuration is stored in JSON files in the `config/user-roles` directory.
+
+**Help Message:**
+`update-user-roles -h`
+
+### Internal Roles
+
+Calls the Identity Management endpoint to get update Internal Roles. The configuration is stored in JSON files in the `config/internal-roles` directory.
+
+**Help Message:**
+`update-internal-roles -h`

--- a/config/phase-0/internal-roles/admin.json
+++ b/config/phase-0/internal-roles/admin.json
@@ -1,0 +1,45 @@
+{
+  "_id": "b0967532-8fb3-43b5-b383-7b72dd498dae",
+  "name": "Admin",
+  "description": "Admin role for internal users",
+  "privileges": [
+    {
+      "path": "managed/Company",
+      "name": "Companies",
+      "actions": [],
+      "permissions": [
+        "VIEW"
+      ],
+      "accessFlags": [
+        {
+          "attribute": "name",
+          "readOnly": true
+        },
+        {
+          "attribute": "presenters",
+          "readOnly": true
+        },
+        {
+          "attribute": "number",
+          "readOnly": true
+        },
+        {
+          "attribute": "type",
+          "readOnly": true
+        },
+        {
+          "attribute": "status",
+          "readOnly": true
+        },
+        {
+          "attribute": "authCode",
+          "readOnly": true
+        },
+        {
+          "attribute": "hasAuthorisedUsers",
+          "readOnly": true
+        }
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,10 @@
         "yargs": "^16.2.0"
       },
       "bin": {
-        "update-managed-objects": "scripts/update-managed-objects/index.js"
+        "update-auth-trees": "scripts/update-auth-trees/index.js",
+        "update-internal-roles": "scripts/update-internal-roles/index.js",
+        "update-managed-objects": "scripts/update-managed-objects/index.js",
+        "update-user-roles": "scripts/update-user-roles/index.js"
       },
       "devDependencies": {
         "jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "bin": {
     "update-auth-trees": "./scripts/update-auth-trees/index.js",
+    "update-internal-roles": "./scripts/update-internal-roles/index.js",
     "update-managed-objects": "./scripts/update-managed-objects/index.js",
     "update-user-roles": "./scripts/update-user-roles/index.js"
   },

--- a/scripts/update-internal-roles/index.js
+++ b/scripts/update-internal-roles/index.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const yargs = require('yargs')
+const updateInternalRoles = require('./update-internal-roles')
+
+// Script arguments
+yargs
+  .usage('Usage: $0 [arguments]')
+  .version(false)
+  .help('h')
+  .alias('h', 'help')
+  .alias('u', 'username')
+  .alias('p', 'password')
+  .alias('a', 'adminClientId')
+  .alias('s', 'adminClientSecret')
+  .alias('r', 'realm')
+  .default('r', '/realms/root/realms/alpha')
+  .describe('u', 'Username')
+  .describe('p', 'Password')
+  .describe('a', 'Admin Client ID')
+  .describe('s', 'Admin Client Secret')
+  .describe('r', 'Realm')
+  .demandOption(['u', 'p', 'a', 's'])
+  .command({
+    command: '$0',
+    desc: 'default',
+    handler: (argv) => updateInternalRoles(argv)
+  })
+  .parse()

--- a/scripts/update-internal-roles/update-internal-roles.js
+++ b/scripts/update-internal-roles/update-internal-roles.js
@@ -1,0 +1,59 @@
+const fetch = require('node-fetch')
+const fs = require('fs')
+const path = require('path')
+const getAccessToken = require('../../helpers/get-access-token')
+
+const updateInternalRoles = async (argv) => {
+  // Check environment variables
+  const { FIDC_URL, PHASE = '0' } = process.env
+
+  if (!FIDC_URL) {
+    console.error('Missing FIDC_URL environment variable')
+    return process.exit(1)
+  }
+
+  try {
+    const accessToken = await getAccessToken(argv)
+
+    console.log(`Using phase ${PHASE} config`)
+
+    // Combine internal roles JSON files
+    const dir = path.resolve(
+      __dirname,
+      `../../config/phase-${PHASE}/internal-roles`
+    )
+
+    const internalRolesFileContent = fs
+      .readdirSync(dir)
+      .filter((name) => path.extname(name) === '.json') // Filter out any non JSON files
+      .map((filename) => require(path.join(dir, filename))) // Map JSON file content to an array
+
+    await Promise.all(
+      internalRolesFileContent.map(async (internalRoleFile) => {
+        const requestUrl = `${FIDC_URL}/openidm/internal/role/${internalRoleFile._id}`
+        const requestOptions = {
+          method: 'put',
+          body: JSON.stringify(internalRoleFile),
+          headers: {
+            authorization: `Bearer ${accessToken}`,
+            'content-type': 'application/json'
+          }
+        }
+        const { status, statusText } = await fetch(requestUrl, requestOptions)
+        if (status > 299) {
+          return Promise.reject(
+            new Error(`${internalRoleFile.name} ${status}: ${statusText}`)
+          )
+        }
+        console.log(`${internalRoleFile.name} updated`)
+        return Promise.resolve()
+      })
+    )
+    console.log('Internal roles updated')
+  } catch (error) {
+    console.error(error.message)
+    process.exit(1)
+  }
+}
+
+module.exports = updateInternalRoles

--- a/tests/scripts/update-internal-roles.test.js
+++ b/tests/scripts/update-internal-roles.test.js
@@ -1,0 +1,168 @@
+describe('update-internal-roles', () => {
+  jest.mock('node-fetch')
+  const fetch = require('node-fetch')
+  jest.mock('fs')
+  const fs = require('fs')
+  const path = require('path')
+  jest.mock('../../helpers/get-access-token')
+  const getAccessToken = require('../../helpers/get-access-token')
+  jest.spyOn(console, 'log').mockImplementation(() => {})
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  jest.spyOn(process, 'exit').mockImplementation(() => {})
+
+  const updateUserRoles = require('../../scripts/update-internal-roles/update-internal-roles')
+
+  const mockValues = {
+    fidcUrl: 'https://fidc-test.forgerock.com',
+    accessToken: 'forgerock-token'
+  }
+
+  const mockPhase0ConfigFile = path.resolve(
+    __dirname,
+    '../../config/phase-0/internal-roles/admin.json'
+  )
+  const mockPhase1ConfigFile1 = path.resolve(
+    __dirname,
+    '../../config/phase-1/internal-roles/admin.json'
+  )
+  const mockPhase1ConfigFile2 = path.resolve(
+    __dirname,
+    '../../config/phase-1/internal-roles/write-user.json'
+  )
+
+  const mockPhase0Config = {
+    _id: 'abcd',
+    name: 'Admin',
+    description: 'Admin role for internal users',
+    privileges: [
+      {
+        path: 'managed/Company',
+        name: 'Companies',
+        permissions: ['ALL']
+      }
+    ]
+  }
+
+  const mockPhase1Config = {
+    _id: '1234',
+    name: 'Write User',
+    description: 'Write permissions for internal users',
+    privileges: [
+      {
+        path: 'managed/Company',
+        name: 'Companies',
+        permissions: ['WRITE']
+      }
+    ]
+  }
+
+  beforeEach(() => {
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        statusText: 'OK'
+      })
+    )
+    getAccessToken.mockImplementation(() =>
+      Promise.resolve(mockValues.accessToken)
+    )
+    process.env.FIDC_URL = mockValues.fidcUrl
+    delete process.env.PHASE
+    fs.readdirSync.mockReturnValue(['admin.json'])
+    jest.mock(mockPhase0ConfigFile, () => mockPhase0Config, { virtual: true })
+    jest.mock(mockPhase1ConfigFile1, () => mockPhase1Config, { virtual: true })
+    jest.mock(mockPhase1ConfigFile2, () => mockPhase1Config, { virtual: true })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    console.log.mockClear()
+    console.error.mockClear()
+    process.exit.mockClear()
+  })
+
+  afterAll(() => {
+    console.log.mockRestore()
+    console.error.mockRestore()
+    process.exit.mockRestore()
+  })
+
+  it('should error if missing FRIC environment variable', async () => {
+    expect.assertions(2)
+    delete process.env.FIDC_URL
+    await updateUserRoles(mockValues)
+    expect(console.error).toHaveBeenCalledWith(
+      'Missing FIDC_URL environment variable'
+    )
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('should error if getAccessToken functions fails', async () => {
+    expect.assertions(2)
+    const errorMessage = 'Invalid user'
+    getAccessToken.mockImplementation(() =>
+      Promise.reject(new Error(errorMessage))
+    )
+    await updateUserRoles(mockValues)
+    expect(console.error).toHaveBeenCalledWith(errorMessage)
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('should call API with phase 0 config by default', async () => {
+    expect.assertions(2)
+    const expectedUrl = `${mockValues.fidcUrl}/openidm/internal/role/${mockPhase0Config._id}`
+    const expectedApiOptions = {
+      method: 'put',
+      body: JSON.stringify(mockPhase0Config),
+      headers: {
+        authorization: `Bearer ${mockValues.accessToken}`,
+        'content-type': 'application/json'
+      }
+    }
+    await updateUserRoles(mockValues)
+    expect(fetch.mock.calls.length).toEqual(1)
+    expect(fetch).toHaveBeenCalledWith(expectedUrl, expectedApiOptions)
+  })
+
+  it('should call API with phase config by environment variable', async () => {
+    expect.assertions(2)
+    process.env.PHASE = 1
+    fs.readdirSync.mockReturnValue(['admin.json', 'write-user.json'])
+    const expectedUrl = `${mockValues.fidcUrl}/openidm/internal/role/${mockPhase1Config._id}`
+    const expectedApiOptions = {
+      method: 'put',
+      body: JSON.stringify(mockPhase1Config),
+      headers: {
+        authorization: `Bearer ${mockValues.accessToken}`,
+        'content-type': 'application/json'
+      }
+    }
+    await updateUserRoles(mockValues)
+    expect(fetch.mock.calls.length).toEqual(2)
+    expect(fetch).toHaveBeenCalledWith(expectedUrl, expectedApiOptions)
+  })
+
+  it('should error if API request fails', async () => {
+    expect.assertions(2)
+    const errorMessage = 'Something went wrong'
+    fetch.mockImplementation(() => Promise.reject(new Error(errorMessage)))
+    await updateUserRoles(mockValues)
+    expect(console.error).toHaveBeenCalledWith(errorMessage)
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('should error if API response is not 200', async () => {
+    expect.assertions(2)
+    fetch.mockImplementation(() =>
+      Promise.resolve({
+        status: 401,
+        statusText: 'Unauthorized'
+      })
+    )
+    await updateUserRoles(mockValues)
+    expect(console.error).toHaveBeenCalledWith(
+      `${mockPhase0Config.name} 401: Unauthorized`
+    )
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+})


### PR DESCRIPTION
Added a script for creating internal roles with an example role configuration. This will be used for setting internal admin user permissions