### PR TITLE
idam-1035/add unknown email to logging and payload response

### DIFF
--- a/config/am-scripts/scripts-content/ch-login-error-message.js
+++ b/config/am-scripts/scripts-content/ch-login-error-message.js
@@ -1,12 +1,16 @@
 var _scriptName = 'CH LOGIN ERROR MESSAGE';
 _log('Starting');
 
-_log('Cannot find a user with this email.');
-sharedState.put('errorMessage', 'Cannot find a user with this email.');
+var username = sharedState.get('username') || '<Unknown>';
+
+_log('Cannot find a user with this email : ' + username);
+
+sharedState.put('errorMessage', 'Cannot find a user with this email : ' + username);
+
 sharedState.put('pagePropsJSON', JSON.stringify(
   {
     'errors': [{
-      label: 'Cannot find a user with this email.',
+      label: 'Cannot find a user with this email : ' + username,
       token: 'USER_EMAIL_NOT_FOUND',
       fieldName: 'IDToken2',
       anchor: 'IDToken2'
@@ -14,7 +18,7 @@ sharedState.put('pagePropsJSON', JSON.stringify(
   }));
 
 outcome = 'true';
- 
+
 _log('Outcome = ' + _getOutcomeForDisplay());
 
 // LIBRARY START


### PR DESCRIPTION
# Description

* Add unknown email to logging and payload response so that it's easier to see the user who tried to login but was not found in logs

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [x] scripts (AM)
- [ ] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
