### PR TITLE
feat: session timeout

### DIFF
--- a/config/applications/ig-oidc-client.json.tpl
+++ b/config/applications/ig-oidc-client.json.tpl
@@ -34,7 +34,7 @@
 		},
 		"accessTokenLifetime": {
 			"inherited": false,
-			"value": 0
+			"value": 2400
 		},
 		"redirectionUris": {
 			"inherited": false,

--- a/config/services/session.json
+++ b/config/services/session.json
@@ -1,0 +1,14 @@
+{
+  "dynamic": {
+    "maxSessionTime": 40,
+    "maxIdleTime": 40,
+    "maxCachingTime": 3,
+    "quotaLimit": 5
+  },
+  "_id": "session",
+  "_type": {
+    "_id": "session",
+    "name": "Session",
+    "collection": false
+  }
+}


### PR DESCRIPTION
# Description

Set session timeout and access token lifetime to 40 minutes.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] am-scripts
- [ ] auth-trees
- [ ] connectors
- [ ] cors
- [ ] idm-access-config
- [ ] idm-endpoints
- [ ] managed-objects
- [ ] password-policy
- [x] services