### PR TITLE
Added support for getting an AM Auth Tree JSON payload from the FIDC Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 .DS_Store
 .env
+.idea
 qa-tests/Reports
 
 # Sensitive config files

--- a/helpers/cli-options.js
+++ b/helpers/cli-options.js
@@ -55,6 +55,11 @@ const cliOptions = (requestedOptions) => {
       alias: 'ia',
       demandOption: true,
       describe: 'Password for the IG Agent'
+    },
+    authTreeName: {
+      alias: 'atn',
+      demandOption: false,
+      describe: 'Auth Tree Name'
     }
   }
 

--- a/helpers/fidc-get.js
+++ b/helpers/fidc-get.js
@@ -1,0 +1,32 @@
+const fetch = require('node-fetch')
+
+const fidcGet = async (requestUrl, token, sessionToken) => {
+  const headers = sessionToken
+    ? {
+        'content-type': 'application/json',
+        'x-requested-with': 'ForgeRock CREST.js',
+        cookie: token,
+        'Accept-API-Version': 'resource=1.0'
+      }
+    : {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      }
+
+  const requestOptions = {
+    method: 'get',
+    body: null,
+    headers
+  }
+
+  const response = await fetch(requestUrl, requestOptions)
+
+  if (response.status !== 200) {
+    console.log(`Error ${response.status}: ${response.statusText} - ${requestUrl}`)
+    throw new Error(`${response.status}: ${response.statusText}`)
+  }
+
+  return await response.json()
+}
+
+module.exports = fidcGet

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const {
   updateAgents,
   updateApplications,
   updateAuthTrees,
+  getAuthTree,
   updateConnectorDefinitions,
   updateConnectorMappings,
   updateConnectorSchedules,
@@ -58,6 +59,12 @@ yargs
     desc: 'Update AM Auth Trees (./config/auth-trees)',
     builder: cliOptions(['username', 'password', 'realm']),
     handler: (argv) => updateAuthTrees(argv)
+  })
+  .command({
+    command: 'get-auth-tree',
+    desc: 'Get AM Auth Tree (Journey)',
+    builder: cliOptions(['username', 'password', 'realm', 'authTreeName']),
+    handler: (argv) => getAuthTree(argv)
   })
   .command({
     command: 'connector-definitions',

--- a/package-lock.json
+++ b/package-lock.json
@@ -665,7 +665,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -5340,7 +5339,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -7158,7 +7156,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",

--- a/scripts/get-auth-tree.js
+++ b/scripts/get-auth-tree.js
@@ -1,0 +1,62 @@
+const getSessionToken = require('../helpers/get-session-token')
+const fidcGet = require('../helpers/fidc-get')
+
+const getAuthTree = async (argv) => {
+  const { realm, authTreeName } = argv
+  const { FIDC_URL } = process.env
+
+  try {
+    const sessionToken = await getSessionToken(argv)
+
+    const baseUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication/authenticationtrees`
+
+    const requestUrl = `${baseUrl}/trees/${authTreeName}?forUI=true`
+    const response = await fidcGet(requestUrl, sessionToken, true)
+
+    // console.log('GET AUTH TREE', response)
+
+    // Tidy up the tree response so that it can be persisted
+    delete response._rev
+
+    Object.keys(response.nodes).forEach(node => {
+      // console.log('AAA', response.nodes[node])
+      delete response.nodes[node]._outcomes
+    })
+
+    const ret = { nodes: [], tree: response }
+
+    if (response && response.nodes) {
+      for (const [key, value] of Object.entries(response.nodes)) {
+        const nodeResponse = await processNode(FIDC_URL, realm, sessionToken, key, value)
+        // console.log(nodeResponse)
+
+        ret.nodes.push(nodeResponse)
+      }
+    }
+
+    console.log(JSON.stringify(ret, null, 2))
+  } catch (error) {
+    console.error(error.message)
+    process.exit(1)
+  }
+}
+
+async function processNode (FIDC_URL, realm, sessionToken, nodeId, node) {
+  const nodeType = node.nodeType
+  const requestUrlNode = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication/authenticationtrees/nodes/${nodeType}/${nodeId}`
+
+  const nodeDetails = await fidcGet(requestUrlNode, sessionToken, true)
+  // console.log('XXX -> ', nodeDetails)
+
+  const nodeRet = { _id: nodeId, nodeType: nodeType, details: {} }
+
+  Object.keys(nodeDetails).forEach(key => {
+    if (!key.startsWith('_')) {
+      nodeRet.details[key] = nodeDetails[key]
+    }
+  })
+
+  return nodeRet
+}
+
+module.exports = getAuthTree

--- a/scripts/get-auth-tree.js
+++ b/scripts/get-auth-tree.js
@@ -13,13 +13,10 @@ const getAuthTree = async (argv) => {
     const requestUrl = `${baseUrl}/trees/${authTreeName}?forUI=true`
     const response = await fidcGet(requestUrl, sessionToken, true)
 
-    // console.log('GET AUTH TREE', response)
-
-    // Tidy up the tree response so that it can be persisted
+    // Tidy up the tree response so that it can be persisted correctly
     delete response._rev
 
     Object.keys(response.nodes).forEach(node => {
-      // console.log('AAA', response.nodes[node])
       delete response.nodes[node]._outcomes
     })
 
@@ -28,8 +25,6 @@ const getAuthTree = async (argv) => {
     if (response && response.nodes) {
       for (const [key, value] of Object.entries(response.nodes)) {
         const nodeResponse = await processNode(FIDC_URL, realm, sessionToken, key, value)
-        // console.log(nodeResponse)
-
         ret.nodes.push(nodeResponse)
       }
     }
@@ -46,7 +41,6 @@ async function processNode (FIDC_URL, realm, sessionToken, nodeId, node) {
   const requestUrlNode = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication/authenticationtrees/nodes/${nodeType}/${nodeId}`
 
   const nodeDetails = await fidcGet(requestUrlNode, sessionToken, true)
-  // console.log('XXX -> ', nodeDetails)
 
   const nodeRet = { _id: nodeId, nodeType: nodeType, details: {} }
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,6 +1,7 @@
 const updateAgents = require('./update-agents')
 const updateApplications = require('./update-applications')
 const updateAuthTrees = require('./update-auth-trees')
+const getAuthTree = require('./get-auth-tree')
 const updateConnectorDefinitions = require('./update-connector-definitions')
 const updateConnectorMappings = require('./update-connector-mappings')
 const updateConnectorSchedules = require('./update-connector-schedules')
@@ -21,6 +22,7 @@ module.exports = {
   updateAgents,
   updateApplications,
   updateAuthTrees,
+  getAuthTree,
   updateConnectorDefinitions,
   updateConnectorMappings,
   updateConnectorSchedules,


### PR DESCRIPTION
# Description

Added an additional CLI operation to get the JSON representation of an AM Auth Tree (Journey)

update-fidc get-auth-tree ... -atn CHWebFiling

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications
- [ ] am-scripts
- [ ] auth-trees
- [ ] connectors
- [ ] cors
- [ ] idm-access-config
- [ ] idm-endpoints
- [ ] managed-objects
- [ ] password-policy
- [ ] services
- [ ] internal-roles
