### PR TITLE
Email / Phone Number obfuscation

### DIFF
--- a/config/am-scripts/scripts-library/ch-library-functions.js
+++ b/config/am-scripts/scripts-library/ch-library-functions.js
@@ -34,3 +34,44 @@ function _getSelectedLanguage (requestHeaders) {
     _log("No selected language found - defaulting to EN");
     return "EN";
 }
+
+function _obfuscateEmail (email) {
+    if (!email || email.replace(/\s/g, "").length === 0 || email.replace(/\s/g, "").indexOf("@") <= 0) {
+        return email;
+    }
+
+    email = email.replace(/\s/g, "");
+
+    var at = email.indexOf("@");
+    var username = email.substring(0, at).trim();
+    var domain = email.substring(at + 1).trim();
+
+    return username.substring(0, 1).concat("*****@").concat(domain);
+}
+
+function _obfuscatePhone (phone) {
+    var NUM_CHARS_TO_SHOW = 4;
+
+    if (!phone || phone.replace(/\s/g, "").length < NUM_CHARS_TO_SHOW) {
+        return phone;
+    }
+
+    phone = phone.replace(/\s/g, "");
+
+    var buffer = "";
+    for (var i = 0; i < phone.length - NUM_CHARS_TO_SHOW; i++) {
+        buffer = buffer + "*";
+    }
+
+    buffer = buffer + phone.substring(phone.length - NUM_CHARS_TO_SHOW);
+
+    if (buffer.length > 6) {
+        buffer = buffer.substring(0, 5).concat(" ") + buffer.substring(5);
+    }
+
+    if (buffer.length > 9) {
+        buffer = buffer.substring(0, 9).concat(" ") + buffer.substring(9);
+    }
+
+    return buffer;
+}

--- a/config/am-scripts/scripts-library/ch-library-functions.js
+++ b/config/am-scripts/scripts-library/ch-library-functions.js
@@ -65,7 +65,7 @@ function _obfuscatePhone (phone) {
 
     buffer = buffer + phone.substring(phone.length - NUM_CHARS_TO_SHOW);
 
-    if (buffer.length > 6) {
+    if (buffer.length > 5) {
         buffer = buffer.substring(0, 5).concat(" ") + buffer.substring(5);
     }
 

--- a/scripts/update-scripts.js
+++ b/scripts/update-scripts.js
@@ -101,7 +101,11 @@ const updateScripts = async (argv) => {
             );
 
             if (libraryFunctionsScript) {
-                const uglified = uglifyJS.minify(libraryFunctionsScript);
+                const uglified = uglifyJS.minify(libraryFunctionsScript, {
+                    output: {
+                        max_line_len: 140
+                    }
+                });
 
                 if (uglified.error) {
                     throw new Error("Failed to minify Library Functions Script!");


### PR DESCRIPTION
# Description

Added some obfuscation functions to the library to support CH styles (as confirmed with Sophie).

Emails will always be "first char + 5 asterisks"
Phone Numbers will always be "asterisks + last 4 chars, with spaces in key places for accessibility"

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [x] scripts (AM)
- [ ] auth-trees (AM)
- [ ] connectors/mappings (IDM)
- [ ] cors (AM/IDM)
- [ ] idm-access-config (IDM)
- [ ] idm-endpoints (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
