### PR TITLE
idam-1039/remove unused parameters

### DIFF
--- a/bash-scripts/add_concourse_user.sh
+++ b/bash-scripts/add_concourse_user.sh
@@ -5,7 +5,7 @@
 #####################################################
 
 usage() {
-  echo "Usage: $0  [ -t templateFile ] [ -c concourseUserPassword ] [ -u username ] [ -p password] [ -a adminClientId ] [ -s adminClientSecret ] [ -f fidcServerUrl ] [ -r fidcRealm (optional) ]"
+  echo "Usage: $0  [ -t templateFile ] [ -c concourseUserPassword ] [ -u username ] [ -p password] [ -f fidcServerUrl ] [ -r fidcRealm (optional) ]"
   exit 1
 }
 
@@ -13,12 +13,10 @@ unset templateFile
 unset concourseUserPassword
 unset username
 unset password
-unset adminClientId
-unset adminClientSecret
 unset fidcServer
 unset fidcRealm
 
-while getopts ht:c:u:p:a:s:f:r: flag
+while getopts ht:c:u:p:f:r: flag
 do
     case "${flag}" in
         h) usage;;
@@ -26,8 +24,6 @@ do
         c) concourseUserPassword=${OPTARG};;
         u) username=${OPTARG};;
         p) password=${OPTARG};;
-        a) adminClientId=${OPTARG};;
-        s) adminClientSecret=${OPTARG};;
         f) fidcServer=${OPTARG};;
         r) fidcRealm=${OPTARG};;
         *) usage;;
@@ -39,7 +35,7 @@ done
 #echo "FIDC Server: $fidcServer";
 #echo "FIDC Realm: $fidcRealm";
 
-if [[  ( -z "${templateFile}" ) || ( -z "${concourseUserPassword}" ) || ( -z "${username}" ) || ( -z "${password}" ) || ( -z "${adminClientId}" ) || ( -z "${adminClientSecret}" ) || ( -z "${fidcServer}" ) ]]; then
+if [[  ( -z "${templateFile}" ) || ( -z "${concourseUserPassword}" ) || ( -z "${username}" ) || ( -z "${password}" ) || ( -z "${fidcServer}" ) ]]; then
     echo "Invalid or missing arguments, quitting."
     usage
 fi
@@ -48,7 +44,7 @@ if [[ ( -z "${fidcRealm}" ) ]]; then
     fidcRealm="alpha"
 fi
 
-ACCESS_TOKEN=$(sh get_idm_access_token.sh -u ${username} -p ${password} -a ${adminClientId} -s ${adminClientSecret} -f ${fidcServer})
+ACCESS_TOKEN=$(sh get_idm_access_token.sh -u ${username} -p ${password} -f ${fidcServer})
 
 TEMPLATE_FILE_COMMAND="cat ${templateFile} | sed 's/{CONCOURSE_USER_PASSWORD\}/${concourseUserPassword}/g'"
 TEMPLATE_MERGED=$(eval ${TEMPLATE_FILE_COMMAND})

--- a/bash-scripts/get_idm_access_token.sh
+++ b/bash-scripts/get_idm_access_token.sh
@@ -5,45 +5,32 @@
 #############################################
 
 usage() {
-  echo "Usage: $0 [ -u username ] [ -p password] [ -a adminClientId ] [ -s adminClientSecret ] [ -f fidcServerUrl ] [ -r fidcRealm (optional) ]"
+  echo "Usage: $0 [ -u username ] [ -p password] [ -f fidcServerUrl ]"
   exit 1
 }
 
 unset username
 unset password
-unset adminClientId
-unset adminClientSecret
 unset fidcServer
-unset fidcRealm
 
-while getopts hu:p:a:s:f:r: flag
+while getopts hu:p:f: flag
 do
     case "${flag}" in
         h) usage;;
         u) username=${OPTARG};;
         p) password=${OPTARG};;
-        a) adminClientId=${OPTARG};;
-        s) adminClientSecret=${OPTARG};;
         f) fidcServer=${OPTARG};;
-        r) fidcRealm=${OPTARG};;
         *) usage;;
     esac
 done
 
 #echo "Username: $username";
 #echo "Password: $password";
-#echo "Admin Client Id: $adminClientId";
-#echo "Admin Client Secret: $adminClientSecret";
 #echo "FIDC Server: $fidcServer";
-#echo "FIDC Realm: $fidcRealm";
 
-if [[ ( -z "${username}" ) || ( -z "${password}" ) || ( -z "${adminClientId}" ) || ( -z "${adminClientSecret}" ) || ( -z "${fidcServer}" ) ]]; then
+if [[ ( -z "${username}" ) || ( -z "${password}" ) || ( -z "${fidcServer}" ) ]]; then
     echo "Invalid or missing arguments, quitting."
     usage
-fi
-
-if [[ ( -z "${fidcRealm}" ) ]]; then
-    fidcRealm="alpha"
 fi
 
 #################################


### PR DESCRIPTION
# Description

* Remove OAuth2 client requirements as params
* Remove Realm requirements as params
* Modify Add Concourse User script to pass less params to get IDM token

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [x] scripts (AM)
- [ ] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
