### PR TITLE
chore: include provisioner.openicf in connector id

### DIFF
--- a/config/phase-0/connectors/definitions/mongodb.json
+++ b/config/phase-0/connectors/definitions/mongodb.json
@@ -1,5 +1,5 @@
 {
-	"_id": "CHSUser",
+	"_id": "provisioner.openicf/CHSUser",
 	"connectorRef": {
 		"connectorHostRef": "aws",
 		"displayName": "CHS User Connector",

--- a/scripts/update-connectors/update-connector-definitions.js
+++ b/scripts/update-connectors/update-connector-definitions.js
@@ -30,7 +30,7 @@ const updateConnectorDefinitions = async (argv) => {
     // Update each connector
     await Promise.all(
       connectorFileContent.map(async (connectorFile) => {
-        const requestUrl = `${FIDC_URL}/openidm/config/provisioner.openicf/${connectorFile._id}`
+        const requestUrl = `${FIDC_URL}/openidm/config/${connectorFile._id}`
         const requestOptions = {
           method: 'put',
           body: JSON.stringify(connectorFile),

--- a/tests/scripts/update-connector-definitions.test.js
+++ b/tests/scripts/update-connector-definitions.test.js
@@ -132,7 +132,7 @@ describe('update-connector-definitions', () => {
 
   it('should call API with phase 0 config by default', async () => {
     expect.assertions(2)
-    const expectedUrl = `${mockValues.fidcUrl}/openidm/config/provisioner.openicf/${mockPhase0Config._id}`
+    const expectedUrl = `${mockValues.fidcUrl}/openidm/config/${mockPhase0Config._id}`
     const expectedApiOptions = {
       method: 'put',
       headers: {
@@ -149,7 +149,7 @@ describe('update-connector-definitions', () => {
   it('should call API with phase config by environment variable', async () => {
     process.env.PHASE = 1
     fs.readdirSync.mockReturnValue(['mongodb.json', 'oracle.json'])
-    const expectedUrl = `${mockValues.fidcUrl}/openidm/config/provisioner.openicf/${mockPhase1Config._id}`
+    const expectedUrl = `${mockValues.fidcUrl}/openidm/config/${mockPhase1Config._id}`
     const expectedApiOptions = {
       method: 'put',
       headers: {


### PR DESCRIPTION
Prefix connector definition ID with `provisioner.openicf/` so that the config file matches the netwrok inspector.