### PR TITLE
added extra scopes to add user claims in ID token

### DIFF
--- a/config/applications/sdk-client.json.tpl
+++ b/config/applications/sdk-client.json.tpl
@@ -11,13 +11,20 @@
     },
     "refreshTokenLifetime": {
       "inherited": false,
-      "value": 0
+      "value":[
+        "email",
+        "profile",
+        "phone"
+      ]
     },
     "scopes": {
       "inherited": false,
       "value": [
         "openid",
-        "fr:idm:*"
+        "fr:idm:*",
+        "email",
+        "profile",
+        "phone"
       ]
     },
     "status": {


### PR DESCRIPTION
Added the 'email', 'profile' and 'phone' scopes to the OAuth2 SDK client application, so that the correct claims appear in the ID token for the UI to consume.