### PR TITLE
Added additional callback for oidc_client to support non-443 endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 .DS_Store
 .env
+.idea
 qa-tests/Reports
 
 # Sensitive config files

--- a/config/applications/ig-oidc-client.json.tpl
+++ b/config/applications/ig-oidc-client.json.tpl
@@ -40,7 +40,8 @@
 			"inherited": false,
 			"value": [
 				"http://localhost:8080/oidc/callback",
-				"{EWF_URL}:443/oidc/callback"
+				"{EWF_URL}:443/oidc/callback",
+				"{EWF_URL}/oidc/callback"
 			]
 		},
 		"clientName": {


### PR DESCRIPTION
# Description

Added additional callback endpoint (same as existing one) but without the 443 port.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications
- [ ] am-scripts
- [ ] auth-trees
- [ ] connectors
- [ ] cors
- [ ] idm-access-config
- [ ] idm-endpoints
- [ ] managed-objects
- [ ] password-policy
- [ ] services
- [ ] internal-roles
