### PR TITLE
idam-1042/increase jwt timeout to 30 minutes

### DIFF
--- a/config/auth-trees/settings/tree-auth.json
+++ b/config/auth-trees/settings/tree-auth.json
@@ -1,0 +1,6 @@
+{
+  "authenticationSessionsStateManagement": "JWT",
+  "suspendedAuthenticationTimeout": 1440,
+  "authenticationSessionsWhitelist": false,
+  "authenticationSessionsMaxDuration": 30
+}

--- a/scripts/update-auth-trees.js
+++ b/scripts/update-auth-trees.js
@@ -1,55 +1,66 @@
-const fs = require('fs')
-const path = require('path')
-const getSessionToken = require('../helpers/get-session-token')
-const fidcRequest = require('../helpers/fidc-request')
-const fileFilter = require('../helpers/file-filter')
+const fs = require('fs');
+const path = require('path');
+const getSessionToken = require('../helpers/get-session-token');
+const fidcRequest = require('../helpers/fidc-request');
+const fileFilter = require('../helpers/file-filter');
 
 const updateAuthTrees = async (argv) => {
-  const { realm } = argv
-  const { FIDC_URL, filenameFilter } = process.env
+  const { realm } = argv;
+  const { FIDC_URL, filenameFilter } = process.env;
 
   try {
-    const sessionToken = await getSessionToken(argv)
+    const sessionToken = await getSessionToken(argv);
+
+    // Setup the Auth Tree config for token timeout
+    const treeAuth = path.resolve(__dirname, '../config/auth-trees/settings/tree-auth.json');
+    if (fs.existsSync(treeAuth)) {
+      const treeAuthJson = fs.readFileSync(treeAuth, { encoding: 'utf8' });
+      if (treeAuthJson) {
+        const requestUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication`;
+        await fidcRequest(requestUrl, JSON.parse(treeAuthJson), sessionToken, true);
+        console.log('Tree Auth settings updated');
+      }
+    }
 
     // Read auth tree JSON files
-    const dir = path.resolve(__dirname, '../config/auth-trees')
-    const useFF = filenameFilter || argv.filenameFilter
+    const dir = path.resolve(__dirname, '../config/auth-trees');
+    const useFF = filenameFilter || argv.filenameFilter;
 
     const authTreesFileContent = fs
       .readdirSync(dir)
       .filter((name) => path.extname(name) === '.json') // Filter out any non JSON files
       .filter((name) => fileFilter(name, useFF)) // Filter based on name, if required
-      .map((filename) => require(path.join(dir, filename))) // Map JSON file content to an array
+      .map((filename) => require(path.join(dir, filename))); // Map JSON file content to an array
 
     // Update each auth tree
     await authTreesFileContent.reduce(async (previousPromise, authTreeFile) => {
-      await previousPromise
-      const baseUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication/authenticationtrees`
+      await previousPromise;
+      const baseUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication/authenticationtrees`;
       await Promise.all(
         authTreeFile.nodes.map(async (node) => {
-          const nodeRequestUrl = `${baseUrl}/nodes/${node.nodeType}/${node._id}`
+          const nodeRequestUrl = `${baseUrl}/nodes/${node.nodeType}/${node._id}`;
           const nodeRequestBody = {
             _id: node._id,
             ...node.details
-          }
+          };
           return await fidcRequest(
             nodeRequestUrl,
             nodeRequestBody,
             sessionToken,
             true
-          )
+          );
         })
-      )
-      console.log(`Nodes updated - ${authTreeFile.tree._id}`)
-      const requestUrl = `${baseUrl}/trees/${authTreeFile.tree._id}`
-      await fidcRequest(requestUrl, authTreeFile.tree, sessionToken, true)
-      console.log(`Tree updated - ${authTreeFile.tree._id}`)
-      return Promise.resolve()
-    }, Promise.resolve())
+      );
+      console.log(`Nodes updated - ${authTreeFile.tree._id}`);
+      const requestUrl = `${baseUrl}/trees/${authTreeFile.tree._id}`;
+      await fidcRequest(requestUrl, authTreeFile.tree, sessionToken, true);
+      console.log(`Tree updated - ${authTreeFile.tree._id}`);
+      return Promise.resolve();
+    }, Promise.resolve());
   } catch (error) {
-    console.error(error.message)
-    process.exit(1)
+    console.error(error.message);
+    process.exit(1);
   }
-}
+};
 
-module.exports = updateAuthTrees
+module.exports = updateAuthTrees;

--- a/scripts/update-auth-trees.js
+++ b/scripts/update-auth-trees.js
@@ -1,66 +1,66 @@
-const fs = require('fs');
-const path = require('path');
-const getSessionToken = require('../helpers/get-session-token');
-const fidcRequest = require('../helpers/fidc-request');
-const fileFilter = require('../helpers/file-filter');
+const fs = require('fs')
+const path = require('path')
+const getSessionToken = require('../helpers/get-session-token')
+const fidcRequest = require('../helpers/fidc-request')
+const fileFilter = require('../helpers/file-filter')
 
 const updateAuthTrees = async (argv) => {
-  const { realm } = argv;
-  const { FIDC_URL, filenameFilter } = process.env;
+  const { realm } = argv
+  const { FIDC_URL, filenameFilter } = process.env
 
   try {
-    const sessionToken = await getSessionToken(argv);
+    const sessionToken = await getSessionToken(argv)
 
     // Setup the Auth Tree config for token timeout
-    const treeAuth = path.resolve(__dirname, '../config/auth-trees/settings/tree-auth.json');
+    const treeAuth = path.resolve(__dirname, '../config/auth-trees/settings/tree-auth.json')
     if (fs.existsSync(treeAuth)) {
-      const treeAuthJson = fs.readFileSync(treeAuth, { encoding: 'utf8' });
+      const treeAuthJson = fs.readFileSync(treeAuth, { encoding: 'utf8' })
       if (treeAuthJson) {
-        const requestUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication`;
-        await fidcRequest(requestUrl, JSON.parse(treeAuthJson), sessionToken, true);
-        console.log('Tree Auth settings updated');
+        const requestUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication`
+        await fidcRequest(requestUrl, JSON.parse(treeAuthJson), sessionToken, true)
+        console.log('Tree Auth settings updated')
       }
     }
 
     // Read auth tree JSON files
-    const dir = path.resolve(__dirname, '../config/auth-trees');
-    const useFF = filenameFilter || argv.filenameFilter;
+    const dir = path.resolve(__dirname, '../config/auth-trees')
+    const useFF = filenameFilter || argv.filenameFilter
 
     const authTreesFileContent = fs
       .readdirSync(dir)
       .filter((name) => path.extname(name) === '.json') // Filter out any non JSON files
       .filter((name) => fileFilter(name, useFF)) // Filter based on name, if required
-      .map((filename) => require(path.join(dir, filename))); // Map JSON file content to an array
+      .map((filename) => require(path.join(dir, filename))) // Map JSON file content to an array
 
     // Update each auth tree
     await authTreesFileContent.reduce(async (previousPromise, authTreeFile) => {
-      await previousPromise;
-      const baseUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication/authenticationtrees`;
+      await previousPromise
+      const baseUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/authentication/authenticationtrees`
       await Promise.all(
         authTreeFile.nodes.map(async (node) => {
-          const nodeRequestUrl = `${baseUrl}/nodes/${node.nodeType}/${node._id}`;
+          const nodeRequestUrl = `${baseUrl}/nodes/${node.nodeType}/${node._id}`
           const nodeRequestBody = {
             _id: node._id,
             ...node.details
-          };
+          }
           return await fidcRequest(
             nodeRequestUrl,
             nodeRequestBody,
             sessionToken,
             true
-          );
+          )
         })
-      );
-      console.log(`Nodes updated - ${authTreeFile.tree._id}`);
-      const requestUrl = `${baseUrl}/trees/${authTreeFile.tree._id}`;
-      await fidcRequest(requestUrl, authTreeFile.tree, sessionToken, true);
-      console.log(`Tree updated - ${authTreeFile.tree._id}`);
-      return Promise.resolve();
-    }, Promise.resolve());
+      )
+      console.log(`Nodes updated - ${authTreeFile.tree._id}`)
+      const requestUrl = `${baseUrl}/trees/${authTreeFile.tree._id}`
+      await fidcRequest(requestUrl, authTreeFile.tree, sessionToken, true)
+      console.log(`Tree updated - ${authTreeFile.tree._id}`)
+      return Promise.resolve()
+    }, Promise.resolve())
   } catch (error) {
-    console.error(error.message);
-    process.exit(1);
+    console.error(error.message)
+    process.exit(1)
   }
-};
+}
 
-module.exports = updateAuthTrees;
+module.exports = updateAuthTrees


### PR DESCRIPTION
# Description

* Support the modification of the JWT for Auth Journeys via config (set to 30 mins instead of default 5 mins)

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [ ] scripts (AM)
- [x] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
