### PR TITLE
idam-837/Change SCRS emails to EN and use original response format

### DIFF
--- a/config/idm-endpoints/scripts-content/scrs.js
+++ b/config/idm-endpoints/scripts-content/scrs.js
@@ -42,16 +42,14 @@
 
   function removeDuplicateEmails (data) {
     let emails = [];
-    let uniqueSet = [];
 
-    data.forEach(element => {
-      if (!emails.includes(element.email)) {
-        emails.push(element.email);
-        uniqueSet.push(element);
+    data.forEach(email => {
+      if (email && !emails.includes(email)) {
+        emails.push(email);
       }
     });
 
-    return uniqueSet;
+    return emails;
   }
 
   function padding (num) {
@@ -507,14 +505,9 @@
 
                         _log('Emails (unique) : ' + emailsUnique);
 
-                        emailsUnique.forEach(emailEntry => {
-
-                          if (!emailEntry.email) {
-                            return;
-                          }
-
-                          let email = emailEntry.email;
-                          let emailLang = emailEntry.language || 'en';
+                        emailsUnique.forEach(email => {
+                          // Force to EN based on a CH Decision that all SCRS user emails are in English
+                          let emailLang = 'en';
 
                           try {
                             _log('Processing user with email : ' + email + ', language = ' + emailLang);


### PR DESCRIPTION
# Description

* Back to original Harmonia format for emails list service
* Force all emails to use "en" language as per CH decision

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [ ] scripts (AM)
- [ ] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [x] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
