### PR TITLE
EWF oidc config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,5 @@
-FIDC_URL=https://openam-ch.forgeblocks.com
-UI_URL=https://idam-ui.com
-OAUTH2_HASH_SALT=r3KRSZt85yQTuWf6c1ORBbBa5p1=
+FIDC_URL=https://openam-companieshouse-uk-dev.id.forgerock.io
+UI_URL=https://idam-ui.amido.aws.chdev.org
+EWF_URL=https://ewf-kermit.companieshouse.gov.uk
+OAUTH2_HASH_SALT=n0FLWZh88zPTlWf2c3OEBlBd5r4=
+IG_OIDC_PASSWORD=3mEf1V@1AY

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ qa-tests/Reports
 config/services/oauth2-provider.json
 config/applications/sdk-client.json
 config/applications/idm-admin-client.json
+config/applications/ig-oidc-client.json
 config/consent/terms-and-conditions.json
 config/idm-endpoints/scripts-content/companyauth-frdemo.js

--- a/config/am-scripts/scripts-content/oidc-claims-script.groovy
+++ b/config/am-scripts/scripts-content/oidc-claims-script.groovy
@@ -112,6 +112,18 @@ userAddressClaimResolver = { claim, identity ->
     [:]
 }
 
+webFilingClaimResolver = { claim, identity ->
+    if (identity != null) {
+        return [
+            "company_no" : "08694860",
+            "password" : "DevPass12",
+            "jurisdiction": "EN",
+            "auth_code": "222222"
+        ]
+    }
+    [:]
+}
+
 /*
  * Claim resolver which resolves the value of the claim by looking up the user's profile.
  *
@@ -210,9 +222,11 @@ claimAttributes = [
         "zoneinfo": userProfileClaimResolver.curry("preferredtimezone"),
         "family_name": userProfileClaimResolver.curry("sn"),
         "locale": userProfileClaimResolver.curry("preferredlocale"),
-        "name": userProfileClaimResolver.curry("cn")
+        "name": userProfileClaimResolver.curry("cn"),
+        "webfiling_info": { claim, identity -> [ (claim.getName()) : webFilingClaimResolver(claim, identity)] }
 ]
 
+//https://backstage.forgerock.com/knowledge/kb/book/b66926033#a74498680 
 
 // -------------- UPDATE THIS TO CHANGE SCOPE TO CLAIM MAPPINGS --------------
 /*
@@ -223,9 +237,8 @@ scopeClaimsMap = [
         "email": [ "email" ],
         "address": [ "address" ],
         "phone": [ "phone_number" ],
-        "profile": [ "given_name", "zoneinfo", "family_name", "locale", "name" ]
+        "profile": [ "given_name", "zoneinfo", "family_name", "locale", "name", "webfiling_info" ]
 ]
-
 
 // ---------------- UPDATE BELOW FOR ADVANCED USAGES -------------------
 if (logger.messageEnabled()) {

--- a/config/applications/idm-admin-client.json.tpl
+++ b/config/applications/idm-admin-client.json.tpl
@@ -1,7 +1,7 @@
 {
    "_id": "AMTreeAdminClient",
    "coreOAuth2ClientConfig": {
-      "userpassword": "{REPLACEMENT_AUTH_TREE_PASSWORD}",
+      "userpassword": "{AUTH_TREE_PASSWORD}",
       "loopbackInterfaceRedirection": {
          "inherited": false,
          "value": false

--- a/config/applications/ig-oidc-client.json.tpl
+++ b/config/applications/ig-oidc-client.json.tpl
@@ -2,8 +2,7 @@
 	"_id": "oidc_client",
 	"coreOAuth2ClientConfig": {
 		"agentgroup": null,
-		"userpassword": null,
-		"userpassword-encrypted": "AAAAA0FFUwIQ6PrXca0MXVeUeB95oIls1zhaIeTCWfodJAI/Rkiv6vDx1/ZQnvl1iw==",
+		"userpassword": "{IG_OIDC_PASSWORD}",
 		"loopbackInterfaceRedirection": {
 			"inherited": false,
 			"value": false

--- a/config/applications/ig-oidc-client.json.tpl
+++ b/config/applications/ig-oidc-client.json.tpl
@@ -1,0 +1,277 @@
+{
+	"_id": "oidc_client",
+	"coreOAuth2ClientConfig": {
+		"agentgroup": null,
+		"userpassword": null,
+		"userpassword-encrypted": "AAAAA0FFUwIQ6PrXca0MXVeUeB95oIls1zhaIeTCWfodJAI/Rkiv6vDx1/ZQnvl1iw==",
+		"loopbackInterfaceRedirection": {
+			"inherited": false,
+			"value": false
+		},
+		"backchannel_logout_uri": {
+			"inherited": false,
+			"value": null
+		},
+		"defaultScopes": {
+			"inherited": false,
+			"value": []
+		},
+		"refreshTokenLifetime": {
+			"inherited": false,
+			"value": 0
+		},
+		"scopes": {
+			"inherited": false,
+			"value": ["openid", "profile", "email"]
+		},
+		"status": {
+			"inherited": false,
+			"value": "Active"
+		},
+		"accessTokenLifetime": {
+			"inherited": false,
+			"value": 0
+		},
+		"redirectionUris": {
+			"inherited": false,
+			"value": [
+                "http://localhost:8080/oidc/callback", 
+                "{REPLACEMENT_EWF_URL}"
+            ]
+		},
+		"clientName": {
+			"inherited": false,
+			"value": []
+		},
+		"clientType": {
+			"inherited": false,
+			"value": "Confidential"
+		},
+		"authorizationCodeLifetime": {
+			"inherited": false,
+			"value": 0
+		},
+		"backchannel_logout_session_required": {
+			"inherited": false,
+			"value": false
+		}
+	},
+	"advancedOAuth2ClientConfig": {
+		"descriptions": {
+			"inherited": false,
+			"value": []
+		},
+		"requestUris": {
+			"inherited": false,
+			"value": []
+		},
+		"logoUri": {
+			"inherited": false,
+			"value": []
+		},
+		"subjectType": {
+			"inherited": false,
+			"value": "public"
+		},
+		"clientUri": {
+			"inherited": false,
+			"value": []
+		},
+		"tokenExchangeAuthLevel": {
+			"inherited": false,
+			"value": 0
+		},
+		"name": {
+			"inherited": false,
+			"value": []
+		},
+		"contacts": {
+			"inherited": false,
+			"value": []
+		},
+		"responseTypes": {
+			"inherited": false,
+			"value": ["code", "token", "id_token", "code token", "token id_token", "code id_token", "code token id_token", "device_code", "device_code id_token"]
+		},
+		"updateAccessToken": {
+			"inherited": false
+		},
+		"mixUpMitigation": {
+			"inherited": false,
+			"value": false
+		},
+		"customProperties": {
+			"inherited": false,
+			"value": []
+		},
+		"javascriptOrigins": {
+			"inherited": false,
+			"value": []
+		},
+		"policyUri": {
+			"inherited": false,
+			"value": []
+		},
+		"softwareVersion": {
+			"inherited": false
+		},
+		"tosURI": {
+			"inherited": false,
+			"value": []
+		},
+		"sectorIdentifierUri": {
+			"inherited": false
+		},
+		"tokenEndpointAuthMethod": {
+			"inherited": false,
+			"value": "client_secret_post"
+		},
+		"isConsentImplied": {
+			"inherited": false,
+			"value": true
+		},
+		"softwareIdentity": {
+			"inherited": false
+		},
+		"grantTypes": {
+			"inherited": false,
+			"value": ["authorization_code", "password"]
+		}
+	},
+	"signEncOAuth2ClientConfig": {
+		"tokenEndpointAuthSigningAlgorithm": {
+			"inherited": false,
+			"value": "RS256"
+		},
+		"idTokenEncryptionEnabled": {
+			"inherited": false,
+			"value": false
+		},
+		"tokenIntrospectionEncryptedResponseEncryptionAlgorithm": {
+			"inherited": false,
+			"value": "A128CBC-HS256"
+		},
+		"requestParameterSignedAlg": {
+			"inherited": false
+		},
+		"clientJwtPublicKey": {
+			"inherited": false
+		},
+		"idTokenPublicEncryptionKey": {
+			"inherited": false
+		},
+		"mTLSSubjectDN": {
+			"inherited": false
+		},
+		"userinfoResponseFormat": {
+			"inherited": false,
+			"value": "JSON"
+		},
+		"mTLSCertificateBoundAccessTokens": {
+			"inherited": false,
+			"value": false
+		},
+		"publicKeyLocation": {
+			"inherited": false,
+			"value": "jwks_uri"
+		},
+		"tokenIntrospectionResponseFormat": {
+			"inherited": false,
+			"value": "JSON"
+		},
+		"jwkStoreCacheMissCacheTime": {
+			"inherited": false,
+			"value": 60000
+		},
+		"requestParameterEncryptedEncryptionAlgorithm": {
+			"inherited": false,
+			"value": "A128CBC-HS256"
+		},
+		"userinfoSignedResponseAlg": {
+			"inherited": false
+		},
+		"idTokenEncryptionAlgorithm": {
+			"inherited": false,
+			"value": "RSA-OAEP-256"
+		},
+		"requestParameterEncryptedAlg": {
+			"inherited": false
+		},
+		"mTLSTrustedCert": {
+			"inherited": false
+		},
+		"jwkSet": {
+			"inherited": false
+		},
+		"idTokenEncryptionMethod": {
+			"inherited": false,
+			"value": "A128CBC-HS256"
+		},
+		"jwksCacheTimeout": {
+			"inherited": false,
+			"value": 3600000
+		},
+		"userinfoEncryptedResponseAlg": {
+			"inherited": false
+		},
+		"idTokenSignedResponseAlg": {
+			"inherited": false,
+			"value": "HS256"
+		},
+		"jwksUri": {
+			"inherited": false
+		},
+		"tokenIntrospectionSignedResponseAlg": {
+			"inherited": false,
+			"value": "RS256"
+		},
+		"userinfoEncryptedResponseEncryptionAlgorithm": {
+			"inherited": false,
+			"value": "A128CBC-HS256"
+		},
+		"tokenIntrospectionEncryptedResponseAlg": {
+			"inherited": false,
+			"value": "RSA-OAEP-256"
+		}
+	},
+	"coreOpenIDClientConfig": {
+		"claims": {
+			"inherited": false,
+			"value": []
+		},
+		"clientSessionUri": {
+			"inherited": false
+		},
+		"defaultAcrValues": {
+			"inherited": false,
+			"value": ["webfiling"]
+		},
+		"jwtTokenLifetime": {
+			"inherited": false,
+			"value": 0
+		},
+		"defaultMaxAgeEnabled": {
+			"inherited": false,
+			"value": false
+		},
+		"defaultMaxAge": {
+			"inherited": false,
+			"value": 600
+		},
+		"postLogoutRedirectUri": {
+			"inherited": false,
+			"value": []
+		}
+	},
+	"coreUmaClientConfig": {
+		"claimsRedirectionUris": {
+			"inherited": false,
+			"value": []
+		}
+	},
+	"_type": {
+		"_id": "OAuth2Client",
+		"name": "OAuth2 Clients",
+		"collection": true
+	}
+}

--- a/config/applications/ig-oidc-client.json.tpl
+++ b/config/applications/ig-oidc-client.json.tpl
@@ -22,7 +22,11 @@
 		},
 		"scopes": {
 			"inherited": false,
-			"value": ["openid", "profile", "email"]
+			"value": [
+				"openid",
+				"profile",
+				"email"
+			]
 		},
 		"status": {
 			"inherited": false,
@@ -35,9 +39,9 @@
 		"redirectionUris": {
 			"inherited": false,
 			"value": [
-                "http://localhost:8080/oidc/callback", 
-                "{REPLACEMENT_EWF_URL}"
-            ]
+				"http://localhost:8080/oidc/callback",
+				"{EWF_URL}"
+			]
 		},
 		"clientName": {
 			"inherited": false,
@@ -91,7 +95,17 @@
 		},
 		"responseTypes": {
 			"inherited": false,
-			"value": ["code", "token", "id_token", "code token", "token id_token", "code id_token", "code token id_token", "device_code", "device_code id_token"]
+			"value": [
+				"code",
+				"token",
+				"id_token",
+				"code token",
+				"token id_token",
+				"code id_token",
+				"code token id_token",
+				"device_code",
+				"device_code id_token"
+			]
 		},
 		"updateAccessToken": {
 			"inherited": false
@@ -135,7 +149,10 @@
 		},
 		"grantTypes": {
 			"inherited": false,
-			"value": ["authorization_code", "password"]
+			"value": [
+				"authorization_code",
+				"password"
+			]
 		}
 	},
 	"signEncOAuth2ClientConfig": {
@@ -244,7 +261,9 @@
 		},
 		"defaultAcrValues": {
 			"inherited": false,
-			"value": ["webfiling"]
+			"value": [
+				"webfiling"
+			]
 		},
 		"jwtTokenLifetime": {
 			"inherited": false,

--- a/config/applications/sdk-client.json.tpl
+++ b/config/applications/sdk-client.json.tpl
@@ -7,7 +7,7 @@
     },
     "defaultScopes": {
       "inherited": false,
-      "value":[
+      "value": [
         "email",
         "profile",
         "phone"
@@ -42,9 +42,9 @@
         "http://localhost:3000",
         "http://localhost:3000/_callback",
         "http://localhost:3000/account/home/",
-        "{REPLACEMENT_UI_URL}",
-        "{REPLACEMENT_UI_URL}/account/home/",
-        "{REPLACEMENT_UI_URL}/_callback"
+        "{UI_URL}",
+        "{UI_URL}/account/home/",
+        "{UI_URL}/_callback"
       ]
     },
     "clientName": {
@@ -116,9 +116,9 @@
       "inherited": false,
       "value": [
         "forgerock://oidc_callback",
-        "{REPLACEMENT_UI_URL}",
-        "{REPLACEMENT_UI_URL}/account/home",
-        "{REPLACEMENT_UI_URL}/_callback",
+        "{UI_URL}",
+        "{UI_URL}/account/home",
+        "{UI_URL}/_callback",
         "http://localhost:3000",
         "http://localhost:3000/_callback",
         "http://localhost:3000/account/home"
@@ -273,8 +273,8 @@
         "forgerock://oidc_callback",
         "http://localhost:3000",
         "http://localhost:3000/_callback",
-        "{REPLACEMENT_UI_URL}",
-        "{REPLACEMENT_UI_URL}/_callback"
+        "{UI_URL}",
+        "{UI_URL}/_callback"
       ]
     }
   },

--- a/config/auth-trees/ch-webfiling.json
+++ b/config/auth-trees/ch-webfiling.json
@@ -1,0 +1,92 @@
+{
+	"nodes": [
+		{
+			"_id": "ce2dab5c-3b95-4ab6-9a5c-b58dd9eee84d",
+			"nodeType": "PageNode",
+			"details": {
+				"stage":"EWF_LOGIN_1",
+				"nodes": [
+					{
+						"_id": "47096e1a-1a2d-443e-8bd9-498f0a441772",
+						"nodeType":"ValidatedUsernameNode",
+						"displayName":"Platform Username"
+					 },
+					 {
+						"_id": "bbd5738a-e80c-42e8-8a34-e95f287a2f8f",
+						"nodeType":"ValidatedPasswordNode",
+						"displayName":"Platform Password"
+					 }
+				],
+				"pageDescription": {
+					"en": "New here? <a href=\"#/service/Registration\">Create an account</a><br><a href=\"#/service/ForgottenUsername\">Forgot username?</a><a href=\"#/service/ResetPassword\"> Forgot password?</a>"
+				},
+				"pageHeader": {
+					"en": "Sign In to WebFiling"
+				}
+			}
+		},
+		{
+			"_id": "47096e1a-1a2d-443e-8bd9-498f0a441772",
+			"nodeType": "ValidatedUsernameNode",
+			"details": {
+				"validateInput": false,
+				"usernameAttribute": "userName"
+			}
+		},
+		{
+			"_id": "bbd5738a-e80c-42e8-8a34-e95f287a2f8f",
+			"nodeType": "ValidatedPasswordNode",
+			"details": {
+				"validateInput": false,
+				"passwordAttribute": "password"
+			}
+		},
+		{
+			"_id": "b6943bfa-4890-4e62-8fbe-f32b3a50c7ef",
+			"nodeType": "DataStoreDecisionNode",
+			"details": {}
+		}
+    ],
+    "tree": {
+		"_id": "CHWebFiling",
+		"description": "Journey for WebFiling users",
+		"identityResource": "managed/alpha_user",
+		"uiConfig": {},
+		"entryNodeId": "ce2dab5c-3b95-4ab6-9a5c-b58dd9eee84d",
+		"nodes": {
+			"ce2dab5c-3b95-4ab6-9a5c-b58dd9eee84d": {
+				"x": 285,
+				"y": 115,
+				"connections": {
+					"outcome": "b6943bfa-4890-4e62-8fbe-f32b3a50c7ef"
+				},
+				"nodeType": "PageNode",
+				"displayName": "Page Node"
+			},
+			"b6943bfa-4890-4e62-8fbe-f32b3a50c7ef": {
+				"x": 748,
+				"y": 107,
+				"connections": {
+					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
+					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+				},
+				"nodeType": "DataStoreDecisionNode",
+				"displayName": "Data Store Decision"
+			}
+		},
+		"staticNodes": {
+			"startNode": {
+				"x": 70,
+				"y": 80
+			},
+			"70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+				"x": 1396,
+				"y": 41
+			},
+			"e301438c-0bd0-429c-ab0c-66126501069a": {
+				"x": 1398,
+				"y": 217
+			}
+		}
+	}
+}

--- a/config/services/oauth2-provider.json.tpl
+++ b/config/services/oauth2-provider.json.tpl
@@ -32,7 +32,7 @@
             "urn:ietf:params:oauth:grant-type:uma-ticket",
             "urn:ietf:params:oauth:grant-type:jwt-bearer"
         ],
-        "hashSalt": "{REPLACEMENT_HASH_SALT}",
+        "hashSalt": "{HASH_SALT}",
         "macaroonTokenFormat": "V2",
         "moduleMessageEnabledInPasswordGrant": false,
         "passwordGrantAuthService": "PasswordGrant",

--- a/config/services/oauth2-provider.json.tpl
+++ b/config/services/oauth2-provider.json.tpl
@@ -86,7 +86,9 @@
     "claimsParameterSupported": false,
     "defaultACR": [],
     "idTokenInfoClientAuthenticationEnabled": true,
-    "loaMapping": {},
+    "loaMapping": {
+			"webfiling": "CHWebFiling"
+		},
     "storeOpsTokens": true,
     "supportedRequestParameterEncryptionAlgorithms": [
       "ECDH-ES+A256KW",

--- a/config/services/oauth2-provider.json.tpl
+++ b/config/services/oauth2-provider.json.tpl
@@ -11,7 +11,7 @@
             "uid"
         ],
         "codeVerifierEnforced": "false",
-        "customLoginUrlTemplate": "https://idam-ui.amido.aws.chdev.org/account/login/?goto=${goto}<#if acrValues??>&acr_values=${acrValues}</#if><#if realm??>&realm=${realm}</#if><#if module??>&module=${module}</#if><#if service??>&service=${service}</#if><#if locale??>&locale=${locale}</#if><#if authIndexType??>&authIndexType=${authIndexType}</#if><#if authIndexValue??>&authIndexValue=${authIndexValue}</#if>",
+        "customLoginUrlTemplate": "https://idam-ui.amido.aws.chdev.org/account/login/?goto=${goto}<#if acrValues??>&acr_values=${acrValues}</#if><#if realm??>&realm=${realm}</#if><#if module??>&module=${module}</#if><#if service??>&service=${service}</#if><#if locale??>&locale=${locale}</#if><#if authIndexType??>&authIndexType=${authIndexType}</#if><#if authIndexValue??>&authIndexValue=${authIndexValue}</#if>&mode=AUTHN_ONLY",
         "defaultScopes": [
             "address",
             "phone",

--- a/config/services/oauth2-provider.json.tpl
+++ b/config/services/oauth2-provider.json.tpl
@@ -1,350 +1,347 @@
 {
-  "_id": "oauth-oidc",
-  "_type": {
     "_id": "oauth-oidc",
-    "name": "OAuth2 Provider",
-    "collection": false
-  },
-  "advancedOAuth2Config": {
-    "customLoginUrlTemplate": "https://idam-ui.amido.aws.chdev.org/account/login/?goto=${goto}<#if acrValues??>&acr_values=${acrValues}</#if><#if realm??>&realm=${realm}</#if><#if module??>&module=${module}</#if><#if service??>&service=${service}</#if><#if locale??>&locale=${locale}</#if>",
-    "displayNameAttribute": "cn",
-    "tlsOcspResponderUri": "",
-    "tokenValidatorClasses": [
-      "urn:ietf:params:oauth:token-type:id_token|org.forgerock.oauth2.core.tokenexchange.idtoken.OidcIdTokenValidator",
-      "urn:ietf:params:oauth:token-type:access_token|org.forgerock.oauth2.core.tokenexchange.accesstoken.OAuth2AccessTokenValidator"
-    ],
-    "tokenExchangeClasses": [
-      "urn:ietf:params:oauth:token-type:access_token=>urn:ietf:params:oauth:token-type:access_token|org.forgerock.oauth2.core.tokenexchange.accesstoken.AccessTokenToAccessTokenExchanger",
-      "urn:ietf:params:oauth:token-type:id_token=>urn:ietf:params:oauth:token-type:id_token|org.forgerock.oauth2.core.tokenexchange.idtoken.IdTokenToIdTokenExchanger",
-      "urn:ietf:params:oauth:token-type:access_token=>urn:ietf:params:oauth:token-type:id_token|org.forgerock.oauth2.core.tokenexchange.accesstoken.AccessTokenToIdTokenExchanger",
-      "urn:ietf:params:oauth:token-type:id_token=>urn:ietf:params:oauth:token-type:access_token|org.forgerock.oauth2.core.tokenexchange.idtoken.IdTokenToAccessTokenExchanger"
-    ],
-    "allowedAudienceValues": [],
-    "tlsOcspResponderCert": "",
-    "hashSalt": "{REPLACEMENT_HASH_SALT}",
-    "tlsClientCertificateTrustedHeader": "",
-    "supportedScopes": [
-      "email|Your email address",
-      "openid|",
-      "address|Your postal address",
-      "phone|Your telephone number(s)",
-      "fr:idm:*",
-      "am-introspect-all-tokens",
-      "profile|Your personal information"
-    ],
-    "responseTypeClasses": [
-      "code|org.forgerock.oauth2.core.AuthorizationCodeResponseTypeHandler",
-      "id_token|org.forgerock.openidconnect.IdTokenResponseTypeHandler",
-      "device_code|org.forgerock.oauth2.core.TokenResponseTypeHandler",
-      "token|org.forgerock.oauth2.core.TokenResponseTypeHandler"
-    ],
-    "passwordGrantAuthService": "PasswordGrant",
-    "tlsCertificateBoundAccessTokensEnabled": true,
-    "createdTimestampAttribute": "",
-    "tlsCertificateRevocationCheckingEnabled": false,
-    "tlsClientCertificateHeaderFormat": "URLENCODED_PEM",
-    "modifiedTimestampAttribute": "",
-    "tokenEncryptionEnabled": false,
-    "supportedSubjectTypes": [
-      "public",
-      "pairwise"
-    ],
-    "defaultScopes": [
-      "address",
-      "phone",
-      "openid",
-      "profile",
-      "email"
-    ],
-    "authenticationAttributes": [
-      "uid"
-    ],
-    "grantTypes": [
-      "implicit",
-      "urn:ietf:params:oauth:grant-type:saml2-bearer",
-      "refresh_token",
-      "password",
-      "client_credentials",
-      "urn:ietf:params:oauth:grant-type:device_code",
-      "authorization_code",
-      "urn:openid:params:grant-type:ciba",
-      "urn:ietf:params:oauth:grant-type:uma-ticket",
-      "urn:ietf:params:oauth:grant-type:jwt-bearer"
-    ],
-    "moduleMessageEnabledInPasswordGrant": false,
-    "scopeImplementationClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
-    "tokenCompressionEnabled": false,
-    "codeVerifierEnforced": "false",
-    "macaroonTokenFormat": "V2",
-    "tokenSigningAlgorithm": "HS256"
-  },
-  "advancedOIDCConfig": {
-    "alwaysAddClaimsToToken": true,
-    "amrMappings": {},
-    "authorisedIdmDelegationClients": [],
-    "authorisedOpenIdConnectSSOClients": [],
-    "claimsParameterSupported": false,
-    "defaultACR": [],
-    "idTokenInfoClientAuthenticationEnabled": true,
-    "loaMapping": {
-			"webfiling": "CHWebFiling"
-		},
-    "storeOpsTokens": true,
-    "supportedRequestParameterEncryptionAlgorithms": [
-      "ECDH-ES+A256KW",
-      "ECDH-ES+A192KW",
-      "ECDH-ES+A128KW",
-      "RSA-OAEP",
-      "RSA-OAEP-256",
-      "A128KW",
-      "A256KW",
-      "ECDH-ES",
-      "dir",
-      "A192KW"
-    ],
-    "supportedRequestParameterEncryptionEnc": [
-      "A256GCM",
-      "A192GCM",
-      "A128GCM",
-      "A128CBC-HS256",
-      "A192CBC-HS384",
-      "A256CBC-HS512"
-    ],
-    "supportedRequestParameterSigningAlgorithms": [
-      "PS384",
-      "ES384",
-      "RS384",
-      "HS256",
-      "HS512",
-      "ES256",
-      "RS256",
-      "HS384",
-      "ES512",
-      "PS256",
-      "PS512",
-      "RS512"
-    ],
-    "supportedTokenEndpointAuthenticationSigningAlgorithms": [
-      "PS384",
-      "ES384",
-      "RS384",
-      "HS256",
-      "HS512",
-      "ES256",
-      "RS256",
-      "HS384",
-      "ES512",
-      "PS256",
-      "PS512",
-      "RS512"
-    ],
-    "supportedTokenIntrospectionResponseEncryptionAlgorithms": [
-      "ECDH-ES+A256KW",
-      "ECDH-ES+A192KW",
-      "RSA-OAEP",
-      "ECDH-ES+A128KW",
-      "RSA-OAEP-256",
-      "A128KW",
-      "A256KW",
-      "ECDH-ES",
-      "dir",
-      "A192KW"
-    ],
-    "supportedTokenIntrospectionResponseEncryptionEnc": [
-      "A256GCM",
-      "A192GCM",
-      "A128GCM",
-      "A128CBC-HS256",
-      "A192CBC-HS384",
-      "A256CBC-HS512"
-    ],
-    "supportedTokenIntrospectionResponseSigningAlgorithms": [
-      "PS384",
-      "RS384",
-      "EdDSA",
-      "ES384",
-      "HS256",
-      "HS512",
-      "ES256",
-      "RS256",
-      "HS384",
-      "ES512",
-      "PS256",
-      "PS512",
-      "RS512"
-    ],
-    "supportedUserInfoEncryptionAlgorithms": [
-      "ECDH-ES+A256KW",
-      "ECDH-ES+A192KW",
-      "RSA-OAEP",
-      "ECDH-ES+A128KW",
-      "RSA-OAEP-256",
-      "A128KW",
-      "A256KW",
-      "ECDH-ES",
-      "dir",
-      "A192KW"
-    ],
-    "supportedUserInfoEncryptionEnc": [
-      "A256GCM",
-      "A192GCM",
-      "A128GCM",
-      "A128CBC-HS256",
-      "A192CBC-HS384",
-      "A256CBC-HS512"
-    ],
-    "supportedUserInfoSigningAlgorithms": [
-      "ES384",
-      "HS256",
-      "HS512",
-      "ES256",
-      "RS256",
-      "HS384",
-      "ES512"
-    ]
-  },
-  "cibaConfig": {
-    "cibaAuthReqIdLifetime": 600,
-    "cibaMinimumPollingInterval": 2,
-    "supportedCibaSigningAlgorithms": [
-      "ES256",
-      "PS256"
-    ]
-  },
-  "clientDynamicRegistrationConfig": {
-    "allowDynamicRegistration": false,
-    "dynamicClientRegistrationScope": "dynamic_client_registration",
-    "dynamicClientRegistrationSoftwareStatementRequired": false,
-    "generateRegistrationAccessTokens": true,
-    "requiredSoftwareStatementAttestedAttributes": [
-      "redirect_uris"
-    ]
-  },
-  "consent": {
-    "clientsCanSkipConsent": true,
-    "enableRemoteConsent": false,
-    "supportedRcsRequestEncryptionAlgorithms": [
-      "ECDH-ES+A256KW",
-      "ECDH-ES+A192KW",
-      "RSA-OAEP",
-      "ECDH-ES+A128KW",
-      "RSA-OAEP-256",
-      "A128KW",
-      "A256KW",
-      "ECDH-ES",
-      "dir",
-      "A192KW"
-    ],
-    "supportedRcsRequestEncryptionMethods": [
-      "A256GCM",
-      "A192GCM",
-      "A128GCM",
-      "A128CBC-HS256",
-      "A192CBC-HS384",
-      "A256CBC-HS512"
-    ],
-    "supportedRcsRequestSigningAlgorithms": [
-      "PS384",
-      "ES384",
-      "RS384",
-      "HS256",
-      "HS512",
-      "ES256",
-      "RS256",
-      "HS384",
-      "ES512",
-      "PS256",
-      "PS512",
-      "RS512"
-    ],
-    "supportedRcsResponseEncryptionAlgorithms": [
-      "ECDH-ES+A256KW",
-      "ECDH-ES+A192KW",
-      "ECDH-ES+A128KW",
-      "RSA-OAEP",
-      "RSA-OAEP-256",
-      "A128KW",
-      "A256KW",
-      "ECDH-ES",
-      "dir",
-      "A192KW"
-    ],
-    "supportedRcsResponseEncryptionMethods": [
-      "A256GCM",
-      "A192GCM",
-      "A128GCM",
-      "A128CBC-HS256",
-      "A192CBC-HS384",
-      "A256CBC-HS512"
-    ],
-    "supportedRcsResponseSigningAlgorithms": [
-      "PS384",
-      "ES384",
-      "RS384",
-      "HS256",
-      "HS512",
-      "ES256",
-      "RS256",
-      "HS384",
-      "ES512",
-      "PS256",
-      "PS512",
-      "RS512"
-    ]
-  },
-  "coreOAuth2Config": {
-    "accessTokenLifetime": 3600,
-    "accessTokenModificationScript": "d22f9a0c-426a-4466-b95e-d0f125b0d5fa",
-    "codeLifetime": 120,
-    "issueRefreshToken": true,
-    "issueRefreshTokenOnRefreshedToken": true,
-    "macaroonTokensEnabled": false,
-    "refreshTokenLifetime": 604800,
-    "statelessTokensEnabled": true,
-    "usePolicyEngineForScope": false
-  },
-  "coreOIDCConfig": {
-    "jwtTokenLifetime": 3600,
-    "oidcClaimsScript": "36863ffb-40ec-48b9-94b1-9a99f71cc3b5",
-    "overrideableOIDCClaims": [],
-    "supportedClaims": [],
-    "supportedIDTokenEncryptionAlgorithms": [
-      "ECDH-ES+A256KW",
-      "ECDH-ES+A192KW",
-      "RSA-OAEP",
-      "ECDH-ES+A128KW",
-      "RSA-OAEP-256",
-      "A128KW",
-      "A256KW",
-      "ECDH-ES",
-      "dir",
-      "A192KW"
-    ],
-    "supportedIDTokenEncryptionMethods": [
-      "A256GCM",
-      "A192GCM",
-      "A128GCM",
-      "A128CBC-HS256",
-      "A192CBC-HS384",
-      "A256CBC-HS512"
-    ],
-    "supportedIDTokenSigningAlgorithms": [
-      "PS384",
-      "ES384",
-      "RS384",
-      "HS256",
-      "HS512",
-      "ES256",
-      "RS256",
-      "HS384",
-      "ES512",
-      "PS256",
-      "PS512",
-      "RS512"
-    ]
-  },
-  "deviceCodeConfig": {
-    "deviceCodeLifetime": 300,
-    "devicePollInterval": 5
-  }
+    "_type": {
+        "_id": "oauth-oidc",
+        "name": "OAuth2 Provider",
+        "collection": false
+    },
+    "advancedOAuth2Config": {
+        "allowedAudienceValues": [],
+        "authenticationAttributes": [
+            "uid"
+        ],
+        "codeVerifierEnforced": "false",
+        "customLoginUrlTemplate": "https://idam-ui.amido.aws.chdev.org/account/login/?goto=${goto}<#if acrValues??>&acr_values=${acrValues}</#if><#if realm??>&realm=${realm}</#if><#if module??>&module=${module}</#if><#if service??>&service=${service}</#if><#if locale??>&locale=${locale}</#if><#if authIndexType??>&authIndexType=${authIndexType}</#if><#if authIndexValue??>&authIndexValue=${authIndexValue}</#if>",
+        "defaultScopes": [
+            "address",
+            "phone",
+            "openid",
+            "profile",
+            "email"
+        ],
+        "displayNameAttribute": "cn",
+        "grantTypes": [
+            "implicit",
+            "urn:ietf:params:oauth:grant-type:saml2-bearer",
+            "refresh_token",
+            "password",
+            "client_credentials",
+            "urn:ietf:params:oauth:grant-type:device_code",
+            "authorization_code",
+            "urn:openid:params:grant-type:ciba",
+            "urn:ietf:params:oauth:grant-type:uma-ticket",
+            "urn:ietf:params:oauth:grant-type:jwt-bearer"
+        ],
+        "hashSalt": "{REPLACEMENT_HASH_SALT}",
+        "macaroonTokenFormat": "V2",
+        "moduleMessageEnabledInPasswordGrant": false,
+        "passwordGrantAuthService": "PasswordGrant",
+        "responseTypeClasses": [
+            "code|org.forgerock.oauth2.core.AuthorizationCodeResponseTypeHandler",
+            "id_token|org.forgerock.openidconnect.IdTokenResponseTypeHandler",
+            "device_code|org.forgerock.oauth2.core.TokenResponseTypeHandler",
+            "token|org.forgerock.oauth2.core.TokenResponseTypeHandler"
+        ],
+        "scopeImplementationClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
+        "supportedScopes": [
+            "email|Your email address",
+            "openid|",
+            "address|Your postal address",
+            "phone|Your telephone number(s)",
+            "fr:idm:*",
+            "am-introspect-all-tokens",
+            "profile|Your personal information"
+        ],
+        "supportedSubjectTypes": [
+            "public",
+            "pairwise"
+        ],
+        "tlsCertificateBoundAccessTokensEnabled": true,
+        "tlsCertificateRevocationCheckingEnabled": false,
+        "tlsClientCertificateHeaderFormat": "URLENCODED_PEM",
+        "tokenCompressionEnabled": false,
+        "tokenEncryptionEnabled": false,
+        "tokenExchangeClasses": [
+            "urn:ietf:params:oauth:token-type:access_token=>urn:ietf:params:oauth:token-type:access_token|org.forgerock.oauth2.core.tokenexchange.accesstoken.AccessTokenToAccessTokenExchanger",
+            "urn:ietf:params:oauth:token-type:id_token=>urn:ietf:params:oauth:token-type:id_token|org.forgerock.oauth2.core.tokenexchange.idtoken.IdTokenToIdTokenExchanger",
+            "urn:ietf:params:oauth:token-type:access_token=>urn:ietf:params:oauth:token-type:id_token|org.forgerock.oauth2.core.tokenexchange.accesstoken.AccessTokenToIdTokenExchanger",
+            "urn:ietf:params:oauth:token-type:id_token=>urn:ietf:params:oauth:token-type:access_token|org.forgerock.oauth2.core.tokenexchange.idtoken.IdTokenToAccessTokenExchanger"
+        ],
+        "tokenSigningAlgorithm": "HS256",
+        "tokenValidatorClasses": [
+            "urn:ietf:params:oauth:token-type:id_token|org.forgerock.oauth2.core.tokenexchange.idtoken.OidcIdTokenValidator",
+            "urn:ietf:params:oauth:token-type:access_token|org.forgerock.oauth2.core.tokenexchange.accesstoken.OAuth2AccessTokenValidator"
+        ]
+    },
+    "advancedOIDCConfig": {
+        "supportedTokenEndpointAuthenticationSigningAlgorithms": [
+            "PS384",
+            "ES384",
+            "RS384",
+            "HS256",
+            "HS512",
+            "ES256",
+            "RS256",
+            "HS384",
+            "ES512",
+            "PS256",
+            "PS512",
+            "RS512"
+        ],
+        "supportedRequestParameterEncryptionEnc": [
+            "A256GCM",
+            "A192GCM",
+            "A128GCM",
+            "A128CBC-HS256",
+            "A192CBC-HS384",
+            "A256CBC-HS512"
+        ],
+        "loaMapping": {
+            "webfiling": "CHWebFiling"
+        },
+        "storeOpsTokens": true,
+        "supportedUserInfoEncryptionEnc": [
+            "A256GCM",
+            "A192GCM",
+            "A128GCM",
+            "A128CBC-HS256",
+            "A192CBC-HS384",
+            "A256CBC-HS512"
+        ],
+        "supportedTokenIntrospectionResponseSigningAlgorithms": [
+            "PS384",
+            "RS384",
+            "EdDSA",
+            "ES384",
+            "HS256",
+            "HS512",
+            "ES256",
+            "RS256",
+            "HS384",
+            "ES512",
+            "PS256",
+            "PS512",
+            "RS512"
+        ],
+        "idTokenInfoClientAuthenticationEnabled": true,
+        "supportedRequestParameterSigningAlgorithms": [
+            "PS384",
+            "ES384",
+            "RS384",
+            "HS256",
+            "HS512",
+            "ES256",
+            "RS256",
+            "HS384",
+            "ES512",
+            "PS256",
+            "PS512",
+            "RS512"
+        ],
+        "supportedUserInfoSigningAlgorithms": [
+            "ES384",
+            "HS256",
+            "HS512",
+            "ES256",
+            "RS256",
+            "HS384",
+            "ES512"
+        ],
+        "supportedTokenIntrospectionResponseEncryptionEnc": [
+            "A256GCM",
+            "A192GCM",
+            "A128GCM",
+            "A128CBC-HS256",
+            "A192CBC-HS384",
+            "A256CBC-HS512"
+        ],
+        "amrMappings": {},
+        "claimsParameterSupported": false,
+        "supportedUserInfoEncryptionAlgorithms": [
+            "ECDH-ES+A256KW",
+            "ECDH-ES+A192KW",
+            "RSA-OAEP",
+            "ECDH-ES+A128KW",
+            "RSA-OAEP-256",
+            "A128KW",
+            "A256KW",
+            "ECDH-ES",
+            "dir",
+            "A192KW"
+        ],
+        "defaultACR": [],
+        "authorisedOpenIdConnectSSOClients": [],
+        "includeAllKtyAlgCombinationsInJwksUri": false,
+        "supportedRequestParameterEncryptionAlgorithms": [
+            "ECDH-ES+A256KW",
+            "ECDH-ES+A192KW",
+            "ECDH-ES+A128KW",
+            "RSA-OAEP",
+            "RSA-OAEP-256",
+            "A128KW",
+            "A256KW",
+            "ECDH-ES",
+            "dir",
+            "A192KW"
+        ],
+        "alwaysAddClaimsToToken": true,
+        "supportedTokenIntrospectionResponseEncryptionAlgorithms": [
+            "ECDH-ES+A256KW",
+            "ECDH-ES+A192KW",
+            "RSA-OAEP",
+            "ECDH-ES+A128KW",
+            "RSA-OAEP-256",
+            "A128KW",
+            "A256KW",
+            "ECDH-ES",
+            "dir",
+            "A192KW"
+        ],
+        "authorisedIdmDelegationClients": []
+    },
+    "cibaConfig": {
+        "cibaAuthReqIdLifetime": 600,
+        "cibaMinimumPollingInterval": 2,
+        "supportedCibaSigningAlgorithms": [
+            "ES256",
+            "PS256"
+        ]
+    },
+    "clientDynamicRegistrationConfig": {
+        "allowDynamicRegistration": false,
+        "dynamicClientRegistrationScope": "dynamic_client_registration",
+        "dynamicClientRegistrationSoftwareStatementRequired": false,
+        "generateRegistrationAccessTokens": true,
+        "requiredSoftwareStatementAttestedAttributes": [
+            "redirect_uris"
+        ]
+    },
+    "consent": {
+        "clientsCanSkipConsent": true,
+        "enableRemoteConsent": false,
+        "supportedRcsRequestEncryptionAlgorithms": [
+            "ECDH-ES+A256KW",
+            "ECDH-ES+A192KW",
+            "RSA-OAEP",
+            "ECDH-ES+A128KW",
+            "RSA-OAEP-256",
+            "A128KW",
+            "A256KW",
+            "ECDH-ES",
+            "dir",
+            "A192KW"
+        ],
+        "supportedRcsRequestEncryptionMethods": [
+            "A256GCM",
+            "A192GCM",
+            "A128GCM",
+            "A128CBC-HS256",
+            "A192CBC-HS384",
+            "A256CBC-HS512"
+        ],
+        "supportedRcsRequestSigningAlgorithms": [
+            "PS384",
+            "ES384",
+            "RS384",
+            "HS256",
+            "HS512",
+            "ES256",
+            "RS256",
+            "HS384",
+            "ES512",
+            "PS256",
+            "PS512",
+            "RS512"
+        ],
+        "supportedRcsResponseEncryptionAlgorithms": [
+            "ECDH-ES+A256KW",
+            "ECDH-ES+A192KW",
+            "ECDH-ES+A128KW",
+            "RSA-OAEP",
+            "RSA-OAEP-256",
+            "A128KW",
+            "A256KW",
+            "ECDH-ES",
+            "dir",
+            "A192KW"
+        ],
+        "supportedRcsResponseEncryptionMethods": [
+            "A256GCM",
+            "A192GCM",
+            "A128GCM",
+            "A128CBC-HS256",
+            "A192CBC-HS384",
+            "A256CBC-HS512"
+        ],
+        "supportedRcsResponseSigningAlgorithms": [
+            "PS384",
+            "ES384",
+            "RS384",
+            "HS256",
+            "HS512",
+            "ES256",
+            "RS256",
+            "HS384",
+            "ES512",
+            "PS256",
+            "PS512",
+            "RS512"
+        ]
+    },
+    "coreOAuth2Config": {
+        "accessTokenLifetime": 3600,
+        "accessTokenModificationScript": "d22f9a0c-426a-4466-b95e-d0f125b0d5fa",
+        "codeLifetime": 120,
+        "issueRefreshToken": true,
+        "issueRefreshTokenOnRefreshedToken": true,
+        "macaroonTokensEnabled": false,
+        "refreshTokenLifetime": 604800,
+        "statelessTokensEnabled": true,
+        "usePolicyEngineForScope": false
+    },
+    "coreOIDCConfig": {
+        "jwtTokenLifetime": 3600,
+        "oidcClaimsScript": "36863ffb-40ec-48b9-94b1-9a99f71cc3b5",
+        "oidcDiscoveryEndpointEnabled": true,
+        "overrideableOIDCClaims": [],
+        "supportedClaims": [],
+        "supportedIDTokenEncryptionAlgorithms": [
+            "ECDH-ES+A256KW",
+            "ECDH-ES+A192KW",
+            "RSA-OAEP",
+            "ECDH-ES+A128KW",
+            "RSA-OAEP-256",
+            "A128KW",
+            "A256KW",
+            "ECDH-ES",
+            "dir",
+            "A192KW"
+        ],
+        "supportedIDTokenEncryptionMethods": [
+            "A256GCM",
+            "A192GCM",
+            "A128GCM",
+            "A128CBC-HS256",
+            "A192CBC-HS384",
+            "A256CBC-HS512"
+        ],
+        "supportedIDTokenSigningAlgorithms": [
+            "PS384",
+            "ES384",
+            "RS384",
+            "HS256",
+            "HS512",
+            "ES256",
+            "RS256",
+            "HS384",
+            "ES512",
+            "PS256",
+            "PS512",
+            "RS512"
+        ]
+    },
+    "deviceCodeConfig": {
+        "deviceCodeLifetime": 300,
+        "devicePollInterval": 5
+    }
 }

--- a/config/services/validation.json
+++ b/config/services/validation.json
@@ -2,7 +2,9 @@
     "validGotoDestinations": [
         "https://openam-companieshouse-uk-dev.id.forgerock.io/*?*",
         "https://ewf-kermit.companieshouse.gov.uk/*",
-        "https://ewf-kermit.companieshouse.gov.uk/*?*"
+        "https://ewf-kermit.companieshouse.gov.uk/*?*",
+        "https://idam.amido.aws.chdev.org/*?*",
+        "https://idam.amido.aws.chdev.org/*"
     ],
     "_id": "validation",
     "_type": {

--- a/config/services/validation.json
+++ b/config/services/validation.json
@@ -1,0 +1,13 @@
+{
+    "validGotoDestinations": [
+        "https://openam-companieshouse-uk-dev.id.forgerock.io/*?*",
+        "https://ewf-kermit.companieshouse.gov.uk/*",
+        "https://ewf-kermit.companieshouse.gov.uk/*?*"
+    ],
+    "_id": "validation",
+    "_type": {
+        "_id": "validation",
+        "name": "Validation Service",
+        "collection": false
+    }
+}

--- a/helpers/cli-options.js
+++ b/helpers/cli-options.js
@@ -45,6 +45,11 @@ const cliOptions = (requestedOptions) => {
       alias: 't',
       demandOption: true,
       describe: 'Password for the Auth Tree Admin Client'
+    },
+    igOidcPassword: {
+      alias: 'i',
+      demandOption: true,
+      describe: 'Password for the IG OIDC Client'
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,13 @@ yargs
   .command({
     command: 'applications',
     desc: 'Update ForgeRock Applications (./config/applications)',
-    builder: cliOptions(['username', 'password', 'realm', 'authTreePassword']),
+    builder: cliOptions([
+      'username',
+      'password',
+      'realm',
+      'authTreePassword',
+      'igOidcPassword'
+    ]),
     handler: (argv) => updateApplications(argv)
   })
   .command({

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ const {
 
 require('dotenv').config()
 
-if (!process.env.FIDC_URL || !process.env.UI_URL) {
-  console.error('Missing required environment variable(s)')
+if (!process.env.FIDC_URL) {
+  console.error('Missing required environment variable: FIDC_URL')
   process.exit(1)
 }
 

--- a/scripts/update-applications.js
+++ b/scripts/update-applications.js
@@ -20,8 +20,8 @@ const updateApplications = async (argv) => {
 
     await replaceSensitiveValues(
       dir,
-      [/{UI_URL}/g, /{AUTH_TREE_PASSWORD}/g],
-      [UI_URL, authTreePassword]
+      [/{UI_URL}/g, /{EWF_URL}/g, /{AUTH_TREE_PASSWORD}/g],
+      [UI_URL, EWF_URL, authTreePassword]
     )
 
     const applicationFileContent = fs

--- a/scripts/update-applications.js
+++ b/scripts/update-applications.js
@@ -20,7 +20,7 @@ const updateApplications = async (argv) => {
 
     await replaceSensitiveValues(
       dir,
-      [/{REPLACEMENT_UI_URL}/g, /{REPLACEMENT_AUTH_TREE_PASSWORD}/g],
+      [/{UI_URL}/g, /{AUTH_TREE_PASSWORD}/g],
       [UI_URL, authTreePassword]
     )
 

--- a/scripts/update-applications.js
+++ b/scripts/update-applications.js
@@ -6,9 +6,13 @@ const replaceSensitiveValues = require('../helpers/replace-sensitive-values')
 
 const updateApplications = async (argv) => {
   const { realm, authTreePassword } = argv
-  const { FIDC_URL, UI_URL } = process.env
+  const { FIDC_URL, UI_URL, EWF_URL } = process.env
 
   try {
+    if (!UI_URL || !EWF_URL) {
+      throw new Error('Missing required environment variable(s)')
+    }
+
     const sessionToken = await getSessionToken(argv)
 
     // Read application JSON files

--- a/scripts/update-applications.js
+++ b/scripts/update-applications.js
@@ -5,7 +5,7 @@ const fidcRequest = require('../helpers/fidc-request')
 const replaceSensitiveValues = require('../helpers/replace-sensitive-values')
 
 const updateApplications = async (argv) => {
-  const { realm, authTreePassword } = argv
+  const { realm, authTreePassword, igOidcPassword } = argv
   const { FIDC_URL, UI_URL, EWF_URL } = process.env
 
   try {
@@ -20,8 +20,13 @@ const updateApplications = async (argv) => {
 
     await replaceSensitiveValues(
       dir,
-      [/{UI_URL}/g, /{EWF_URL}/g, /{AUTH_TREE_PASSWORD}/g],
-      [UI_URL, EWF_URL, authTreePassword]
+      [
+        /{UI_URL}/g,
+        /{EWF_URL}/g,
+        /{AUTH_TREE_PASSWORD}/g,
+        /{IG_OIDC_PASSWORD}/g
+      ],
+      [UI_URL, EWF_URL, authTreePassword, igOidcPassword]
     )
 
     const applicationFileContent = fs

--- a/scripts/update-services.js
+++ b/scripts/update-services.js
@@ -18,11 +18,7 @@ const updateServices = async (argv) => {
     // Read JSON files
     const dir = path.resolve(__dirname, '../config/services')
 
-    await replaceSensitiveValues(
-      dir,
-      ['{REPLACEMENT_HASH_SALT}'],
-      [OAUTH2_HASH_SALT]
-    )
+    await replaceSensitiveValues(dir, ['{HASH_SALT}'], [OAUTH2_HASH_SALT])
 
     const servicesFileContent = fs
       .readdirSync(dir)

--- a/tests/scripts/update-applications.test.js
+++ b/tests/scripts/update-applications.test.js
@@ -16,6 +16,8 @@ describe('update-applications', () => {
 
   const mockValues = {
     fidcUrl: 'https://fidc-test.forgerock.com',
+    uiUrl: 'https://idam-ui.companieshouse.gov.uk',
+    ewfUrl: 'https://ewf.companieshouse.gov.uk',
     sessionToken: 'session=1234',
     realm: 'alpha'
   }
@@ -60,6 +62,8 @@ describe('update-applications', () => {
     fidcRequest.mockImplementation(() => Promise.resolve())
     replaceSensitiveValues.mockImplementation(() => Promise.resolve())
     process.env.FIDC_URL = mockValues.fidcUrl
+    process.env.UI_URL = mockValues.uiUrl
+    process.env.EWF_URL = mockValues.ewfUrl
     fs.readdirSync.mockReturnValue(['sdk-client.json'])
     jest.mock(mockConfigFile, () => mockConfig, { virtual: true })
   })
@@ -75,6 +79,16 @@ describe('update-applications', () => {
     console.log.mockRestore()
     console.error.mockRestore()
     process.exit.mockRestore()
+  })
+
+  it('should error if missing environment variable', async () => {
+    expect.assertions(2)
+    delete process.env.UI_URL
+    await updateApplications(mockValues)
+    expect(console.error).toHaveBeenCalledWith(
+      'Missing required environment variable(s)'
+    )
+    expect(process.exit).toHaveBeenCalledWith(1)
   })
 
   it('should error if getSessionToken functions fails', async () => {


### PR DESCRIPTION
Initial configuration to support WebFiling journey:
- creation of OIDC client to be used by IG for authN (with default ACR value of EWF journey ID)
- config of Oauth2 provider service to include ACR mapping and new custom login URL
- new basic CHWebFiling journey (will be expanded later)
- new URLs added to validation service (will be parametrised later)
- hardcoding of ID Token claims in the OIDC claims script (will be modified later)