### PR TITLE
Fix for merge variable for Agent password

### DIFF
--- a/config/agents/ig-agent.json.tpl
+++ b/config/agents/ig-agent.json.tpl
@@ -1,7 +1,7 @@
 {
   "_id": "ig_agent",
   "igTokenIntrospection": "Realm_Subs",
-  "userpassword": "{PASSWORD}",
+  "userpassword": "{IG_AGENT_PASSWORD}",
   "status": "Active",
   "igCdssoRedirectUrls": []
 }


### PR DESCRIPTION
# Description

The Agent password in the template file was specified incorrectly, meaning that password from the CLI was ignored and it was always being set as the literal string "{PASSWORD}" in FIDC.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [x] agents (AM)
- [ ] applications (AM)
- [ ] scripts (AM)
- [ ] auth-trees (AM)
- [ ] connectors/mappings (IDM)
- [ ] cors (AM/IDM)
- [ ] idm-access-config (IDM)
- [ ] idm-endpoints (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
