### PR TITLE
adding cleanup mappings for Staging

### DIFF
--- a/config/connectors/mappings/alphaUser_webfilingUser.json
+++ b/config/connectors/mappings/alphaUser_webfilingUser.json
@@ -34,7 +34,7 @@
       "situation": "AMBIGUOUS"
     },
     {
-      "action": "DELETE",
+      "action": "EXCEPTION",
       "situation": "SOURCE_MISSING"
     },
     {

--- a/config/connectors/mappings/cleanup_FIDC_companies.json
+++ b/config/connectors/mappings/cleanup_FIDC_companies.json
@@ -1,0 +1,184 @@
+{
+	"target": "managed/alpha_organization",
+	"enabled": true,
+	"source": "system/CHSCompany/company_profile",
+	"name": "companies-cleanup-mapping",
+	"consentRequired": false,
+	"icon": null,
+	"displayName": "companies-cleanup-mapping",
+	"properties": [
+		{
+			"target": "name",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "source.company_name"
+			}
+		},
+		{
+			"target": "number",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "source.company_number"
+			}
+		},
+		{
+			"target": "type",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "source.type"
+			}
+		},
+		{
+			"target": "status",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "source.company_status"
+			}
+		},
+		{
+			"target": "locality",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "if (source.registered_office_address) {\n  source.registered_office_address.locality\n}"
+			}
+		},
+		{
+			"target": "postalCode",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "if (source.registered_office_address) {\n  source.registered_office_address.postal_code\n}"
+			}
+		},
+		{
+			"target": "addressLine1",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "if (source.registered_office_address) {\n  source.registered_office_address.address_line_1\n}"
+			}
+		},
+		{
+			"target": "addressLine2",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "if (source.registered_office_address) {\n  source.registered_office_address.address_line_2\n}"
+			}
+		},
+		{
+			"target": "region",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "if (source.registered_office_address) {\n  source.registered_office_address.region\n}"
+			}
+		},
+		{
+			"target": "creationDate",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "source.date_of_creation"
+			}
+		},
+		{
+			"target": "jurisdiction",
+			"source": "data",
+			"transform": {
+				"type": "text/javascript",
+				"globals": {},
+				"source": "if (source.jurisdiction == \"england-wales\") {\n  \"EW\"\n} else if (source.jurisdiction == \"scotland\") {\n  \"SC\"\n} else if (source.jurisdiction == \"northern-ireland\") {\n  \"NI\"\n} else {\n  source.jurisdiction\n}"
+			}
+		}
+	],
+	"policies": [
+		{
+			"action": "EXCEPTION",
+			"situation": "AMBIGUOUS"
+		},
+		{
+			"action": "DELETE",
+			"situation": "SOURCE_MISSING"
+		},
+		{
+			"action": "EXCEPTION",
+			"situation": "MISSING"
+		},
+		{
+			"action": "EXCEPTION",
+			"situation": "FOUND_ALREADY_LINKED"
+		},
+		{
+			"action": "DELETE",
+			"situation": "UNQUALIFIED"
+		},
+		{
+			"action": "DELETE",
+			"situation": "UNASSIGNED"
+		},
+		{
+			"action": "EXCEPTION",
+			"situation": "LINK_ONLY"
+		},
+		{
+			"action": "IGNORE",
+			"situation": "TARGET_IGNORED"
+		},
+		{
+			"action": "IGNORE",
+			"situation": "SOURCE_IGNORED"
+		},
+		{
+			"action": "IGNORE",
+			"situation": "ALL_GONE"
+		},
+		{
+			"action": "DELETE",
+			"situation": "CONFIRMED"
+		},
+		{
+			"action": "UPDATE",
+			"situation": "FOUND"
+		},
+		{
+			"action": "CREATE",
+			"situation": "ABSENT"
+		}
+	],
+	"correlationQuery": [
+		{
+			"linkQualifier": "default",
+			"expressionTree": {
+				"any": [
+					"number"
+				]
+			},
+			"mapping": "companies-cleanup-mapping",
+			"type": "text/javascript",
+			"file": "ui/correlateTreeToQueryFilter.js"
+		}
+	],
+	"clusteredSourceReconEnabled": true,
+	"reconSourceQueryPageSize": 10000,
+	"sourceQueryFullEntry": true,
+	"sourceQuery": {
+		"_queryFilter": "true"
+	},
+	"taskThreads": 20
+}

--- a/config/connectors/mappings/cleanup_FIDC_users.json
+++ b/config/connectors/mappings/cleanup_FIDC_users.json
@@ -1,0 +1,111 @@
+{
+  "target": "managed/alpha_user",
+  "enabled": true,
+  "source": "system/WebfilingUser/webfilingUser",
+  "name": "user-cleanup-mapping",
+  "displayName": "user-cleanup-mapping",
+  "properties": [
+    {
+      "target": "mail",
+      "source": "EMAIL"
+    },
+    {
+      "target": "sn",
+      "source": "EMAIL"
+    },
+    {
+      "target": "userName",
+      "source": "EMAIL"
+    },
+    {
+      "target": "frIndexedString2",
+      "source": "PASSWORD"
+    },
+    {
+      "target": "frIndexedString1",
+      "source": "PARENT_USERNAME"
+    }
+  ],
+  "policies": [
+    {
+      "action": "EXCEPTION",
+      "situation": "AMBIGUOUS"
+    },
+    {
+      "action": "EXCEPTION",
+      "situation": "SOURCE_MISSING"
+    },
+    {
+      "action": "CREATE",
+      "situation": "MISSING"
+    },
+    {
+      "action": "EXCEPTION",
+      "situation": "FOUND_ALREADY_LINKED"
+    },
+    {
+      "action": "DELETE",
+      "situation": "UNQUALIFIED"
+    },
+    {
+      "action": "DELETE",
+      "situation": "UNASSIGNED"
+    },
+    {
+      "action": "EXCEPTION",
+      "situation": "LINK_ONLY"
+    },
+    {
+      "action": "IGNORE",
+      "situation": "TARGET_IGNORED"
+    },
+    {
+      "action": "IGNORE",
+      "situation": "SOURCE_IGNORED"
+    },
+    {
+      "action": "IGNORE",
+      "situation": "ALL_GONE"
+    },
+    {
+      "action": "DELETE",
+      "situation": "CONFIRMED"
+    },
+    {
+      "action": "UPDATE",
+      "situation": "FOUND"
+    },
+    {
+      "action": "CREATE",
+      "situation": "ABSENT"
+    }
+  ],
+  "validTarget" : {
+    "type" : "text/javascript",
+    "globals" : { },
+    "source" : "target.userName !== 'tree-service-user@companieshouse.com' && 'tree-service-user@companieshouse.co.uk' && target.userName !== 'ConcourseUser@companieshouse.gov.uk' && target.userName !== 'AdminClientTest@example.com' && target.userName !== 'pxtdbugadc1@gmail.com' && target.userName !== 'pxtdbugadc2@gmail.com' && target.userName !== 'pxtdbugadc3@gmail.com' && target.userName !== 'pxtdbugadc4@gmail.com' && target.userName !== 'testautomationfr36@test.companieshouse.gov.uk' && target.userName !== 'testautomationfr37@test.companieshouse.gov.uk' && target.userName !== 'fcalvino@companieshouse.gov.uk' && target.userName !== 'francesco.calvino@amido.com'"
+  },
+  "clusteredSourceReconEnabled": true,
+  "reconSourceQueryPageSize": 10000,
+  "sourceQueryFullEntry": true,
+  "sourceQuery": {
+    "_queryFilter": "true",
+    "_sortKeys": "PARENT_USERNAME"
+  },
+  "taskThreads": 20,
+  "correlationQuery": [],
+  "onCreate": {
+    "type": "text/javascript",
+    "globals": {},
+    "source": "// change via external file"
+  },
+  "onUpdate": {
+    "type": "text/javascript",
+    "globals": {},
+    "source": "// change via external file"
+  },
+  "onError": {
+    "type": "text/javascript",
+    "source": "// change via external file"
+  }
+}


### PR DESCRIPTION
- temporarily setting the SOURCE_MISSING behaviour to EXCEPTION action instead of DELETE (as it has side effects when combined with cleanup mappings recons)
- adding users cleanup mappings for Staging
- adding companies cleanup mappings for Staging

# Description

**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [ ] scripts (AM)
- [ ] auth trees (AM)
- [x] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
