### PR TITLE
idam-1060/reset accountStatus to active after reset password completes

### DIFF
--- a/config/am-scripts/scripts-content/ch-reset-password-clear-parameters.js
+++ b/config/am-scripts/scripts-content/ch-reset-password-clear-parameters.js
@@ -4,7 +4,8 @@ _log('Starting');
 var resetParams = {
   'frIndexedString3': null,
   'frIndexedString4': null,
-  'frUnindexedInteger1': null
+  'frUnindexedInteger1': null,
+  'accountStatus': 'active'
 };
 
 sharedState.put('objectAttributes', resetParams);


### PR DESCRIPTION
# Description

* Change status of user back to "active" to cover off cases where the user was created by SCRS, didn't get the link to activate (went to Spam etc) and then goes through the Password Reset route. Currently, if the user is still "inactive" then they get all the way through the journey successfully and right at the end get told they are signed out, which isn't very good.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [x] scripts (AM)
- [ ] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
