### PR TITLE
Idam 1074/use getSelectedLanguage function from library and turn off save of retry state to user 

### DIFF
--- a/config/am-scripts/scripts-content/ch-invite-user-send-email.js
+++ b/config/am-scripts/scripts-content/ch-invite-user-send-email.js
@@ -296,17 +296,6 @@ function sendEmail (language, invitedEmail, companyName, inviterName, returnUrl)
   };
 }
 
-//extracts the language form headers (default to EN)
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 var FIDC_ENDPOINT = _fromConfig('FIDC_ENDPOINT');
 
 // main execution flow
@@ -323,7 +312,7 @@ try {
   var request = new org.forgerock.http.protocol.Request();
   var isOnboarding = sharedState.get('isOnboarding');
   var inviteData = extractInviteDataFromState();
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
 
   if (!inviteData) {
     sendErrorCallbacks('INVITE_USER_ERROR', 'INVITE_USER_ERROR', 'An error has occurred! Please try again later.');

--- a/config/am-scripts/scripts-content/ch-join-company-create-relationship.js
+++ b/config/am-scripts/scripts-content/ch-join-company-create-relationship.js
@@ -166,17 +166,6 @@ function fetchIDMToken () {
   return accessToken;
 }
 
-//extracts the language form headers (default to EN)
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 // main execution flow
 try {
   var idmCompanyAuthEndpoint = _fromConfig('FIDC_ENDPOINT') + '/openidm/endpoint/companyauth/';
@@ -185,7 +174,7 @@ try {
   var userId = sharedState.get('_id');
   _log('Incoming company data :' + companyData);
   _log('Incoming company id :' + JSON.parse(companyData)._id);
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
 
   var accessToken = fetchIDMToken();
   if (!accessToken) {

--- a/config/am-scripts/scripts-content/ch-password-reset-send-email.js
+++ b/config/am-scripts/scripts-content/ch-password-reset-send-email.js
@@ -271,17 +271,6 @@ function sendEmail (language) {
   return (response.getStatus().getCode() === 201);
 }
 
-//extracts the language form headers (default to EN)
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 // main execution flow
 var FIDC_ENDPOINT = _fromConfig('FIDC_ENDPOINT');
 var config = {
@@ -296,7 +285,7 @@ try {
   var request = new org.forgerock.http.protocol.Request();
   var host = requestHeaders.get('origin').get(0);
   var now = new Date();
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
   var resetPasswordjJwt;
   var returnUrl;
 

--- a/config/am-scripts/scripts-content/ch-registration-send-email.js
+++ b/config/am-scripts/scripts-content/ch-registration-send-email.js
@@ -227,17 +227,6 @@ function sendEmail (language, jwt) {
   return (response.getStatus().getCode() === 201);
 }
 
-//extracts the language form headers (default to EN)
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 // main execution flow
 var FIDC_ENDPOINT = _fromConfig('FIDC_ENDPOINT');
 var config = {
@@ -253,7 +242,7 @@ try {
   var registrationJwt;
   var host = requestHeaders.get('origin').get(0);
   var request = new org.forgerock.http.protocol.Request();
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
   var now = new Date();
 
   var regData = extractRegDataFromState();

--- a/config/am-scripts/scripts-content/ch-remove-user-send-email.js
+++ b/config/am-scripts/scripts-content/ch-remove-user-send-email.js
@@ -127,22 +127,11 @@ function sendEmail (language, removerName, userToRemove, companyName) {
   };
 }
 
-//extracts the language form headers (default to EN)
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 // main execution flow
 try {
   var request = new org.forgerock.http.protocol.Request();
   var removalData = extractRemovalDataFromState();
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
 
   if (!removalData) {
     sendErrorCallbacks('REMOVE_AUTHZ_USER_ERROR', 'Error while extracting data from shared state');

--- a/config/am-scripts/scripts-content/ch-send-mfa-email.js
+++ b/config/am-scripts/scripts-content/ch-send-mfa-email.js
@@ -39,17 +39,6 @@ var NodeOutcome = {
   FALSE: 'false'
 };
 
-//extracts the language form headers (default to EN)
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 // extracts the email form shared state (for change email journey) or from IDM profile (other journeys)
 function extractEmail () {
   var isChangeEmail = sharedState.get('isChangeEmail');
@@ -119,8 +108,7 @@ function sendEmail (language, code, emailAddress) {
 try {
   var code = sharedState.get('oneTimePassword');
   var userId = sharedState.get('_id');
-  var emailAddress = '';
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
   var emailAddress = extractEmail();
 
   _log('User email address: ' + emailAddress);

--- a/config/am-scripts/scripts-content/ch-send-mfa-sms.js
+++ b/config/am-scripts/scripts-content/ch-send-mfa-sms.js
@@ -60,17 +60,6 @@ function sendErrorCallbacks () {
   }
 }
 
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 function sendTextMessage (language, phoneNumber, code) {
   sharedState.put('invalidPhone', null);
   sharedState.put('smsSendError', null);
@@ -161,7 +150,7 @@ try {
 
   _log('Code: ' + code);
 
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
   var phoneNumber = extractPhoneNumber();
 
   _log('User phoneNumber: ' + phoneNumber);

--- a/config/am-scripts/scripts-content/ch-webfiling-check-for-company-assoc-status.js
+++ b/config/am-scripts/scripts-content/ch-webfiling-check-for-company-assoc-status.js
@@ -60,23 +60,12 @@ function getUserMembershipForCompany (userIdentifier, companyNo) {
   }
 }
 
-//extracts the language form headers (default to EN)
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 try {
   var idmCompanyAuthEndpoint = _fromConfig('FIDC_ENDPOINT') + '/openidm/endpoint/companyauth/';
   var companyNo = JSON.parse(sharedState.get('companyData')).number;
   var sessionOwner = sharedState.get('_id');
   _log('[EWF - CHECK COMPANY MEMBERSHIP] session owner: ' + sessionOwner);
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
 
   var companyMembership = getUserMembershipForCompany(sessionOwner, companyNo);
   if (!companyMembership) {

--- a/config/am-scripts/scripts-content/ch-webfiling-prompt-for-link-confirmation.js
+++ b/config/am-scripts/scripts-content/ch-webfiling-prompt-for-link-confirmation.js
@@ -32,22 +32,11 @@ var NodeOutcome = {
   ERROR: 'error'
 };
 
-//extracts the language form headers (default to EN)
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 var YES_OPTION_INDEX = 0;
 
 try {
   var companyData = sharedState.get('companyData');
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
   if (callbacks.isEmpty()) {
     var infoMessage = 'Do you want to add this company to your Companies House account?';
     var errorMessage = sharedState.get('errorMessage');

--- a/config/am-scripts/scripts-content/ch-webfiling-store-lang-in-session.js
+++ b/config/am-scripts/scripts-content/ch-webfiling-store-lang-in-session.js
@@ -10,20 +10,9 @@ var NodeOutcome = {
   SUCCESS: 'success'
 };
 
-//extracts the language form headers (default to EN)
-function getSelectedLanguage (requestHeaders) {
-  if (requestHeaders && requestHeaders.get('Chosen-Language')) {
-    var lang = requestHeaders.get('Chosen-Language').get(0);
-    _log('selected language: ' + lang);
-    return lang;
-  }
-  _log('no selected language found - defaulting to EN');
-  return 'EN';
-}
-
 // main execution flow
 try {
-  var language = getSelectedLanguage(requestHeaders);
+  var language = _getSelectedLanguage(requestHeaders);
   action = fr.Action.goTo(NodeOutcome.SUCCESS)
     .putSessionProperty('language', language.toLowerCase())
     .build();

--- a/config/auth-trees/ch-update-email.json
+++ b/config/auth-trees/ch-update-email.json
@@ -43,7 +43,7 @@
       "_id": "2fd8d3ba-efe0-4255-855b-48c3c7b0b154",
       "nodeType": "RetryLimitDecisionNode",
       "details": {
-        "incrementUserAttributeOnFailure": true,
+        "incrementUserAttributeOnFailure": false,
         "retryLimit": 3
       }
     },
@@ -51,7 +51,7 @@
       "_id": "739b7e82-e0b3-4d94-980a-b052c8771303",
       "nodeType": "RetryLimitDecisionNode",
       "details": {
-        "incrementUserAttributeOnFailure": true,
+        "incrementUserAttributeOnFailure": false,
         "retryLimit": 3
       }
     },

--- a/config/auth-trees/ch-update-phone-number.json
+++ b/config/auth-trees/ch-update-phone-number.json
@@ -21,7 +21,7 @@
       "_id": "2fa15e3f-2b3d-48c6-93ee-9661538e2255",
       "nodeType": "RetryLimitDecisionNode",
       "details": {
-        "incrementUserAttributeOnFailure": true,
+        "incrementUserAttributeOnFailure": false,
         "retryLimit": 3
       }
     },

--- a/config/auth-trees/ch-webfiling-complete-profile.json
+++ b/config/auth-trees/ch-webfiling-complete-profile.json
@@ -189,7 +189,7 @@
       "_id": "c91bca42-14ab-44de-a17b-ca6201fddfcc",
       "nodeType": "RetryLimitDecisionNode",
       "details": {
-        "incrementUserAttributeOnFailure": true,
+        "incrementUserAttributeOnFailure": false,
         "retryLimit": 3
       }
     },

--- a/config/auth-trees/ch-webfiling-login.json
+++ b/config/auth-trees/ch-webfiling-login.json
@@ -216,7 +216,7 @@
       "_id": "b07427f0-b984-4be6-a388-083e0111db19",
       "nodeType": "RetryLimitDecisionNode",
       "details": {
-        "incrementUserAttributeOnFailure": true,
+        "incrementUserAttributeOnFailure": false,
         "retryLimit": 3
       }
     },


### PR DESCRIPTION
# Description

* Remove duplicated code in terms of getSelectedLanguage() functions
* Replace usages with call to library function
* Untick any 'Save value to user' checkboxes on Retry Decision nodes in Journeys

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [x] scripts (AM)
- [x] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
