### PR TITLE
email consent

### DIFF
--- a/config/am-scripts/scripts-config.json
+++ b/config/am-scripts/scripts-config.json
@@ -1269,6 +1269,22 @@
                 "lastModifiedDate":1617810491969
              },
             "filename": "ch-remove-user-send-email.js"
+        },
+        {
+            "payload": {
+                "_id":"bdfa0ec4-ad50-484f-9732-77c789a900cb",
+                "name":"CH - Email Consent Collector/Changer",
+                "description":"Collect email consent and allow the user to change it",
+                "script":"<replace>",
+                "default":false,
+                "language":"JAVASCRIPT",
+                "context":"AUTHENTICATION_TREE_DECISION_NODE",
+                "createdBy":"null",
+                "creationDate":0,
+                "lastModifiedBy":"id=f299b657-74e2-42cd-bc80-a27adf5b8602,ou=user,ou=am-config",
+                "lastModifiedDate":1617810491969
+             },
+            "filename": "ch-email-consent-change.js"
         }
     ]
 }

--- a/config/am-scripts/scripts-content/ch-email-consent-change.js
+++ b/config/am-scripts/scripts-content/ch-email-consent-change.js
@@ -1,0 +1,288 @@
+/* 
+  ** INPUT DATA
+    * QUERY PARAMS
+     - [optional] action: the action to be performed (changeUpdates, changeMarketing)
+
+  ** INPUT DATA    
+    * TRANSIENT STATE
+      - 'idmAccessToken': the IDM access token
+
+      * SHARED STATE:
+      - '_id' : the ID of the user performing the operation (session owner/actor)
+      - [optional] 'errorMessage': error message to display from previous attempts
+      - [optional] 'pagePropsJSON': the JSON props for the UI to display 
+      
+  ** OUTCOMES
+    - 'collect_consent': the tree will skip the 'change' logic and show the email consent screen (only if never set before)
+    - 'cancel': the user is in the 'change' screen, and decides to skip/cancel the operation
+    - 'error': an error has happened during processing
+*/
+
+var fr = JavaImporter(
+    org.forgerock.openam.auth.node.api.Action,
+    javax.security.auth.callback.NameCallback,
+    javax.security.auth.callback.TextOutputCallback,
+    com.sun.identity.authentication.callbacks.HiddenValueCallback,
+    javax.security.auth.callback.ConfirmationCallback,
+    org.forgerock.openam.authentication.callbacks.BooleanAttributeInputCallback,
+    javax.security.auth.callback.ChoiceCallback,
+    java.lang.String
+)
+
+var NodeOutcome = {
+    COLLECT_CONSENT: "collect_consent",
+    CANCEL: "cancel",
+    ERROR: "error"
+}
+
+var PreferencesFields = {
+    UPDATES: "updates",
+    MARKETING: "marketing"
+}
+
+var ConfirmIndex = {
+    SUBMIT: 0,
+    CANCEL: 1
+}
+
+function raiseError(message, token) {
+    action = fr.Action.send(
+        new fr.HiddenValueCallback(
+            "stage",
+            "UPDATE_CONSENT_ERROR"
+        ),
+        new fr.HiddenValueCallback(
+            "pagePropsJSON",
+            JSON.stringify({ "error": message, "token": token })
+        ),
+        new fr.TextOutputCallback(
+            fr.TextOutputCallback.ERROR,
+            message
+        )
+    ).build()
+}
+
+function debug(message) {
+    action = fr.Action.send(
+        new fr.TextOutputCallback(
+            fr.TextOutputCallback.ERROR,
+            message
+        )
+    ).build()
+}
+
+function updatePreferences(userId, field, value) {
+    var accessToken = sharedState.get("idmAccessToken");
+    if (accessToken == null) {
+        logger.error("[UPDATE EMAIL CONSENT] Access token not in shared state")
+        return {
+            success: false,
+            message: "Access token not in transient state"
+        }
+    }
+    logger.error("[UPDATE EMAIL CONSENT] Updating counter to " + value);
+
+    var request = new org.forgerock.http.protocol.Request();
+    request.setMethod('PATCH');
+    request.setUri(alphaUserUrl + userId);
+    request.getHeaders().add("Authorization", "Bearer " + accessToken);
+    request.getHeaders().add("Content-Type", "application/json");
+    var requestBodyJson = [
+        {
+            "operation": "replace",
+            "field": "/preferences/" + field,
+            "value": value
+        }
+    ];
+    request.setEntity(requestBodyJson);
+
+    var response = httpClient.send(request).get();
+
+    if (response.getStatus().getCode() === 200) {
+        logger.error("[UPDATE EMAIL CONSENT] Counter updated correctly");
+        return true;
+    } else {
+        logger.error("[UPDATE EMAIL CONSENT] Error while updating counter value: " + response.getStatus().getCode());
+        return false;
+    }
+}
+
+// reads the current invalid login attempts counter from frUnindexedInteger1
+function lookupUser(userId) {
+    try {
+        var accessToken = transientState.get("idmAccessToken");
+        if (accessToken == null) {
+            logger.error("[UPDATE EMAIL CONSENT] Access token not in transient state")
+            return {
+                success: false,
+                message: "Access token not in transient state"
+            }
+        } else {
+            sharedState.put("idmAccessToken", accessToken);
+        }
+
+        var request = new org.forgerock.http.protocol.Request();
+
+        request.setMethod('GET');
+        request.setUri(alphaUserUrl + userId + "?_fields=preferences");
+        request.getHeaders().add("Authorization", "Bearer " + accessToken);
+        request.getHeaders().add("Content-Type", "application/json");
+        var response = httpClient.send(request).get();
+        if (response.getStatus().getCode() === 200) {
+            return {
+                success: true,
+                user: JSON.parse(response.getEntity().getString())
+            }
+        } else {
+            logger.error("[UPDATE EMAIL CONSENT] Error while looking up user " + userId + " : " + response.getStatus().getCode())
+            return {
+                success: false,
+                message: "Error while GET user " + userId + " : " + response.getStatus().getCode() + " - request: " + alphaUserUrl + userId + "_fields=preferences"
+            }
+        }
+    } catch (e) {
+        logger.error("[UPDATE EMAIL CONSENT] lookup User error: " + e);
+        return {
+            success: false,
+            message: "Error while looking up user: " + e
+        };
+    }
+}
+
+//extracts the company number and user ID from the query parameters
+function fetchActionParameter() {
+    var action = requestParameters.get("action");
+
+    if (action && (action.get(0).equals("changeUpdates") || action.get(0).equals("changeMarketing"))) {
+        return {
+            changeUpdates: action.get(0).equals("changeUpdates"),
+            changeMarketing: action.get(0).equals("changeMarketing")
+        }
+    }
+    logger.error("[UPDATE EMAIL CONSENT] action parameter not found in request, or different from 'changeUpdates' or 'changeMarketing'");
+    return false;
+}
+
+// execution flow
+var alphaUserUrl = "https://openam-companieshouse-uk-dev.id.forgerock.io/openidm/managed/alpha_user/";
+try {
+    var answers = ["YES", "NO"];
+    var paramsResponse = fetchActionParameter();
+    var sessionOwnerId = sharedState.get("_id");
+    if (!paramsResponse) {
+        action = fr.Action.goTo(NodeOutcome.COLLECT_CONSENT).build();
+    } else {
+        if (callbacks.isEmpty()) {
+            var userResponse = lookupUser(sessionOwnerId);
+            var currentEmailUpdatesValue = userResponse.user.preferences ? userResponse.user.preferences.updates : false;
+            var currentEmailMarketingValue = userResponse.user.preferences ? userResponse.user.preferences.marketing : false;
+            if (!userResponse.success) {
+                raiseError(userResponse.message, "USER_NOT_FOUND");
+            } else {
+                sharedState.put("user", JSON.stringify(userResponse.user));
+
+                var infoMessage = paramsResponse.changeUpdates ? "Receive email updates?" : "Receive marketing updates?";
+                var errorMessage = sharedState.get("errorMessage");
+                var level = fr.TextOutputCallback.INFORMATION;
+                if (errorMessage !== null) {
+                    var errorProps = sharedState.get("pagePropsJSON");
+                    level = fr.TextOutputCallback.ERROR;
+                    infoMessage = errorMessage.concat(" Please try again.");
+
+                    action = fr.Action.send(
+                        new fr.TextOutputCallback(level, infoMessage),
+                        new fr.ChoiceCallback(
+                            infoMessage,
+                            answers,
+                            0,
+                            false
+                        ),
+                        new fr.TextOutputCallback(fr.TextOutputCallback.INFORMATION, "Do you want to cancel?"),
+                        new fr.ConfirmationCallback(
+                            "Do you want to confirm the changes?",
+                            fr.ConfirmationCallback.INFORMATION,
+                            ["SUBMIT", "CANCEL"],
+                            0),
+                        new fr.HiddenValueCallback("stage", paramsResponse.changeUpdates ? "CHANGE_CONSENT_UPDATES" : "CHANGE_CONSENT_MARKETING"),
+                        new fr.HiddenValueCallback("currentValue", paramsResponse.changeUpdates ? currentEmailUpdatesValue : currentEmailMarketingValue),
+                        new fr.HiddenValueCallback("pagePropsJSON", errorProps)
+                    ).build();
+                } else {
+                    action = fr.Action.send(
+                        new fr.TextOutputCallback(level, infoMessage),
+                        new fr.ChoiceCallback(
+                            infoMessage,
+                            answers,
+                            0,
+                            false
+                        ),
+                        new fr.TextOutputCallback(fr.TextOutputCallback.INFORMATION, "Do you want to cancel?"),
+                        new fr.ConfirmationCallback(
+                            "Do you want to confirm the changes?",
+                            fr.ConfirmationCallback.INFORMATION,
+                            ["SUBMIT", "CANCEL"],
+                            0),
+                        new fr.HiddenValueCallback("stage", paramsResponse.changeUpdates ? "CHANGE_CONSENT_UPDATES" : "CHANGE_CONSENT_MARKETING"),
+                        new fr.HiddenValueCallback("currentValue", paramsResponse.changeUpdates ? currentEmailUpdatesValue : currentEmailMarketingValue)
+                    ).build();
+                }
+            }
+        } else {
+            var user = JSON.parse(sharedState.get("user"));
+            var currentEmailUpdatesValue = user.preferences ? user.preferences.updates : false;
+            var currentEmailMarketingValue = user.preferences ? user.preferences.marketing : false;
+            var selection = callbacks.get(1).getSelectedIndexes()[0];
+
+            var confirmIndex = callbacks.get(3).getSelectedIndex();
+            logger.error("[UPDATE EMAIL CONSENT] confirm remove: " + confirmIndex);
+
+            if (confirmIndex === ConfirmIndex.SUBMIT) { 
+
+                logger.error("[UPDATE EMAIL CONSENT] email updates selection: " + selection);
+                var updateResponse;
+
+                if (paramsResponse.changeUpdates) {
+                    updateResponse = updatePreferences(sessionOwnerId, PreferencesFields.UPDATES, (selection === 0));
+                } else if (paramsResponse.changeMarketing) {
+                    updateResponse = updatePreferences(sessionOwnerId, PreferencesFields.MARKETING, (selection === 0));
+                }
+
+                if (!updateResponse) {
+                    sharedState.put("errorMessage", "Error occurred while updating email preferences.");
+                    sharedState.put("pagePropsJSON", JSON.stringify(
+                        {
+                            'errors': [{
+                                label: "Error occurred while updating preferences.",
+                                token: "UPDATE_CONSENT_ERROR",
+                                fieldName: "IDToken1",
+                                anchor: "IDToken1"
+                            }]
+                        }));
+                    action = fr.Action.goTo(NodeOutcome.ERROR).build();
+                } else {
+                    action = fr.Action.send(
+                        new fr.TextOutputCallback(
+                            fr.TextOutputCallback.INFORMATION,
+                            "Preferences have been updated"
+                        ),
+                        new fr.HiddenValueCallback(
+                            "stage",
+                            paramsResponse.changeUpdates ? "UPDATE_EMAIL_UPDATES_CONSENT_CONFIRMATION" : "UPDATE_EMAIL_MARKETING_CONSENT_CONFIRMATION"
+                        ),
+                        new fr.HiddenValueCallback(
+                            "pagePropsJSON",
+                            JSON.stringify({ "user": user, "newValue": (selection === 0) })
+                        )
+                    ).build();
+                }
+            } else {
+                action = fr.Action.goTo(NodeOutcome.CANCEL).build();
+            }
+        }
+    }
+} catch (e) {
+    logger.error("[UPDATE EMAIL CONSENT] ERROR: " + e);
+    sharedState.put("errorMessage", e.toString());
+    action = fr.Action.goTo(NodeOutcome.ERROR).build();
+}
+

--- a/config/am-scripts/scripts-content/ch-invite-user-send-email.js
+++ b/config/am-scripts/scripts-content/ch-invite-user-send-email.js
@@ -242,7 +242,7 @@ try {
     if (!inviteData) {
         sendErrorCallbacks("INVITE_USER_ERROR", "INVITE_USER_ERROR", "An error has occurred! Please try again later.");
     } else {
-        var sendEmailResult = sendEmail(language, inviteData.invitedEmail, inviteData.companyName, inviteData.companyNumber, inviteData.inviterName)
+        var sendEmailResult = sendEmail(language, inviteData.invitedEmail, inviteData.companyName, inviteData.companyNumber, inviteData.inviterName);
         if (sendEmailResult.success) {
             action = fr.Action.goTo(NodeOutcome.SUCCESS).build();
         } else {

--- a/config/am-scripts/scripts-content/ch-remove-user-prompt-confirmation.js
+++ b/config/am-scripts/scripts-content/ch-remove-user-prompt-confirmation.js
@@ -20,7 +20,7 @@
     - 'confirmed': the user has confirmed the removal
     - 'missing_confirm': the user has tried to confirm removal without acknowledging the information
     - 'cancel': the user has cancelled the operation
-    - 'error': an error has happened duing processing
+    - 'error': an error has happened during processing
 */
 
 var fr = JavaImporter(

--- a/config/auth-trees/ch-manage-email-consent.json
+++ b/config/auth-trees/ch-manage-email-consent.json
@@ -1,0 +1,204 @@
+{
+    "nodes": [
+      {
+         "_id": "3dab574a-7f56-4904-923e-c65aefde466b",
+         "nodeType": "ScriptedDecisionNode", 
+         "details": {
+             "inputs":["*"],
+             "outcomes":["hasSession","noSession"],
+             "outputs":["*"],
+             "script":"c4001e02-469c-4cc4-bf95-9f43d7e46568"
+         }            
+     },
+     {
+         "_id": "43fcdfa0-6f75-466d-befa-a052a1b08c72",
+         "nodeType": "IdentifyExistingUserNode", 
+         "details": {
+            "identifier":"userName",
+            "identityAttribute":"mail"
+         }
+      },    
+      {
+         "_id": "d1144353-a389-49c2-8b1f-3e530bed1aba",
+         "nodeType": "ScriptedDecisionNode", 
+         "details": {
+            "inputs":["*"],
+            "outcomes": ["success", "error"],
+            "outputs":["*"],
+            "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+         }            
+      },
+      {
+         "_id": "3b8927aa-d5c0-4cde-965b-f51c54b81f71",
+         "nodeType": "ScriptedDecisionNode", 
+         "details": {
+            "inputs":["*"],
+            "outcomes": ["collect_consent", "cancel", "error"],
+            "outputs":["*"],
+            "script": "bdfa0ec4-ad50-484f-9732-77c789a900cb"
+         }            
+      },
+      {
+         "_id": "883923db-1b96-41ce-bf3a-aa5d369a9ab4",
+         "nodeType": "AttributeValueDecisionNode", 
+         "details": {
+            "comparisonOperation": "PRESENT",
+	         "identityAttribute": "userName",
+	         "comparisonAttribute": "preferences"
+         }            
+      },
+      {
+         "_id":"2bcba502-62a9-4178-afc8-ce59c6d8201f",
+         "nodeType": "PageNode",
+         "details": {
+             "stage":"EMAIL_CONSENT",
+             "nodes":[
+                 {
+                     "_id":"cb1714aa-6593-4d9d-9873-256db95c71cf",
+                     "nodeType":"AttributeCollectorNode",
+                     "displayName":"Email consent"
+                 }
+             ],
+             "pageDescription":{
+                 "en": "Please enter your email preferences"
+             },
+             "pageHeader":{
+                 "en": "Please enter your email preferences"
+             }
+         }
+     },
+     {
+         "_id":"cb1714aa-6593-4d9d-9873-256db95c71cf",
+         "nodeType": "AttributeCollectorNode",
+         "details": {
+            "attributesToCollect": ["preferences/updates", "preferences/marketing"],
+            "identityAttribute": "userName",
+            "required":false,
+            "validateInputs":false
+         }
+      },
+      {
+			"_id": "71724abd-9915-4f8b-b658-9ef2ba270322",
+			"nodeType": "PatchObjectNode", 
+			"details": {
+				"patchAsObject":false,
+				"ignoredFields": [],
+				"identityResource":"managed/alpha_user",
+				"identityAttribute":"userName"
+			}
+		}
+   ],
+   "tree": {
+      "_id": "CHManageEmailConsent",
+      "description": "Allows the user to set the consent preferences for the first time, or to change the consent preferences after they have been set.",
+      "identityResource": "managed/alpha_user",
+      "uiConfig": {},
+      "entryNodeId": "3dab574a-7f56-4904-923e-c65aefde466b",
+      "nodes": {
+         "b1b8380b-c22f-4254-8fb3-b082886ff615": {
+            "x": 640,
+            "y": 607,
+            "connections": {
+               "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+               "true": "2bcba502-62a9-4178-afc8-ce59c6d8201f"
+            },
+            "nodeType": "QueryFilterDecisionNode",
+            "displayName": "Query Filter Decision"
+         },
+         "2bcba502-62a9-4178-afc8-ce59c6d8201f": {
+            "x": 1085,
+            "y": 14,
+            "connections": {
+               "outcome": "71724abd-9915-4f8b-b658-9ef2ba270322"
+            },
+            "nodeType": "PageNode",
+            "displayName": "Show consent"
+         },
+         "3b8927aa-d5c0-4cde-965b-f51c54b81f71": {
+            "x": 631,
+            "y": 160.015625,
+            "connections": {
+               "collect_consent": "883923db-1b96-41ce-bf3a-aa5d369a9ab4",
+               "error": "e301438c-0bd0-429c-ab0c-66126501069a",
+               "cancel": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+            },
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "Change Consent check"
+         },
+         "883923db-1b96-41ce-bf3a-aa5d369a9ab4": {
+            "x": 796.234375,
+            "y": 17.015625,
+            "connections": {
+               "false": "2bcba502-62a9-4178-afc8-ce59c6d8201f",
+               "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+            },
+            "nodeType": "AttributeValueDecisionNode",
+            "displayName": "Attribute Value Decision"
+         },
+         "3dab574a-7f56-4904-923e-c65aefde466b": {
+            "x": 259,
+            "y": 53.015625,
+            "connections": {
+               "noSession": "e301438c-0bd0-429c-ab0c-66126501069a",
+               "hasSession": "43fcdfa0-6f75-466d-befa-a052a1b08c72"
+            },
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "check session"
+         },
+         "71724abd-9915-4f8b-b658-9ef2ba270322": {
+            "x": 1330,
+            "y": 28,
+            "connections": {
+               "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+               "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+            },
+            "nodeType": "PatchObjectNode",
+            "displayName": "Patch Object"
+         },
+         "43fcdfa0-6f75-466d-befa-a052a1b08c72": {
+            "x": 354,
+            "y": 260.015625,
+            "connections": {
+               "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+               "true": "d1144353-a389-49c2-8b1f-3e530bed1aba"
+            },
+            "nodeType": "IdentifyExistingUserNode",
+            "displayName": "Identify Existing User"
+         },
+         "84f8355f-7f17-488f-9c17-f209ef1135ef": {
+            "x": 874,
+            "y": 596,
+            "connections": {
+               "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+               "true": "2bcba502-62a9-4178-afc8-ce59c6d8201f"
+            },
+            "nodeType": "LoginCountDecisionNode",
+            "displayName": "Login Count Decision"
+         },
+         "d1144353-a389-49c2-8b1f-3e530bed1aba": {
+            "x": 407,
+            "y": 443.015625,
+            "connections": {
+               "success": "3b8927aa-d5c0-4cde-965b-f51c54b81f71",
+               "error": "e301438c-0bd0-429c-ab0c-66126501069a"
+            },
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "get IDM token"
+         }
+      },
+      "staticNodes": {
+         "startNode": {
+            "x": 50,
+            "y": 58.5
+         },
+         "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1205,
+            "y": 330
+         },
+         "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 1640,
+            "y": 174
+         }
+      }
+   }
+}

--- a/config/auth-trees/ch-manage-email-consent.json
+++ b/config/auth-trees/ch-manage-email-consent.json
@@ -11,6 +11,14 @@
          }            
      },
      {
+         "_id": "9880816b-cedd-441c-a560-adc524aaa29b",
+         "nodeType": "SessionDataNode", 
+         "details": {
+            "sharedStateKey":"userName",
+            "sessionDataKey":"UserToken"
+         }				
+     },
+     {
          "_id": "43fcdfa0-6f75-466d-befa-a052a1b08c72",
          "nodeType": "IdentifyExistingUserNode", 
          "details": {
@@ -93,7 +101,7 @@
       "description": "Allows the user to set the consent preferences for the first time, or to change the consent preferences after they have been set.",
       "identityResource": "managed/alpha_user",
       "uiConfig": {},
-      "entryNodeId": "3dab574a-7f56-4904-923e-c65aefde466b",
+      "entryNodeId": "43fcdfa0-6f75-466d-befa-a052a1b08c72",
       "nodes": {
          "b1b8380b-c22f-4254-8fb3-b082886ff615": {
             "x": 640,
@@ -136,11 +144,11 @@
             "displayName": "Attribute Value Decision"
          },
          "3dab574a-7f56-4904-923e-c65aefde466b": {
-            "x": 259,
-            "y": 53.015625,
+            "x": 36,
+            "y": 340.015625,
             "connections": {
                "noSession": "e301438c-0bd0-429c-ab0c-66126501069a",
-               "hasSession": "43fcdfa0-6f75-466d-befa-a052a1b08c72"
+               "hasSession": "9880816b-cedd-441c-a560-adc524aaa29b"
             },
             "nodeType": "ScriptedDecisionNode",
             "displayName": "check session"
@@ -156,8 +164,8 @@
             "displayName": "Patch Object"
          },
          "43fcdfa0-6f75-466d-befa-a052a1b08c72": {
-            "x": 354,
-            "y": 260.015625,
+            "x": 349,
+            "y": 67.015625,
             "connections": {
                "false": "e301438c-0bd0-429c-ab0c-66126501069a",
                "true": "d1144353-a389-49c2-8b1f-3e530bed1aba"
@@ -184,6 +192,15 @@
             },
             "nodeType": "ScriptedDecisionNode",
             "displayName": "get IDM token"
+         },
+         "9880816b-cedd-441c-a560-adc524aaa29b": {
+            "x": 156,
+            "y": 228.015625,
+            "connections": {
+               "outcome": "43fcdfa0-6f75-466d-befa-a052a1b08c72"
+            },
+            "nodeType": "SessionDataNode",
+            "displayName": "Get Session Data"
          }
       },
       "staticNodes": {

--- a/config/auth-trees/ch-onboarding.json
+++ b/config/auth-trees/ch-onboarding.json
@@ -93,6 +93,13 @@
 			"details": {
 				"tree": "CHWebFiling-CompleteProfile"
 			}
+		},
+		{
+			"_id": "d1803b3d-6de4-4644-818b-3fd39819a6a9",
+			"nodeType": "InnerTreeEvaluatorNode",
+			"details": {
+				"tree": "CHManageEmailConsent"
+			}
 		}
 	],
 	"tree": {
@@ -190,14 +197,24 @@
 				"displayName": "Retry Limit Decision"
 			},
 			"90fbab28-de9f-4d6b-9cc6-6519e26fef7f": {
-				"x": 1746,
-				"y": 391.015625,
+				"x": 1581,
+				"y": 379.015625,
+				"connections": {
+					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
+					"true": "d1803b3d-6de4-4644-818b-3fd39819a6a9"
+				},
+				"nodeType": "InnerTreeEvaluatorNode",
+				"displayName": "Inner Tree Evaluator"
+			},
+			"d1803b3d-6de4-4644-818b-3fd39819a6a9": {
+				"x": 1808,
+				"y": 375.015625,
 				"connections": {
 					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
 					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
 				},
 				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Inner Tree Evaluator"
+				"displayName": "Email consent"
 			}
 		},
 		"staticNodes": {
@@ -206,8 +223,8 @@
 				"y": 103
 			},
 			"70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-				"x": 1867,
-				"y": 257
+				"x": 2049,
+				"y": 197
 			},
 			"e301438c-0bd0-429c-ab0c-66126501069a": {
 				"x": 917,

--- a/config/auth-trees/ch-registration-verify.json
+++ b/config/auth-trees/ch-registration-verify.json
@@ -41,7 +41,7 @@
         {
             "_id":"cc0eae7e-d27f-468f-9966-3f9efe7d7918",           
             "nodeType":"ValidatedPasswordNode",
-			"details": {
+			   "details": {
                 "passwordAttribute":"password",
                 "validateInput":true                
             }
@@ -70,88 +70,126 @@
                 "identifier":"userName",
                 "identityAttribute":"mail"
             }
+         },
+         {
+            "_id":"ac4e4e6e-0b76-44d6-af80-a97fb83b70e4",
+            "nodeType": "PageNode",
+            "details": {
+                "stage":"REGISTRATION_5",
+                "nodes":[
+                    {
+                        "_id":"cc0eae7e-d27f-468f-9966-3f9efe7d7918",
+                        "nodeType":"AttributeCollectorNode",
+                        "displayName":"Email consent"
+                    }
+                ],
+                "pageDescription":{
+                    "en": "Please enter your email preferences"
+                },
+                "pageHeader":{
+                    "en": "Please enter your email preferences"
+                }
+            }
+        },
+        {
+            "_id":"cc0eae7e-d27f-468f-9966-3f9efe7d7918",
+            "nodeType": "AttributeCollectorNode",
+            "details": {
+               "attributesToCollect": ["preferences/updates", "preferences/marketing"],
+               "identityAttribute": "userName",
+               "required":false,
+               "validateInputs":false
+            }
          }
     ],
     "tree": {
-        "_id":"CHVerifyReg",
-        "entryNodeId":"7ebb5593-77f8-4125-a11a-5717499da135",
-        "identityResource":"managed/alpha_user",
-        "description":"Verify Registration tree for CH Users",
-        "uiConfig":{},
-        "nodes":{
-           "02d95fe8-1c39-4144-b411-13fcd4226c6a":{
-              "x":1181,
-              "y":163,
-              "connections":{
-                 "FAILURE":"e301438c-0bd0-429c-ab0c-66126501069a",
-                 "CREATED":"bb74cb44-5e3f-4634-9e5f-f18e121ca93f"
-              },
-              "nodeType":"CreateObjectNode",
-              "displayName":"Create User"
-           },
-           "7ebb5593-77f8-4125-a11a-5717499da135":{
-              "x":203,
-              "y":265,
-              "connections":{
-                 "false":"e301438c-0bd0-429c-ab0c-66126501069a",
-                 "true":"63a23daf-33ad-4848-8e2a-c3f3d749e646"
-              },
-              "nodeType":"ScriptedDecisionNode",
-              "displayName":"Verify Reg Token"
-           },
-           "63a23daf-33ad-4848-8e2a-c3f3d749e646":{
-              "x":538,
-              "y":189,
-              "connections":{
-                 "false":"d3d9440a-6562-479a-be32-7d863a159155",
-                 "true":"9d7a87df-d656-4539-b1e4-7199950aa0e8"
-              },
-              "nodeType":"IdentifyExistingUserNode",
-              "displayName":"Identify Existing User"
-           },
-           "9d7a87df-d656-4539-b1e4-7199950aa0e8":{
-              "x":993,
-              "y":367,
-              "connections":{
-                 "false":"e301438c-0bd0-429c-ab0c-66126501069a"
-              },
-              "nodeType":"ScriptedDecisionNode",
-              "displayName":"Callback Existing User"
-           },
-           "d3d9440a-6562-479a-be32-7d863a159155":{
-              "x":905,
-              "y":116,
-              "connections":{
-                 "outcome":"02d95fe8-1c39-4144-b411-13fcd4226c6a"
-              },
-              "nodeType":"PageNode",
-              "displayName":"Password Collector"
-           },
-           "bb74cb44-5e3f-4634-9e5f-f18e121ca93f":{
-              "x":1418,
-              "y":36,
-              "connections":{
-                 "true":"70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-                 "false":"e301438c-0bd0-429c-ab0c-66126501069a"
-              },
-              "nodeType":"IdentifyExistingUserNode",
-              "displayName":"Identify Existing User"
-           }
-        },
-        "staticNodes":{
-           "startNode":{
-              "x":70,
-              "y":80
-           },
-           "70e691a5-1e33-4ac3-a356-e7b6d60d92e0":{
-              "x":1693,
-              "y":39
-           },
-           "e301438c-0bd0-429c-ab0c-66126501069a":{
-              "x":1615,
-              "y":541
-           }
-        }
-     }
-    
+      "_id": "CHVerifyReg",
+      "identityResource": "managed/alpha_user",
+      "description": "Verify Registration tree for CH Users",
+      "uiConfig": {},
+      "entryNodeId": "7ebb5593-77f8-4125-a11a-5717499da135",
+      "nodes": {
+         "02d95fe8-1c39-4144-b411-13fcd4226c6a": {
+            "x": 1379,
+            "y": 197,
+            "connections": {
+               "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
+               "CREATED": "bb74cb44-5e3f-4634-9e5f-f18e121ca93f"
+            },
+            "nodeType": "CreateObjectNode",
+            "displayName": "Create User"
+         },
+         "7ebb5593-77f8-4125-a11a-5717499da135": {
+            "x": 203,
+            "y": 265,
+            "connections": {
+               "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+               "true": "63a23daf-33ad-4848-8e2a-c3f3d749e646"
+            },
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "Verify Reg Token"
+         },
+         "63a23daf-33ad-4848-8e2a-c3f3d749e646": {
+            "x": 538,
+            "y": 189,
+            "connections": {
+               "false": "d3d9440a-6562-479a-be32-7d863a159155",
+               "true": "9d7a87df-d656-4539-b1e4-7199950aa0e8"
+            },
+            "nodeType": "IdentifyExistingUserNode",
+            "displayName": "Identify Existing User"
+         },
+         "9d7a87df-d656-4539-b1e4-7199950aa0e8": {
+            "x": 993,
+            "y": 367,
+            "connections": {
+               "false": "e301438c-0bd0-429c-ab0c-66126501069a"
+            },
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "Callback Existing User"
+         },
+         "d3d9440a-6562-479a-be32-7d863a159155": {
+            "x": 905,
+            "y": 116,
+            "connections": {
+               "outcome": "ac4e4e6e-0b76-44d6-af80-a97fb83b70e4"
+            },
+            "nodeType": "PageNode",
+            "displayName": "Password Collector"
+         },
+         "bb74cb44-5e3f-4634-9e5f-f18e121ca93f": {
+            "x": 1515,
+            "y": 17,
+            "connections": {
+               "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+               "false": "e301438c-0bd0-429c-ab0c-66126501069a"
+            },
+            "nodeType": "IdentifyExistingUserNode",
+            "displayName": "Identify Existing User"
+         },
+         "ac4e4e6e-0b76-44d6-af80-a97fb83b70e4": {
+            "x": 1185,
+            "y": 73.015625,
+            "connections": {
+               "outcome": "02d95fe8-1c39-4144-b411-13fcd4226c6a"
+            },
+            "nodeType": "PageNode",
+            "displayName": "Consent"
+         }
+      },
+      "staticNodes": {
+         "startNode": {
+            "x": 70,
+            "y": 80
+         },
+         "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+            "x": 1772,
+            "y": 40
+         },
+         "e301438c-0bd0-429c-ab0c-66126501069a": {
+            "x": 1615,
+            "y": 541
+         }
+      }
+   }   
 }

--- a/config/auth-trees/ch-webfiling-login.json
+++ b/config/auth-trees/ch-webfiling-login.json
@@ -341,6 +341,13 @@
 				"outputs": ["*"],
 				"script": "19a9ba97-3eaf-46ed-9b59-ea9315d81407"
 			}
+		},
+		{
+			"_id": "46ecc3d3-5c8a-47bc-bcd0-2cc76e70748b",
+			"nodeType": "InnerTreeEvaluatorNode",
+			"details": {
+				"tree": "CHManageEmailConsent"
+			}
 		}
 	],
     "tree": {
@@ -396,7 +403,7 @@
 				"y": 172.5,
 				"connections": {
 					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
-					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+					"true": "46ecc3d3-5c8a-47bc-bcd0-2cc76e70748b"
 				},
 				"nodeType": "InnerTreeEvaluatorNode",
 				"displayName": "Inner Tree Evaluator"
@@ -610,6 +617,16 @@
 				},
 				"nodeType": "ScriptedDecisionNode",
 				"displayName": "Store pwd in session"
+			},
+			"46ecc3d3-5c8a-47bc-bcd0-2cc76e70748b": {
+				"x": 3483,
+				"y": 296.015625,
+				"connections": {
+					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+					"false": "e301438c-0bd0-429c-ab0c-66126501069a"
+				},
+				"nodeType": "InnerTreeEvaluatorNode",
+				"displayName": "Email Consent"
 			}
 		},
 		"staticNodes": {

--- a/config/auth-trees/ch-webfiling-login.json
+++ b/config/auth-trees/ch-webfiling-login.json
@@ -341,13 +341,6 @@
 				"outputs": ["*"],
 				"script": "19a9ba97-3eaf-46ed-9b59-ea9315d81407"
 			}
-		},
-		{
-			"_id": "46ecc3d3-5c8a-47bc-bcd0-2cc76e70748b",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "CHManageEmailConsent"
-			}
 		}
 	],
     "tree": {
@@ -403,7 +396,7 @@
 				"y": 172.5,
 				"connections": {
 					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
-					"true": "46ecc3d3-5c8a-47bc-bcd0-2cc76e70748b"
+					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
 				},
 				"nodeType": "InnerTreeEvaluatorNode",
 				"displayName": "Inner Tree Evaluator"
@@ -617,16 +610,6 @@
 				},
 				"nodeType": "ScriptedDecisionNode",
 				"displayName": "Store pwd in session"
-			},
-			"46ecc3d3-5c8a-47bc-bcd0-2cc76e70748b": {
-				"x": 3483,
-				"y": 296.015625,
-				"connections": {
-					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-					"false": "e301438c-0bd0-429c-ab0c-66126501069a"
-				},
-				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Email Consent"
 			}
 		},
 		"staticNodes": {

--- a/config/auth-trees/ch-webfiling-login.json
+++ b/config/auth-trees/ch-webfiling-login.json
@@ -341,6 +341,20 @@
 				"outputs": ["*"],
 				"script": "19a9ba97-3eaf-46ed-9b59-ea9315d81407"
 			}
+		},
+		{
+			"_id": "318d16a5-37ca-4d58-a3ec-54a4699881e3",
+			"nodeType": "InnerTreeEvaluatorNode",
+			"details": {
+				"tree": "CHWebFiling-CompleteProfile"
+			}
+		},
+		{
+			"_id": "7f0f8fa9-357a-4139-b407-d9a0336faaa9",
+			"nodeType": "InnerTreeEvaluatorNode",
+			"details": {
+				"tree": "CHManageEmailConsent"
+			}
 		}
 	],
     "tree": {
@@ -392,11 +406,11 @@
 				"displayName": "Increment Login Count"
 			},
 			"31fa4b8d-9686-4bec-8db2-45d442533b22": {
-				"x": 3311,
-				"y": 172.5,
+				"x": 3033,
+				"y": 34.5,
 				"connections": {
 					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
-					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+					"true": "318d16a5-37ca-4d58-a3ec-54a4699881e3"
 				},
 				"nodeType": "InnerTreeEvaluatorNode",
 				"displayName": "Inner Tree Evaluator"
@@ -409,6 +423,15 @@
 				},
 				"nodeType": "OneTimePasswordGeneratorNode",
 				"displayName": "HOTP Generator"
+			},
+			"6129ae01-2f10-4e6a-ab4f-eba00524c6b0": {
+				"x": 1058,
+				"y": 554.015625,
+				"connections": {
+					"true": "0ac72f4f-039a-4843-a565-037fb0b8805d"
+				},
+				"nodeType": "ScriptedDecisionNode",
+				"displayName": "Store pwd in session"
 			},
 			"6170276a-52bc-4311-b479-b6cd4fc6c544": {
 				"x": 700,
@@ -602,14 +625,25 @@
 				"nodeType": "PageNode",
 				"displayName": "Login Form (EWF)"
 			},
-			"6129ae01-2f10-4e6a-ab4f-eba00524c6b0": {
-				"x": 1058,
-				"y": 554.015625,
+			"318d16a5-37ca-4d58-a3ec-54a4699881e3": {
+				"x": 3305,
+				"y": 54.015625,
 				"connections": {
-					"true": "0ac72f4f-039a-4843-a565-037fb0b8805d"
+					"true": "7f0f8fa9-357a-4139-b407-d9a0336faaa9",
+					"false": "e301438c-0bd0-429c-ab0c-66126501069a"
 				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Store pwd in session"
+				"nodeType": "InnerTreeEvaluatorNode",
+				"displayName": "Complete Profile"
+			},
+			"7f0f8fa9-357a-4139-b407-d9a0336faaa9": {
+				"x": 3406,
+				"y": 203.015625,
+				"connections": {
+					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+					"false": "e301438c-0bd0-429c-ab0c-66126501069a"
+				},
+				"nodeType": "InnerTreeEvaluatorNode",
+				"displayName": "Email Consent"
 			}
 		},
 		"staticNodes": {

--- a/config/auth-trees/ch-webfiling.json
+++ b/config/auth-trees/ch-webfiling.json
@@ -186,6 +186,13 @@
 				"identifier": "userName",
 				"identityAttribute": "mail"
 			}
+		},
+		{
+			"_id": "22ba2520-ea77-4eb7-b9fb-6767cb98e54e",
+			"nodeType": "InnerTreeEvaluatorNode",
+			"details": {
+				"tree": "CHManageEmailConsent"
+			}
 		}
     ],
     "tree": {
@@ -283,7 +290,7 @@
 				"y": 398.015625,
 				"connections": {
 					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
-					"true": "61877889-8233-4048-b76c-39f882081e40"
+					"true": "22ba2520-ea77-4eb7-b9fb-6767cb98e54e"
 				},
 				"nodeType": "InnerTreeEvaluatorNode",
 				"displayName": "Complete Profile"
@@ -392,6 +399,16 @@
 				},
 				"nodeType": "ScriptedDecisionNode",
 				"displayName": "Add to Session"
+			},
+			"22ba2520-ea77-4eb7-b9fb-6767cb98e54e": {
+				"x": 576,
+				"y": 529.015625,
+				"connections": {
+					"true": "61877889-8233-4048-b76c-39f882081e40",
+					"false": "e301438c-0bd0-429c-ab0c-66126501069a"
+				},
+				"nodeType": "InnerTreeEvaluatorNode",
+				"displayName": "Email Consent"
 			}
 		},
 		"staticNodes": {

--- a/config/auth-trees/ch-webfiling.json
+++ b/config/auth-trees/ch-webfiling.json
@@ -382,16 +382,6 @@
 				},
 				"nodeType": "ScriptedDecisionNode",
 				"displayName": "Add to Session"
-			},
-			"22ba2520-ea77-4eb7-b9fb-6767cb98e54e": {
-				"x": 576,
-				"y": 529.015625,
-				"connections": {
-					"true": "61877889-8233-4048-b76c-39f882081e40",
-					"false": "e301438c-0bd0-429c-ab0c-66126501069a"
-				},
-				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Email Consent"
 			}
 		},
 		"staticNodes": {

--- a/config/auth-trees/ch-webfiling.json
+++ b/config/auth-trees/ch-webfiling.json
@@ -272,8 +272,8 @@
 				"x": 810,
 				"y": 147.015625,
 				"connections": {
-					"true": "9e1930dd-6045-417c-9286-d2083f454f01",
-					"false": "e301438c-0bd0-429c-ab0c-66126501069a"
+					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
+					"true": "9e1930dd-6045-417c-9286-d2083f454f01"
 				},
 				"nodeType": "ScriptedDecisionNode",
 				"displayName": "Prompt for Company No"

--- a/config/auth-trees/ch-webfiling.json
+++ b/config/auth-trees/ch-webfiling.json
@@ -173,13 +173,6 @@
 			}
 		},
 		{
-			"_id": "67e0aedf-a501-4760-b65d-c362d1d0152e",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "CHWebFiling-CompleteProfile"
-			}
-		},
-		{
 			"_id": "cd37f8c8-249f-4d7c-be85-4c2bd262225b",
 			"nodeType": "IdentifyExistingUserNode",
 			"details": {
@@ -285,16 +278,6 @@
 				"nodeType": "ScriptedDecisionNode",
 				"displayName": "Prompt for Company No"
 			},
-			"67e0aedf-a501-4760-b65d-c362d1d0152e": {
-				"x": 575,
-				"y": 398.015625,
-				"connections": {
-					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
-					"true": "22ba2520-ea77-4eb7-b9fb-6767cb98e54e"
-				},
-				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Complete Profile"
-			},
 			"9e1930dd-6045-417c-9286-d2083f454f01": {
 				"x": 831,
 				"y": 264.015625,
@@ -395,7 +378,7 @@
 				"x": 418,
 				"y": 290.015625,
 				"connections": {
-					"true": "67e0aedf-a501-4760-b65d-c362d1d0152e"
+					"true": "61877889-8233-4048-b76c-39f882081e40"
 				},
 				"nodeType": "ScriptedDecisionNode",
 				"displayName": "Add to Session"

--- a/config/managed-objects/alpha-user.json
+++ b/config/managed-objects/alpha-user.json
@@ -1079,11 +1079,11 @@
               ],
               "properties": {
                   "marketing": {
-                      "description": "Send me special offers and services",
+                      "description": "Emails about marketing, communication campaigns, or user research activities",
                       "type": "boolean"
                   },
                   "updates": {
-                      "description": "Send me news and updates",
+                      "description": "Emails to tell you about a new message in your account",
                       "type": "boolean"
                   }
               },


### PR DESCRIPTION
- added 'Manage Email Consent' journey with 'consent collection' and 'change consent' modes
- changed Registration, EWF Login and Onboarding trees to include the 'Manage Email Consent'
- changed alpha_user definition to add preferences description

# Description

**FIDC Update Required:**
- [ x ] am-scripts
- [ x ] auth-trees
- [ x ] managed-objects
