### PR TITLE
Use request parameter to force MFA check (defaults to FALSE)

### DIFF
--- a/config/am-scripts/scripts-content/ch-callback-to-capture-otp-response.js
+++ b/config/am-scripts/scripts-content/ch-callback-to-capture-otp-response.js
@@ -28,11 +28,15 @@ var fr = JavaImporter(
 )
 
 function getMfaRouteOptions (mfaRoute) {
+
+  /*
   if (mfaRoute === 'sms') {
     return ['RESEND', 'NEXT']
   } else if (mfaRoute === 'email') {
     return ['RESEND', 'CHANGE EMAIL', 'NEXT']
   } else return []
+  */
+  return ['RESEND', 'NEXT']
 }
 
 var phoneNumber = ''

--- a/config/am-scripts/scripts-content/ch-callback-to-capture-otp-response.js
+++ b/config/am-scripts/scripts-content/ch-callback-to-capture-otp-response.js
@@ -28,7 +28,6 @@ var fr = JavaImporter(
 )
 
 function getMfaRouteOptions (mfaRoute) {
-
   /*
   if (mfaRoute === 'sms') {
     return ['RESEND', 'NEXT']

--- a/config/am-scripts/scripts-content/ch-require-mfa-check.js
+++ b/config/am-scripts/scripts-content/ch-require-mfa-check.js
@@ -1,53 +1,59 @@
+var _scriptName = 'CH REQUIRE MFA CHECK'
+
 var fr = JavaImporter(
-    org.forgerock.openam.auth.node.api.Action
+  org.forgerock.openam.auth.node.api.Action
 )
 
-var userId = sharedState.get("_id");
+var userId = sharedState.get('_id')
 
 // Use AM representation of attribute
-var LAST_LOGIN_FIELD = "fr-attr-idate1";
+var LAST_LOGIN_FIELD = 'fr-attr-idate1'
 
-var checkMFA = false;
+var forceCheckMFA = requestParameters.get('forceCheckMFA')
+var checkMFA = forceCheckMFA
 
 try {
-    if (idRepository.getAttribute(userId, LAST_LOGIN_FIELD).iterator().hasNext()) {
-        var lastLogin = String(idRepository.getAttribute(userId, LAST_LOGIN_FIELD).iterator().next());
-        
-        logger.error("[MFA-CHECK] lastLogin: " + lastLogin); // e.g. 20210317114005Z
+  if (idRepository.getAttribute(userId, LAST_LOGIN_FIELD).iterator().hasNext()) {
+    var lastLogin = String(idRepository.getAttribute(userId, LAST_LOGIN_FIELD).iterator().next())
 
-        if (lastLogin.length > 0) {
-            var year = lastLogin.substring(0, 4);
-            var month = lastLogin.substring(4, 6);
-            var offsetMonth = parseInt(month) - 1;
-            var day = lastLogin.substring(6, 8);
-            var hour = lastLogin.substring(8, 10);
-            var min = lastLogin.substring(10, 12);
-            var sec = lastLogin.substring(12, 14);
+    logger.error('[MFA-CHECK] lastLogin: ' + lastLogin) // e.g. 20210317114005Z
 
-            var lastLoginDateUTC = Date.UTC(year,offsetMonth,day,hour,min,sec);
+    if (lastLogin.length > 0) {
+      var year = lastLogin.substring(0, 4)
+      var month = lastLogin.substring(4, 6)
+      var offsetMonth = parseInt(month) - 1
+      var day = lastLogin.substring(6, 8)
+      var hour = lastLogin.substring(8, 10)
+      var min = lastLogin.substring(10, 12)
+      var sec = lastLogin.substring(12, 14)
 
-            var now = new Date();
+      var lastLoginDateUTC = Date.UTC(year, offsetMonth, day, hour, min, sec)
 
-            var intervalDays = 30;
-            var intervalInMillis = intervalDays * 86400 * 1000;
+      var now = new Date()
 
-            var delta = now.getTime() - lastLoginDateUTC; // Difference in ms
-            if (delta > intervalInMillis) {
-                logger.error("[MFA-CHECK] User requires MFA check");
-                checkMFA = true;
-            } else {
-                logger.error("[MFA-CHECK] User doesn't require MFA check");
-            }
-        }
+      var intervalDays = 30
+      var intervalInMillis = intervalDays * 86400 * 1000
+
+      var delta = now.getTime() - lastLoginDateUTC // Difference in ms
+      if (delta > intervalInMillis) {
+        logger.error('[MFA-CHECK] User requires MFA check')
+        checkMFA = true
+      } else {
+        logger.error('[MFA-CHECK] User doesn\'t require MFA check')
+      }
     }
+  }
 
-    if (checkMFA) {
-        outcome = "true";
-    } else {
-        outcome = "false"; 
-    }
-} catch(e) {
-    logger.error("[MFA-CHECK] Require MFA Check error: " + e);
-    sharedState.put("errorMessage", e.toString())
-    outcome = "false";
+  if (checkMFA) {
+    outcome = 'true'
+  } else {
+    outcome = 'false'
+  }
+} catch (e) {
+  logger.error('[MFA-CHECK] Require MFA Check error: ' + e)
+  sharedState.put('errorMessage', e.toString())
+  outcome = 'false'
 }
+
+// LIBRARY START
+// LIBRARY END


### PR DESCRIPTION
# Description

* I thought it would be useful to be able to call a journey with a "&forceCheckMFA=true" flag so that we can test the different variations of the journeys without affecting other developers.

So, for example the following URL will ALWAYS require MFA to be completed without having to change the script to set the internal boolean to TRUE:

https://openam-companieshouse-uk-dev.id.forgerock.io/am/XUI/?forceCheckMFA=true&realm=/alpha&authIndexType=service&authIndexValue=SJDLogin#/ 

* Also modified the list of resend options for Email to remove invalid choice

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [x] scripts (AM)
- [ ] auth-trees (AM)
- [ ] connectors/mappings (IDM)
- [ ] cors (AM/IDM)
- [ ] idm-access-config (IDM)
- [ ] idm-endpoints (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
