### PR TITLE
Increase unit test coverage

### DIFF
--- a/scripts/update-managed-objects.js
+++ b/scripts/update-managed-objects.js
@@ -24,6 +24,9 @@ const updateManagedObjects = async (argv) => {
 
         const fileEventScript = path.resolve(__dirname, '../config/managed-objects/event-scripts/' + eventScriptName)
         if (fs.existsSync(fileEventScript)) {
+          if (!managedObject[eventName]) {
+            managedObject[eventName] = {}
+          }
           managedObject[eventName].source = fs.readFileSync(fileEventScript, { encoding: 'utf8' })
         }
       }

--- a/scripts/update-scripts.js
+++ b/scripts/update-scripts.js
@@ -31,7 +31,7 @@ const updateScripts = async (argv) => {
             }
 
             if (!script.payload.name || script.payload.name.trim() === '') {
-              throw new Error(`ERROR script Id :  ${script.payload._id} must have a valid (non-blank) name!`)
+              throw new Error(`ERROR script Id : ${script.payload._id} must have a valid (non-blank) name!`)
             }
 
             // updates the script content with encoded file

--- a/tests/helpers/file-filter.test.js
+++ b/tests/helpers/file-filter.test.js
@@ -1,0 +1,35 @@
+describe('file-filter', () => {
+  const fileFilter = require('../../helpers/file-filter')
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('matches single file completely', async () => {
+    expect.assertions(1)
+
+    const useIt = fileFilter('my-file', 'my-file')
+    expect(useIt).toEqual(true)
+  })
+
+  it('matches multiple files', async () => {
+    expect.assertions(1)
+
+    const useIt = fileFilter('my-extra-file', 'my-file, my-different-file, ~extra')
+    expect(useIt).toEqual(true)
+  })
+
+  it('matches file using fuzz', async () => {
+    expect.assertions(1)
+
+    const useIt = fileFilter('this-is-my-file', '~my-file')
+    expect(useIt).toEqual(true)
+  })
+
+  it('does not match file using fuzz', async () => {
+    expect.assertions(1)
+
+    const useIt = fileFilter('this-is-my-file', '~my-other-file')
+    expect(useIt).toEqual(false)
+  })
+})

--- a/tests/scripts/update-managed-objects.test.js
+++ b/tests/scripts/update-managed-objects.test.js
@@ -41,7 +41,9 @@ describe('update-managed-objects', () => {
       title: 'User',
       type: 'object'
     },
-    type: 'Managed Object'
+    type: 'Managed Object',
+    onUpdate: {
+    }
   }
 
   const expectedUrl = `${mockValues.fidcUrl}/openidm/config/managed`
@@ -85,6 +87,24 @@ describe('update-managed-objects', () => {
     const expectedBody = {
       objects: [mockConfig]
     }
+    await updateManagedObject(mockValues)
+    expect(fidcRequest.mock.calls.length).toEqual(1)
+    expect(fidcRequest).toHaveBeenCalledWith(
+      expectedUrl,
+      expectedBody,
+      mockValues.accessToken
+    )
+  })
+
+  it('should call API using config file merging scripts', async () => {
+    expect.assertions(2)
+    const expectedBody = {
+      objects: [mockConfig]
+    }
+
+    fs.existsSync.mockReturnValue(true)
+    fs.readFileSync.mockReturnValue('my script')
+
     await updateManagedObject(mockValues)
     expect(fidcRequest.mock.calls.length).toEqual(1)
     expect(fidcRequest).toHaveBeenCalledWith(


### PR DESCRIPTION
# Description

Updated tests to increase unit test coverage.

Still have a couple of issues I need to resolve that work OK when run in Debug Mode in Webstorm, but not on the command line when running 'npm test' but this is only related to when an exception is thrown so is low priority.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications
- [ X] am-scripts
- [ ] auth-trees
- [ ] connectors
- [ ] cors
- [ ] idm-access-config
- [ ] idm-endpoints
- [ X] managed-objects
- [ ] password-policy
- [ ] services
- [ ] internal-roles
