### PR TITLE
updated redirect URIs for SDK client

### DIFF
--- a/config/applications/sdk-client.json.tpl
+++ b/config/applications/sdk-client.json.tpl
@@ -117,7 +117,11 @@
       "value": [
         "forgerock://oidc_callback",
         "{REPLACEMENT_UI_URL}",
-        "http://localhost:3000"
+        "{REPLACEMENT_UI_URL}/account/home",
+        "{REPLACEMENT_UI_URL}/_callback",
+        "http://localhost:3000",
+        "http://localhost:3000/_callback",
+        "http://localhost:3000/account/home"
       ]
     },
     "policyUri": {


### PR DESCRIPTION
small fix to include all required redirect URIs for the SDK client