### PR TITLE
Ensure that AM script has a non-blank name on update

### DIFF
--- a/scripts/update-scripts.js
+++ b/scripts/update-scripts.js
@@ -30,11 +30,16 @@ const updateScripts = async (argv) => {
               return
             }
 
+            if (!script.payload.name || script.payload.name.trim() === '') {
+              throw new Error(`ERROR script Id :  ${script.payload._id} must have a valid (non-blank) name!`)
+            }
+
             // updates the script content with encoded file
             script.payload.script = fs.readFileSync(
               `${dir}/scripts-content/${script.filename}`,
               { encoding: 'base64' }
             )
+
             console.log(`updating script : ${script.payload.name} (${script.filename})`)
             const requestUrl = `${baseUrl}/scripts/${script.payload._id}`
             return await fidcRequest(


### PR DESCRIPTION
# Description

Throw an exception if the AM Script has a blank, or undefined, name prior to PUT call to FIDC

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications
- [ X] am-scripts
- [ ] auth-trees
- [ ] connectors
- [ ] cors
- [ ] idm-access-config
- [ ] idm-endpoints
- [ ] managed-objects
- [ ] password-policy
- [ ] services
- [ ] internal-roles
