### PR TITLE
Idam 923/use generic otp subflow

### DIFF
--- a/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
+++ b/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
@@ -29,6 +29,9 @@ if (journeyName === 'CHChangePhoneNumber') {
 } else if (journeyName === 'CHWebFiling-Login') {
   useStageName = 'PHONE_OTP';
   useOutcome = NodeOutcome.FORCE_TEXT;
+} else if (journeyName === 'CHRegistration') {
+  useStageName = 'REGISTRATION_MFA';
+  useOutcome = NodeOutcome.FORCE_TEXT;
 }
 
 sharedState.put(config.otpCheckStageNameVariable, useStageName);

--- a/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
+++ b/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
@@ -26,6 +26,9 @@ if (journeyName === 'CHChangePhoneNumber') {
 } else if (journeyName === 'CHResetPassword') {
   useStageName = 'RESET_PASSWORD_3';
   useOutcome = NodeOutcome.FORCE_TEXT;
+} else if (journeyName === 'CHWebFiling-Login') {
+  useStageName = 'PHONE_OTP';
+  useOutcome = NodeOutcome.FORCE_TEXT;
 }
 
 sharedState.put(config.otpCheckStageNameVariable, useStageName);

--- a/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
+++ b/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
@@ -17,6 +17,9 @@ var NodeOutcome = {
 var useStageName = 'DEFAULT_OTP_STAGE_NAME';
 var useOutcome = NodeOutcome.DEFAULT;
 
+var isRegistrationMFA = sharedState.get('registrationMFA');
+_log('Is Registration MFA : ' + isRegistrationMFA);
+
 if (journeyName === 'CHChangePhoneNumber') {
   useStageName = 'UPDATE_PHONE_2';
   useOutcome = NodeOutcome.FORCE_TEXT;
@@ -26,9 +29,13 @@ if (journeyName === 'CHChangePhoneNumber') {
 } else if (journeyName === 'CHResetPassword') {
   useStageName = 'RESET_PASSWORD_3';
   useOutcome = NodeOutcome.FORCE_TEXT;
-} else if (journeyName === 'CHWebFiling-Login') {
+} else if (journeyName === 'CHWebFiling-Login' && isRegistrationMFA) {
+  // Complete Profile
   useStageName = 'PHONE_OTP';
   useOutcome = NodeOutcome.FORCE_TEXT;
+} else if (journeyName === 'CHWebFiling-Login') {
+  useStageName = 'EWF_LOGIN_OTP';
+  useOutcome = NodeOutcome.DEFAULT;
 } else if (journeyName === 'CHRegistration') {
   useStageName = 'REGISTRATION_MFA';
   useOutcome = NodeOutcome.FORCE_TEXT;

--- a/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
+++ b/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
@@ -23,6 +23,9 @@ if (journeyName === 'CHChangePhoneNumber') {
 } else if (journeyName === 'CHChangeEmailAddress') {
   useStageName = 'CHANGE_EMAIL_INPUT';
   useOutcome = NodeOutcome.FORCE_EMAIL;
+} else if (journeyName === 'CHResetPassword') {
+  useStageName = 'RESET_PASSWORD_3';
+  useOutcome = NodeOutcome.FORCE_TEXT;
 }
 
 sharedState.put(config.otpCheckStageNameVariable, useStageName);

--- a/config/auth-trees/ch-multi-factor-generic.json
+++ b/config/auth-trees/ch-multi-factor-generic.json
@@ -151,23 +151,6 @@
       }
     },
     {
-      "_id": "98541a2b-eb47-4344-9136-020eba006a6c",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "20a3599f-b742-4554-a8b7-27862f248dd5",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
       "_id": "9a94e91d-e442-4c2c-8018-23f0f8672f7b",
       "nodeType": "ScriptedDecisionNode",
       "details": {
@@ -358,23 +341,13 @@
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Has Phone Number"
       },
-      "98541a2b-eb47-4344-9136-020eba006a6c": {
-        "x": 551,
-        "y": 429.5,
-        "connections": {
-          "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "true": "cfdd2637-5058-475e-80a5-984e2f1f7141"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Require MFA"
-      },
       "9a94e91d-e442-4c2c-8018-23f0f8672f7b": {
         "x": 237.33333333333337,
         "y": 423.69270833333337,
         "connections": {
-          "default": "98541a2b-eb47-4344-9136-020eba006a6c",
           "forceEmail": "5877bfca-a540-4c93-a9cf-6081b66f9fe8",
-          "forceText": "d8bd9341-0bb4-49ff-a119-964e51146f74"
+          "forceText": "d8bd9341-0bb4-49ff-a119-964e51146f74",
+          "default": "cfdd2637-5058-475e-80a5-984e2f1f7141"
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Setup based on Calling Journey"

--- a/config/auth-trees/ch-password-reset.json
+++ b/config/auth-trees/ch-password-reset.json
@@ -1,632 +1,594 @@
 {
-    "nodes": [
-        {
-            "_id":"29524a97-032e-40b1-8cd0-ef3938309671",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["resume","start"],
-                "outputs":["*"],
-                "script":"7fc79258-1c54-4df3-baa4-b51850ef3474"
-            }            
-        },
-        {
-            "_id":"4a0a458b-f374-4a7e-a5ec-5352aa21f834",
-            "nodeType": "PageNode",
-            "details": {
-                "pageHeader":{
-                    "en":"Reset Password"
-                },
-                "pageDescription":{
-                    "en":"Enter your email address or <a href=\"#/service/Login\">Sign in</a>"
-                },
-                "nodes":[
-                    {
-                        "_id":"fa9ca089-6a40-4f8a-87bd-4fbc3b133f2b",
-                        "nodeType":"AttributeCollectorNode",
-                        "displayName":"Attribute Collector"
-                    }
-                ],
-                "stage":"RESET_PASSWORD_1"
-            }
-        },
-        {
-            "_id":"fa9ca089-6a40-4f8a-87bd-4fbc3b133f2b",
-            "nodeType": "AttributeCollectorNode",
-            "details": {
-                "attributesToCollect":["mail"],
-                "identityAttribute":"mail",
-                "required":false,
-                "validateInputs":true
-            }
-        },
-        {
-            "_id":"6de1f9ea-0421-4065-8b70-bed9152c9a05",
-            "nodeType": "IdentifyExistingUserNode",
-            "details": {
-                "identifier":"userName",
-                "identityAttribute":"mail"
-            }
-        },
-        {
-            "_id":"e5b2d3d4-0995-48ad-bf0c-ae2b8560387e",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"b480d9f7-5908-45cf-91d1-bc1fe56fe8de"
-            }            
-        },
-        {
-            "_id":"5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e",
-            "nodeType": "PageNode",
-            "details": {
-                "nodes":[
-                    {
-                        "_id":"79b4e46e-034a-42b0-8f86-8435451f633e",
-                        "nodeType":"ChoiceCollectorNode",
-                        "displayName":"Choice Collector"
-                    }
-                ],
-                "pageDescription":{
-                    "desc":"How do you want to confirm it's you?"
-                },
-                "pageHeader":{
-                    "header":"How do you want to confirm it's you?"
-                },
-                "stage":"RESET_PASSWORD_2"
-            }    
-        },
-        {
-            "_id":"79b4e46e-034a-42b0-8f86-8435451f633e",
-            "nodeType": "ChoiceCollectorNode",
-            "details": {
-                "choices":["email","text"],
-                "defaultChoice":"Email",
-                "prompt":"How do you want to confirm it's you?"
-            }
-        },
-        {
-            "_id":"8e86cb2b-52ab-4341-a89b-1379976c790a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-            }  
-        },
-        {
-            "_id":"79c759fc-b836-42b4-afd4-ad564d1bbe60",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-            }
-        },
-        {
-            "_id":"bb5fc733-547b-41da-9b51-f709cac78764",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"c056951c-622e-11eb-ae93-0242ac130002"
-            }   
-        },
-        {
-            "_id":"b39ecc00-d42f-4cff-8f2e-3256bb8b3669",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"a39f3f71-1782-46dc-97cf-7cc417d4ca4a"
-            }
-        },
-        {
-            "_id":"cfb95e8e-a908-40f3-a756-f5959759e22e",
-            "nodeType": "OneTimePasswordGeneratorNode", 
-            "details": {
-                "length":6
-            }    
-        },
-        {
-            "_id":"70a15b0f-cb2a-48a9-81f0-6ba902a9e24a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"b276c566-622e-11eb-ae93-0242ac130002"
-            }    
-        },
-        {
-            "_id":"843b8111-3af6-49fa-bf8d-a650e04dec2e",
-            "nodeType": "PageNode", 
-            "details": {
-                "nodes":[
-                    {
-                        "_id":"5d337edd-8b0e-4c2d-a6cc-ab4e30f1ecbd",
-                        "nodeType":"ScriptedDecisionNode",
-                        "displayName":"Scripted Decision"
-                     },
-                    {
-                        "_id":"229f3a48-ddba-4528-8c72-dd7c2e7d53cd",
-                        "nodeType":"OneTimePasswordCollectorDecisionNode",
-                        "displayName":"OTP Collector Decision"
-                    }
-                ],
-                "pageDescription":{
-                    "desc":"Please enter the code you received via SMS"
-                },
-                "pageHeader":{
-                    "header":"Please enter your code"
-                },
-                "stage":"RESET_PASSWORD_3"
-            }
-        },
-        {
-            "_id":"ff7ee39c-e731-438a-8bf0-8492d9ee61bd",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c"
-            }    
-        },
-        {
-            "_id":"229f3a48-ddba-4528-8c72-dd7c2e7d53cd",
-            "nodeType": "OneTimePasswordCollectorDecisionNode", 
-            "details": {
-                "passwordExpiryTime":5   
-            }
-        },
-        {
-            "_id":"5d337edd-8b0e-4c2d-a6cc-ab4e30f1ecbd",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["True"],
-                "outputs":["*"],
-                "script":"24b1421b-8130-4eae-a999-a44dc6e94fa6"
-            }
-        },
-        {
-            "_id":"067ea40b-8eb7-48b9-8de3-c9bf73103e2d",
-            "nodeType": "PatchObjectNode", 
-            "details": {
-                "identityAttribute":"mail",
-                "identityResource":"managed/alpha_user",
-                "ignoredFields":[],
-                "patchAsObject":false
-            }
-        },
-        {
-            "_id":"129a2a4d-ea48-4ea4-a02f-eff667ffcc0e",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"ae90c22f-2613-49a6-9091-2238ec13eacb"
-            }
-        },
-        {
-            "_id":"4b011f55-d230-407d-8e91-8c5d0f573133",
-            "nodeType": "IdentifyExistingUserNode",
-            "details": {
-                "identifier":"userName",
-                "identityAttribute":"mail"
-            }
-        },
-        {
-            "_id":"56c8d746-4a57-467b-bc70-8cb944e98d8e",
-            "nodeType": "PageNode", 
-            "details": {
-                "nodes":[
-                    {
-                        "_id":"36437c17-0c4f-4c3e-9fd1-05ec0f0bab6a",
-                        "nodeType":"ScriptedDecisionNode",
-                        "displayName":"Cannot Find User"
-                    }
-                ],
-                "pageDescription":{
-                    "desc":"Cannot Find User"
-                },
-                "pageHeader":{
-                    "header":"Cannot Find User"
-                },
-                "stage":"PASSWORD_RESET_ERROR"
-            }
-        },
-        {
-            "_id":"36437c17-0c4f-4c3e-9fd1-05ec0f0bab6a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["false"],
-                "outputs":["*"],
-                "script":"8f08bdfd-08b9-42ce-8f45-99da5bc9dcfd"
-            }
-        },
-        {
-            "_id":"c98726b2-cee9-47ba-9677-40ae29223c65",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit": 3
-            }
-        },
-        {
-            "_id":"d085bafb-b361-4992-a766-7ffa1a73b4a1",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"fdac4efb-d8b8-478b-8300-e11a4c3503df"
-            }
-        },
-        {
-            "_id": "a248803f-1e17-4c42-975f-9b18c9477b7d",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "256dac17-1055-4798-9b98-a1321f3a8f09"
-            }
-        },
-        {
-            "_id": "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true", "false"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6"
-            }
-        },
-        {
-            "_id": "c94755f5-ea1e-4b8e-84ba-deeaf652d30d",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true", "false"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6"
-            }
-        },
-        {
-            "_id": "dab16163-28f8-484b-84c6-ed45763d3423",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-                "script": "a15a784a-489e-49ee-af79-a7153447c843"
-            }
-        },
-        {
-            "_id": "67cda865-3a06-452a-aa12-09b85b29bf73",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-                "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }
-        },
-        {
-            "_id": "fe52863d-fc41-41ee-ac16-07f1ac238088",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["pass", "fail", "error"],
-                "outputs":["*"],
-                "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
-            }
-        },
-        {
-            "_id": "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false"],
-                "outputs":["*"],
-                "script": "84caf8b3-813a-4998-85ff-a3dd8eee4bcf"
-            }
-        },
-        {
-            "_id": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-                "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-            }
-        }
-    ],
-    "tree" : {
-        "_id": "CHResetPassword",
-        "description": "CH Reset Password Tree",
+  "nodes": [
+    {
+      "_id": "067ea40b-8eb7-48b9-8de3-c9bf73103e2d",
+      "nodeType": "PatchObjectNode",
+      "details": {
         "identityResource": "managed/alpha_user",
-        "uiConfig": {},
-        "entryNodeId": "c94755f5-ea1e-4b8e-84ba-deeaf652d30d",
-        "nodes": {
-            "067ea40b-8eb7-48b9-8de3-c9bf73103e2d": {
-                "x": 1714,
-                "y": 554,
-                "connections": {
-                    "FAILURE": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "PATCHED": "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e"
-                },
-                "nodeType": "PatchObjectNode",
-                "displayName": "Update Password"
-            },
-            "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e": {
-                "x": 1928,
-                "y": 579,
-                "connections": {},
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Password Updated"
-            },
-            "29524a97-032e-40b1-8cd0-ef3938309671": {
-                "x": 233,
-                "y": 385,
-                "connections": {
-                    "resume": "4b011f55-d230-407d-8e91-8c5d0f573133",
-                    "start": "4a0a458b-f374-4a7e-a5ec-5352aa21f834"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Start or Resume"
-            },
-            "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27": {
-                "x": 1452,
-                "y": 483.015625,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "a248803f-1e17-4c42-975f-9b18c9477b7d"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Load password for patch"
-            },
-            "4a0a458b-f374-4a7e-a5ec-5352aa21f834": {
-                "x": 213,
-                "y": 27,
-                "connections": {
-                    "outcome": "6de1f9ea-0421-4065-8b70-bed9152c9a05"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Enter Email"
-            },
-            "4b011f55-d230-407d-8e91-8c5d0f573133": {
-                "x": 389,
-                "y": 622,
-                "connections": {
-                    "false": "56c8d746-4a57-467b-bc70-8cb944e98d8e",
-                    "true": "dab16163-28f8-484b-84c6-ed45763d3423"
-                },
-                "nodeType": "IdentifyExistingUserNode",
-                "displayName": "Identify Existing User 2"
-            },
-            "56c8d746-4a57-467b-bc70-8cb944e98d8e": {
-                "x": 720,
-                "y": 738,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Cannot Find User"
-            },
-            "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e": {
-                "x": 453,
-                "y": 286,
-                "connections": {
-                    "email": "8e86cb2b-52ab-4341-a89b-1379976c790a",
-                    "text": "79c759fc-b836-42b4-afd4-ad564d1bbe60"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Choose Email/SMS"
-            },
-            "67cda865-3a06-452a-aa12-09b85b29bf73": {
-                "x": 1323,
-                "y": 364.015625,
-                "connections": {
-                    "error": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "success": "fe52863d-fc41-41ee-ac16-07f1ac238088"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Get IDM token"
-            },
-            "6de1f9ea-0421-4065-8b70-bed9152c9a05": {
-                "x": 541,
-                "y": 29,
-                "connections": {
-                    "false": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669",
-                    "true": "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e"
-                },
-                "nodeType": "IdentifyExistingUserNode",
-                "displayName": "Identify Existing User 1"
-            },
-            "70a15b0f-cb2a-48a9-81f0-6ba902a9e24a": {
-                "x": 840,
-                "y": 528,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "843b8111-3af6-49fa-bf8d-a650e04dec2e"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Send MFA text"
-            },
-            "79c759fc-b836-42b4-afd4-ad564d1bbe60": {
-                "x": 690,
-                "y": 336,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "cfb95e8e-a908-40f3-a756-f5959759e22e"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Create Notify JWT - SMS"
-            },
-            "7caa061d-3986-453b-9e95-deeb3bd914f3": {
-                "x": 1790,
-                "y": 55.015625,
-                "connections": {},
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Generic Error"
-            },
-            "843b8111-3af6-49fa-bf8d-a650e04dec2e": {
-                "x": 1014,
-                "y": 618,
-                "connections": {
-                    "false": "c98726b2-cee9-47ba-9677-40ae29223c65",
-                    "true": "dab16163-28f8-484b-84c6-ed45763d3423"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Enter OTP"
-            },
-            "8e86cb2b-52ab-4341-a89b-1379976c790a": {
-                "x": 732,
-                "y": 171,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Create Notify JWT - Email"
-            },
-            "a248803f-1e17-4c42-975f-9b18c9477b7d": {
-                "x": 1689,
-                "y": 704.015625,
-                "connections": {
-                    "true": "067ea40b-8eb7-48b9-8de3-c9bf73103e2d"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Reset Parameters"
-            },
-            "b39ecc00-d42f-4cff-8f2e-3256bb8b3669": {
-                "x": 1425,
-                "y": 20,
-                "connections": {},
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Email sent ok "
-            },
-            "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5": {
-                "x": 934,
-                "y": 49.015625,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "bb5fc733-547b-41da-9b51-f709cac78764"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Load Keys"
-            },
-            "bb5fc733-547b-41da-9b51-f709cac78764": {
-                "x": 1142,
-                "y": 65,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Send Pwd Reset Email"
-            },
-            "c94755f5-ea1e-4b8e-84ba-deeaf652d30d": {
-                "x": 105,
-                "y": 268.015625,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "29524a97-032e-40b1-8cd0-ef3938309671"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Load Keys"
-            },
-            "c98726b2-cee9-47ba-9677-40ae29223c65": {
-                "x": 1250,
-                "y": 762.015625,
-                "connections": {
-                    "Reject": "d085bafb-b361-4992-a766-7ffa1a73b4a1",
-                    "Retry": "ff7ee39c-e731-438a-8bf0-8492d9ee61bd"
-                },
-                "nodeType": "RetryLimitDecisionNode",
-                "displayName": "Retry Limit Decision"
-            },
-            "cfb95e8e-a908-40f3-a756-f5959759e22e": {
-                "x": 763,
-                "y": 458,
-                "connections": {
-                    "outcome": "70a15b0f-cb2a-48a9-81f0-6ba902a9e24a"
-                },
-                "nodeType": "OneTimePasswordGeneratorNode",
-                "displayName": "HOTP Generator"
-            },
-            "d085bafb-b361-4992-a766-7ffa1a73b4a1": {
-                "x": 1461,
-                "y": 876.015625,
-                "connections": {},
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Max Attempts message"
-            },
-            "dab16163-28f8-484b-84c6-ed45763d3423": {
-                "x": 1188,
-                "y": 494.015625,
-                "connections": {
-                    "success": "67cda865-3a06-452a-aa12-09b85b29bf73",
-                    "error": "7caa061d-3986-453b-9e95-deeb3bd914f3"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Pwd Collector"
-            },
-            "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e": {
-                "x": 427,
-                "y": 151,
-                "connections": {
-                    "false": "8e86cb2b-52ab-4341-a89b-1379976c790a",
-                    "true": "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Has Phone Number"
-            },
-            "fe52863d-fc41-41ee-ac16-07f1ac238088": {
-                "x": 1628,
-                "y": 327.015625,
-                "connections": {
-                    "error": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "fail": "dab16163-28f8-484b-84c6-ed45763d3423",
-                    "pass": "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check Pwd policy"
-            },
-            "ff7ee39c-e731-438a-8bf0-8492d9ee61bd": {
-                "x": 1119,
-                "y": 942,
-                "connections": {
-                    "true": "843b8111-3af6-49fa-bf8d-a650e04dec2e"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Raise Error"
-            }
+        "patchAsObject": false,
+        "ignoredFields": [],
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "ae90c22f-2613-49a6-9091-2238ec13eacb",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "29524a97-032e-40b1-8cd0-ef3938309671",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "7fc79258-1c54-4df3-baa4-b51850ef3474",
+        "outcomes": [
+          "resume",
+          "start"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "84caf8b3-813a-4998-85ff-a3dd8eee4bcf",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "4a0a458b-f374-4a7e-a5ec-5352aa21f834",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "fa9ca089-6a40-4f8a-87bd-4fbc3b133f2b",
+            "nodeType": "AttributeCollectorNode",
+            "displayName": "Attribute Collector"
+          }
+        ],
+        "pageDescription": {
+          "en": "Enter your email address or <a href=\"#/service/Login\">Sign in</a>"
         },
-        "staticNodes": {
-            "startNode": {
-                "x": 25,
-                "y": 25
-            },
-            "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-                "x": 1896,
-                "y": 273
-            },
-            "e301438c-0bd0-429c-ab0c-66126501069a": {
-                "x": 1916,
-                "y": 154
-            }
+        "stage": "RESET_PASSWORD_1",
+        "pageHeader": {
+          "en": "Reset Password"
         }
+      }
+    },
+    {
+      "_id": "fa9ca089-6a40-4f8a-87bd-4fbc3b133f2b",
+      "nodeType": "AttributeCollectorNode",
+      "details": {
+        "attributesToCollect": [
+          "mail"
+        ],
+        "identityAttribute": "mail",
+        "validateInputs": true,
+        "required": false
+      }
+    },
+    {
+      "_id": "4b011f55-d230-407d-8e91-8c5d0f573133",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identityAttribute": "mail",
+        "identifier": "userName"
+      }
+    },
+    {
+      "_id": "56c8d746-4a57-467b-bc70-8cb944e98d8e",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "36437c17-0c4f-4c3e-9fd1-05ec0f0bab6a",
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "Cannot Find User"
+          }
+        ],
+        "pageDescription": {
+          "desc": "Cannot Find User"
+        },
+        "stage": "PASSWORD_RESET_ERROR",
+        "pageHeader": {
+          "header": "Cannot Find User"
+        }
+      }
+    },
+    {
+      "_id": "36437c17-0c4f-4c3e-9fd1-05ec0f0bab6a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "8f08bdfd-08b9-42ce-8f45-99da5bc9dcfd",
+        "outcomes": [
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "79b4e46e-034a-42b0-8f86-8435451f633e",
+            "nodeType": "ChoiceCollectorNode",
+            "displayName": "Choice Collector"
+          }
+        ],
+        "pageDescription": {
+          "desc": "How do you want to confirm it's you?"
+        },
+        "stage": "RESET_PASSWORD_2",
+        "pageHeader": {
+          "header": "How do you want to confirm it's you?"
+        }
+      }
+    },
+    {
+      "_id": "79b4e46e-034a-42b0-8f86-8435451f633e",
+      "nodeType": "ChoiceCollectorNode",
+      "details": {
+        "defaultChoice": "Email",
+        "choices": [
+          "email",
+          "text"
+        ],
+        "prompt": "How do you want to confirm it's you?"
+      }
+    },
+    {
+      "_id": "67cda865-3a06-452a-aa12-09b85b29bf73",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149",
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "6de1f9ea-0421-4065-8b70-bed9152c9a05",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identityAttribute": "mail",
+        "identifier": "userName"
+      }
+    },
+    {
+      "_id": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "8e86cb2b-52ab-4341-a89b-1379976c790a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "a248803f-1e17-4c42-975f-9b18c9477b7d",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "256dac17-1055-4798-9b98-a1321f3a8f09",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "a39f3f71-1782-46dc-97cf-7cc417d4ca4a",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "bb5fc733-547b-41da-9b51-f709cac78764",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "c056951c-622e-11eb-ae93-0242ac130002",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "c94755f5-ea1e-4b8e-84ba-deeaf652d30d",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "dab16163-28f8-484b-84c6-ed45763d3423",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "a15a784a-489e-49ee-af79-a7153447c843",
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "b480d9f7-5908-45cf-91d1-bc1fe56fe8de",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "fe52863d-fc41-41ee-ac16-07f1ac238088",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf",
+        "outcomes": [
+          "pass",
+          "fail",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "8727a90b-c53b-4e04-bdfd-e806654022bf",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHMultiFactorGeneric"
+      }
     }
+  ],
+  "tree": {
+    "_id": "CHResetPassword",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "c94755f5-ea1e-4b8e-84ba-deeaf652d30d",
+    "nodes": {
+      "067ea40b-8eb7-48b9-8de3-c9bf73103e2d": {
+        "x": 1714,
+        "y": 554,
+        "connections": {
+          "FAILURE": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "PATCHED": "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e"
+        },
+        "nodeType": "PatchObjectNode",
+        "displayName": "Update Password"
+      },
+      "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e": {
+        "x": 1928,
+        "y": 579,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Password Updated"
+      },
+      "29524a97-032e-40b1-8cd0-ef3938309671": {
+        "x": 233,
+        "y": 385,
+        "connections": {
+          "resume": "4b011f55-d230-407d-8e91-8c5d0f573133",
+          "start": "4a0a458b-f374-4a7e-a5ec-5352aa21f834"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Start or Resume"
+      },
+      "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27": {
+        "x": 1327,
+        "y": 592.015625,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "a248803f-1e17-4c42-975f-9b18c9477b7d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load password for patch"
+      },
+      "4a0a458b-f374-4a7e-a5ec-5352aa21f834": {
+        "x": 213,
+        "y": 27,
+        "connections": {
+          "outcome": "6de1f9ea-0421-4065-8b70-bed9152c9a05"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Enter Email"
+      },
+      "4b011f55-d230-407d-8e91-8c5d0f573133": {
+        "x": 389,
+        "y": 622,
+        "connections": {
+          "false": "56c8d746-4a57-467b-bc70-8cb944e98d8e",
+          "true": "dab16163-28f8-484b-84c6-ed45763d3423"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User 2"
+      },
+      "56c8d746-4a57-467b-bc70-8cb944e98d8e": {
+        "x": 720,
+        "y": 738,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Cannot Find User"
+      },
+      "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e": {
+        "x": 453,
+        "y": 286,
+        "connections": {
+          "email": "8e86cb2b-52ab-4341-a89b-1379976c790a",
+          "text": "8727a90b-c53b-4e04-bdfd-e806654022bf"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Choose Email/SMS"
+      },
+      "67cda865-3a06-452a-aa12-09b85b29bf73": {
+        "x": 1323,
+        "y": 364.015625,
+        "connections": {
+          "error": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "success": "fe52863d-fc41-41ee-ac16-07f1ac238088"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM token"
+      },
+      "6de1f9ea-0421-4065-8b70-bed9152c9a05": {
+        "x": 541,
+        "y": 29,
+        "connections": {
+          "false": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669",
+          "true": "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User 1"
+      },
+      "7caa061d-3986-453b-9e95-deeb3bd914f3": {
+        "x": 1790,
+        "y": 55.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Generic Error"
+      },
+      "8e86cb2b-52ab-4341-a89b-1379976c790a": {
+        "x": 732,
+        "y": 171,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT - Email"
+      },
+      "a248803f-1e17-4c42-975f-9b18c9477b7d": {
+        "x": 1689,
+        "y": 704.015625,
+        "connections": {
+          "true": "067ea40b-8eb7-48b9-8de3-c9bf73103e2d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Reset Parameters"
+      },
+      "b39ecc00-d42f-4cff-8f2e-3256bb8b3669": {
+        "x": 1425,
+        "y": 20,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Email sent ok "
+      },
+      "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5": {
+        "x": 934,
+        "y": 49.015625,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "bb5fc733-547b-41da-9b51-f709cac78764"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load Keys"
+      },
+      "bb5fc733-547b-41da-9b51-f709cac78764": {
+        "x": 1142,
+        "y": 65,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Send Pwd Reset Email"
+      },
+      "c94755f5-ea1e-4b8e-84ba-deeaf652d30d": {
+        "x": 105,
+        "y": 268.015625,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "29524a97-032e-40b1-8cd0-ef3938309671"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load Keys"
+      },
+      "dab16163-28f8-484b-84c6-ed45763d3423": {
+        "x": 959,
+        "y": 460.015625,
+        "connections": {
+          "success": "67cda865-3a06-452a-aa12-09b85b29bf73",
+          "error": "7caa061d-3986-453b-9e95-deeb3bd914f3"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Pwd Collector"
+      },
+      "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e": {
+        "x": 427,
+        "y": 151,
+        "connections": {
+          "false": "8e86cb2b-52ab-4341-a89b-1379976c790a",
+          "true": "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Has Phone Number"
+      },
+      "fe52863d-fc41-41ee-ac16-07f1ac238088": {
+        "x": 1628,
+        "y": 327.015625,
+        "connections": {
+          "error": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "fail": "dab16163-28f8-484b-84c6-ed45763d3423",
+          "pass": "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Pwd policy"
+      },
+      "8727a90b-c53b-4e04-bdfd-e806654022bf": {
+        "x": 751,
+        "y": 359.015625,
+        "connections": {
+          "true": "dab16163-28f8-484b-84c6-ed45763d3423",
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3"
+        },
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Check OTP SubFlow"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 25,
+        "y": 25
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1896,
+        "y": 273
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1916,
+        "y": 154
+      }
+    },
+    "description": "CH Reset Password Tree"
+  }
 }

--- a/config/auth-trees/ch-registration-start.json
+++ b/config/auth-trees/ch-registration-start.json
@@ -1,448 +1,397 @@
 {
-   "nodes": [
-      {
-         "_id":"eb711261-5253-4e17-9357-43e175a5005d",
-         "nodeType": "PageNode",
-         "details": {
-            "stage":"REGISTRATION_1",
-            "nodes":[
-               {
-                  "_id":"f07f1b4a-8aef-4c53-b04f-e41fd06ed859",
-                  "nodeType":"AttributeCollectorNode",
-                  "displayName":"Attribute Collector"
-               }
-            ],
-            "pageDescription":{
-               "en":"Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>"
-            },
-            "pageHeader":{
-               "en":"Sign Up"
-            }
-         }         
-      },
-      {
-         "_id":"f07f1b4a-8aef-4c53-b04f-e41fd06ed859",     
-         "nodeType": "AttributeCollectorNode",
-         "details": {
-            "attributesToCollect":[
-               "givenName",
-               "mail",
-               "telephoneNumber"
-            ],
-            "identityAttribute":"userName",
-            "required":false,
-            "validateInputs":true
-         }
-      },
-      {
-         "_id":"997cc39b-afde-4935-b9b5-a0d4e3034072",
-         "nodeType": "ScriptedDecisionNode",    
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-         }      
-      },
-      {
-         "_id":"9e02588a-e4ac-4b08-b10f-ad8f298ae720",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"b6ca4a1f-573f-4a3a-a410-d18b01207f6e"
-         }
-      },
-      {
-         "_id":"a87fa542-b6d3-49a1-bbdf-30370ae7042e",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["false","true"],
-            "outputs":["*"],
-            "script":"000c65e1-c9c6-4edb-96d2-298a9b152b40"
-         }
-      },
-      {
-         "_id":"5c7f4247-3b01-4dae-b18b-1d90ee710891",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["false","true"],
-            "outputs":["*"],
-            "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-         }
-      },
-      {
-         "_id":"27ec8bc7-d2ed-4877-b8bd-ebd84d5b9994",
-         "nodeType": "OneTimePasswordGeneratorNode", 
-         "details": {
-            "length":6
-         }
-      },
-      {
-         "_id":"37a1f12f-1e7b-4ca2-a870-040bf63291a0",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"b276c566-622e-11eb-ae93-0242ac130002"
-         }
-      },   
-      {
-         "_id":"42d22a17-4022-4d9a-8cc2-2ef7b2fd331c",
-         "nodeType": "PageNode", 
-         "details": {
-             "nodes":[
-                 {
-                     "_id":"6b8324ab-700c-40f9-a138-f03f25c425aa",
-                     "nodeType":"ScriptedDecisionNode",
-                     "displayName":"Scripted Decision"
-                  },
-                 {
-                     "_id":"0ab69626-b411-41d0-8744-c2313b74fd93",
-                     "nodeType":"OneTimePasswordCollectorDecisionNode",
-                     "displayName":"OTP Collector Decision"
-                 }
-             ],
-             "pageDescription":{
-                 "desc":"Please enter the code you received via SMS"
-             },
-             "pageHeader":{
-                 "header":"Please enter your code"
-             },
-             "stage":"REGISTRATION_MFA"
-         }
-     },
-     {
-         "_id":"6b8324ab-700c-40f9-a138-f03f25c425aa",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["True"],
-            "outputs":["*"],
-            "script":"24b1421b-8130-4eae-a999-a44dc6e94fa6"
-         }
-      },
-      {
-            "_id":"0ab69626-b411-41d0-8744-c2313b74fd93",
-            "nodeType": "OneTimePasswordCollectorDecisionNode", 
-            "details": {
-               "passwordExpiryTime":5   
-            }
-      },
-      {
-         "_id":"2eaa7c69-f97d-4bbf-b8b0-2214832cbc6f",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true"],
-            "outputs":["*"],
-            "script":"bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c"
-         }    
-      },
-      {
-         "_id":"14a23247-eeb0-436c-99dd-1b046fc1204f",
-         "nodeType": "RetryLimitDecisionNode", 
-         "details": {
-            "retryLimit": 3
-         }
-      },
-      {
-         "_id":"30518af8-5af3-45e1-bd23-d404e13d922b",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes": ["resend", "change_email"],
-            "outputs":["*"],
-            "script":"8b203967-fa57-4ce2-9dad-2f387ca52a61"
-         }    
-      },
-      {
-         "_id":"817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea",
-         "nodeType": "IdentifyExistingUserNode", 
-         "details": {
-            "identifier":"userName",
-            "identityAttribute":"mail"
-         }
-      },
-      {
-         "_id":"453352a5-1e8a-4696-a439-0f09555ebc4f",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true"],
-            "outputs":["*"],
-            "script":"d67457d4-b0ed-4b77-9ca1-23295246c9fd"
-         }    
-      },
-      {
-         "_id":"26f0bca6-8070-4d16-a5bc-8c3136e0057e",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-         }
-      },   
-      {
-         "_id":"24595c6d-40a2-4592-a8f2-7823bb5d84be",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"c056951c-622e-11eb-ae93-0242ac130002"
-         }
-      },
-      {
-         "_id": "0245c9e5-297b-4092-9e40-e3453f3581b6",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6"
-         }
-      },
-      {
-         "_id": "d4cff847-705b-44ed-81c9-c9da0ece05b5",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6"
-         }
-      },
-      {
-         "_id": "6ca3881c-7762-4280-a8be-692395b136d4",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes": ["true"],
-            "outputs":["*"],
-            "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-         }
-      },
-      {
-         "_id": "781e185e-f4da-442b-9fcd-827a4f235066",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes": ["resend", "change_email", "error"],
-            "outputs":["*"],
-            "script": "3e1aa9b2-7ca9-4292-8378-a08b27f09fd5"
-         }
-      }      
-   ],
-   "tree": {
-      "_id": "CHRegistration",
-      "description": "Registration Tree for CH Users - First part (email sending)",
-      "identityResource": "managed/alpha_user",
-      "uiConfig": {},
-      "entryNodeId": "eb711261-5253-4e17-9357-43e175a5005d",
-      "nodes": {
-         "0245c9e5-297b-4092-9e40-e3453f3581b6": {
-            "x": 497,
-            "y": 747.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "24595c6d-40a2-4592-a8f2-7823bb5d84be"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Load Keys"
-         },
-         "14a23247-eeb0-436c-99dd-1b046fc1204f": {
-            "x": 1276,
-            "y": 346.015625,
-            "connections": {
-               "Reject": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "Retry": "2eaa7c69-f97d-4bbf-b8b0-2214832cbc6f"
-            },
-            "nodeType": "RetryLimitDecisionNode",
-            "displayName": "Retry Limit Decision"
-         },
-         "24595c6d-40a2-4592-a8f2-7823bb5d84be": {
-            "x": 714,
-            "y": 829.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "30518af8-5af3-45e1-bd23-d404e13d922b"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Send Pwd Reset email"
-         },
-         "26f0bca6-8070-4d16-a5bc-8c3136e0057e": {
-            "x": 436,
-            "y": 601.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "0245c9e5-297b-4092-9e40-e3453f3581b6"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Notify JWT"
-         },
-         "27ec8bc7-d2ed-4877-b8bd-ebd84d5b9994": {
-            "x": 772,
-            "y": 586.015625,
-            "connections": {
-               "outcome": "37a1f12f-1e7b-4ca2-a870-040bf63291a0"
-            },
-            "nodeType": "OneTimePasswordGeneratorNode",
-            "displayName": "HOTP Generator"
-         },
-         "2eaa7c69-f97d-4bbf-b8b0-2214832cbc6f": {
-            "x": 1195,
-            "y": 606.015625,
-            "connections": {
-               "true": "42d22a17-4022-4d9a-8cc2-2ef7b2fd331c"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "OTP not valid"
-         },
-         "30518af8-5af3-45e1-bd23-d404e13d922b": {
-            "x": 1724,
-            "y": 143.015625,
-            "connections": {
-               "resend": "781e185e-f4da-442b-9fcd-827a4f235066",
-               "change_email": "eb711261-5253-4e17-9357-43e175a5005d"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Email Sent Confirmation"
-         },
-         "37a1f12f-1e7b-4ca2-a870-040bf63291a0": {
-            "x": 981,
-            "y": 715.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "42d22a17-4022-4d9a-8cc2-2ef7b2fd331c"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Send OTP"
-         },
-         "42d22a17-4022-4d9a-8cc2-2ef7b2fd331c": {
-            "x": 1013,
-            "y": 369.015625,
-            "connections": {
-               "false": "14a23247-eeb0-436c-99dd-1b046fc1204f",
-               "true": "997cc39b-afde-4935-b9b5-a0d4e3034072"
-            },
-            "nodeType": "PageNode",
-            "displayName": "OTP page"
-         },
-         "453352a5-1e8a-4696-a439-0f09555ebc4f": {
-            "x": 342,
-            "y": 484.015625,
-            "connections": {
-               "true": "26f0bca6-8070-4d16-a5bc-8c3136e0057e"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Set User Existing"
-         },
-         "5c7f4247-3b01-4dae-b18b-1d90ee710891": {
-            "x": 654,
-            "y": 365.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "27ec8bc7-d2ed-4877-b8bd-ebd84d5b9994"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Notify JWT - SMS"
-         },
-         "6ca3881c-7762-4280-a8be-692395b136d4": {
-            "x": 1847,
-            "y": 302.015625,
-            "connections": {},
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "General Error"
-         },
-         "781e185e-f4da-442b-9fcd-827a4f235066": {
-            "x": 1171,
-            "y": 213.015625,
-            "connections": {
-               "change_email": "eb711261-5253-4e17-9357-43e175a5005d",
-               "resend": "997cc39b-afde-4935-b9b5-a0d4e3034072"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Resend Or Change address"
-         },
-         "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea": {
-            "x": 245,
-            "y": 244.015625,
-            "connections": {
-               "false": "a87fa542-b6d3-49a1-bbdf-30370ae7042e",
-               "true": "453352a5-1e8a-4696-a439-0f09555ebc4f"
-            },
-            "nodeType": "IdentifyExistingUserNode",
-            "displayName": "Identify Existing User"
-         },
-         "997cc39b-afde-4935-b9b5-a0d4e3034072": {
-            "x": 894,
-            "y": 110,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "d4cff847-705b-44ed-81c9-c9da0ece05b5"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Notify JWT - Email"
-         },
-         "9e02588a-e4ac-4b08-b10f-ad8f298ae720": {
-            "x": 1465,
-            "y": 57.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "30518af8-5af3-45e1-bd23-d404e13d922b"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create & Email link"
-         },
-         "a87fa542-b6d3-49a1-bbdf-30370ae7042e": {
-            "x": 588,
-            "y": 107.015625,
-            "connections": {
-               "false": "997cc39b-afde-4935-b9b5-a0d4e3034072",
-               "true": "5c7f4247-3b01-4dae-b18b-1d90ee710891"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Check phone entered"
-         },
-         "d4cff847-705b-44ed-81c9-c9da0ece05b5": {
-            "x": 1198,
-            "y": 36.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "9e02588a-e4ac-4b08-b10f-ad8f298ae720"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Load Keys"
-         },
-         "eb711261-5253-4e17-9357-43e175a5005d": {
-            "x": 231,
-            "y": 57,
-            "connections": {
-               "outcome": "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea"
-            },
-            "nodeType": "PageNode",
-            "displayName": "Email Collector"
-         }
-      },
-      "staticNodes": {
-         "startNode": {
-            "x": 70,
-            "y": 80
-         },
-         "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-            "x": 1764,
-            "y": 501
-         },
-         "e301438c-0bd0-429c-ab0c-66126501069a": {
-            "x": 1901,
-            "y": 502
-         }
+  "nodes": [
+    {
+      "_id": "0245c9e5-297b-4092-9e40-e3453f3581b6",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
       }
-   }
+    },
+    {
+      "_id": "24595c6d-40a2-4592-a8f2-7823bb5d84be",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "c056951c-622e-11eb-ae93-0242ac130002",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "26f0bca6-8070-4d16-a5bc-8c3136e0057e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "30518af8-5af3-45e1-bd23-d404e13d922b",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "8b203967-fa57-4ce2-9dad-2f387ca52a61",
+        "outcomes": [
+          "resend",
+          "change_email"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "453352a5-1e8a-4696-a439-0f09555ebc4f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "d67457d4-b0ed-4b77-9ca1-23295246c9fd",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "6ca3881c-7762-4280-a8be-692395b136d4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "781e185e-f4da-442b-9fcd-827a4f235066",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "3e1aa9b2-7ca9-4292-8378-a08b27f09fd5",
+        "outcomes": [
+          "resend",
+          "change_email",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identityAttribute": "mail",
+        "identifier": "userName"
+      }
+    },
+    {
+      "_id": "997cc39b-afde-4935-b9b5-a0d4e3034072",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "9e02588a-e4ac-4b08-b10f-ad8f298ae720",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "b6ca4a1f-573f-4a3a-a410-d18b01207f6e",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "a87fa542-b6d3-49a1-bbdf-30370ae7042e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "000c65e1-c9c6-4edb-96d2-298a9b152b40",
+        "outcomes": [
+          "false",
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "d4cff847-705b-44ed-81c9-c9da0ece05b5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "eb711261-5253-4e17-9357-43e175a5005d",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "f07f1b4a-8aef-4c53-b04f-e41fd06ed859",
+            "nodeType": "AttributeCollectorNode",
+            "displayName": "Attribute Collector"
+          }
+        ],
+        "stage": "REGISTRATION_1",
+        "pageDescription": {
+          "en": "Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>"
+        },
+        "pageHeader": {
+          "en": "Sign Up"
+        }
+      }
+    },
+    {
+      "_id": "f07f1b4a-8aef-4c53-b04f-e41fd06ed859",
+      "nodeType": "AttributeCollectorNode",
+      "details": {
+        "attributesToCollect": [
+          "givenName",
+          "mail",
+          "telephoneNumber"
+        ],
+        "identityAttribute": "userName",
+        "validateInputs": true,
+        "required": false
+      }
+    },
+    {
+      "_id": "17c4c923-5d2d-4b22-8850-a4a4d8904a3d",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHMultiFactorGeneric"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHRegistration",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "eb711261-5253-4e17-9357-43e175a5005d",
+    "nodes": {
+      "0245c9e5-297b-4092-9e40-e3453f3581b6": {
+        "x": 497,
+        "y": 747.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "24595c6d-40a2-4592-a8f2-7823bb5d84be"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load Keys"
+      },
+      "24595c6d-40a2-4592-a8f2-7823bb5d84be": {
+        "x": 714,
+        "y": 829.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "30518af8-5af3-45e1-bd23-d404e13d922b"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Send Pwd Reset email"
+      },
+      "26f0bca6-8070-4d16-a5bc-8c3136e0057e": {
+        "x": 436,
+        "y": 601.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "0245c9e5-297b-4092-9e40-e3453f3581b6"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT"
+      },
+      "30518af8-5af3-45e1-bd23-d404e13d922b": {
+        "x": 1724,
+        "y": 143.015625,
+        "connections": {
+          "resend": "781e185e-f4da-442b-9fcd-827a4f235066",
+          "change_email": "eb711261-5253-4e17-9357-43e175a5005d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Email Sent Confirmation"
+      },
+      "453352a5-1e8a-4696-a439-0f09555ebc4f": {
+        "x": 342,
+        "y": 484.015625,
+        "connections": {
+          "true": "26f0bca6-8070-4d16-a5bc-8c3136e0057e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Set User Existing"
+      },
+      "6ca3881c-7762-4280-a8be-692395b136d4": {
+        "x": 1519,
+        "y": 684.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "General Error"
+      },
+      "781e185e-f4da-442b-9fcd-827a4f235066": {
+        "x": 1068,
+        "y": 228.015625,
+        "connections": {
+          "change_email": "eb711261-5253-4e17-9357-43e175a5005d",
+          "resend": "997cc39b-afde-4935-b9b5-a0d4e3034072"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Resend Or Change address"
+      },
+      "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea": {
+        "x": 169,
+        "y": 254.015625,
+        "connections": {
+          "false": "a87fa542-b6d3-49a1-bbdf-30370ae7042e",
+          "true": "453352a5-1e8a-4696-a439-0f09555ebc4f"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "997cc39b-afde-4935-b9b5-a0d4e3034072": {
+        "x": 886,
+        "y": 39,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "d4cff847-705b-44ed-81c9-c9da0ece05b5"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT - Email"
+      },
+      "9e02588a-e4ac-4b08-b10f-ad8f298ae720": {
+        "x": 1465,
+        "y": 57.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "30518af8-5af3-45e1-bd23-d404e13d922b"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create & Email link"
+      },
+      "a87fa542-b6d3-49a1-bbdf-30370ae7042e": {
+        "x": 496,
+        "y": 232.015625,
+        "connections": {
+          "false": "997cc39b-afde-4935-b9b5-a0d4e3034072",
+          "true": "17c4c923-5d2d-4b22-8850-a4a4d8904a3d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check phone entered"
+      },
+      "d4cff847-705b-44ed-81c9-c9da0ece05b5": {
+        "x": 1198,
+        "y": 36.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "9e02588a-e4ac-4b08-b10f-ad8f298ae720"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load Keys"
+      },
+      "eb711261-5253-4e17-9357-43e175a5005d": {
+        "x": 231,
+        "y": 57,
+        "connections": {
+          "outcome": "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Email Collector"
+      },
+      "17c4c923-5d2d-4b22-8850-a4a4d8904a3d": {
+        "x": 749,
+        "y": 396.015625,
+        "connections": {
+          "true": "997cc39b-afde-4935-b9b5-a0d4e3034072",
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4"
+        },
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Check OTP SubFlow"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 70,
+        "y": 80
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1764,
+        "y": 501
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1901,
+        "y": 502
+      }
+    },
+    "description": "Registration Tree for CH Users - First part (email sending)"
+  }
 }

--- a/config/auth-trees/ch-webfiling-complete-profile.json
+++ b/config/auth-trees/ch-webfiling-complete-profile.json
@@ -21,100 +21,11 @@
       }
     },
     {
-      "_id": "45d936c3-7d04-48d8-b7cb-02448fc9991e",
-      "nodeType": "PageNode",
-      "details": {
-        "nodes": [
-          {
-            "_id": "50869d72-4bbf-4ab5-b331-037ab48ada38",
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Callback Show Number"
-          },
-          {
-            "_id": "02d1400e-cf84-4b6e-984e-7958d8a11636",
-            "nodeType": "OneTimePasswordCollectorDecisionNode",
-            "displayName": "OTP Collector Decision"
-          }
-        ],
-        "pageDescription": {
-          "desc": "Please enter the code you received"
-        },
-        "stage": "PHONE_OTP",
-        "pageHeader": {
-          "header": "Please enter your code"
-        }
-      }
-    },
-    {
-      "_id": "50869d72-4bbf-4ab5-b331-037ab48ada38",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "72e60c8b-f4e9-4696-8218-6efee1f5d97b",
-        "outcomes": [
-          "True"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "02d1400e-cf84-4b6e-984e-7958d8a11636",
-      "nodeType": "OneTimePasswordCollectorDecisionNode",
-      "details": {
-        "passwordExpiryTime": 5
-      }
-    },
-    {
       "_id": "535f7949-b52e-4a8b-835d-ba46dff7ea51",
       "nodeType": "SessionDataNode",
       "details": {
         "sessionDataKey": "UserToken",
         "sharedStateKey": "userName"
-      }
-    },
-    {
-      "_id": "609cc371-1b68-4b18-8d95-4162b83662e9",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "6feedc53-41e0-49d0-b181-a8b43ccdadfe",
-      "nodeType": "OneTimePasswordGeneratorNode",
-      "details": {
-        "length": 6
-      }
-    },
-    {
-      "_id": "816ad4ee-870e-473b-aac6-feb203f3811f",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "b276c566-622e-11eb-ae93-0242ac130002",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
       }
     },
     {
@@ -153,22 +64,6 @@
       }
     },
     {
-      "_id": "a892b1a6-5f10-4ea6-aa5c-31772a90c987",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c",
-        "outcomes": [
-          "true"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
       "_id": "b802b783-cae6-4b4e-849c-2ab9c7b80391",
       "nodeType": "ScriptedDecisionNode",
       "details": {
@@ -186,19 +81,10 @@
       }
     },
     {
-      "_id": "c91bca42-14ab-44de-a17b-ca6201fddfcc",
-      "nodeType": "RetryLimitDecisionNode",
+      "_id": "59c4be80-649a-491e-b1be-92299e3b85ca",
+      "nodeType": "InnerTreeEvaluatorNode",
       "details": {
-        "incrementUserAttributeOnFailure": false,
-        "retryLimit": 3
-      }
-    },
-    {
-      "_id": "1df96f3f-82f1-4967-8d91-34488f4b0921",
-      "nodeType": "RetryLimitDecisionNode",
-      "details": {
-        "incrementUserAttributeOnFailure": false,
-        "retryLimit": 3
+        "tree": "CHMultiFactorGeneric"
       }
     }
   ],
@@ -209,8 +95,8 @@
     "entryNodeId": "3ece9748-a455-43b1-99b2-20fea28ed6ee",
     "nodes": {
       "1aeb1667-8dfe-417f-abaf-b02626fa5392": {
-        "x": 1907,
-        "y": 122.015625,
+        "x": 1542,
+        "y": 278.015625,
         "connections": {
           "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
           "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
@@ -228,16 +114,6 @@
         "nodeType": "IdentifyExistingUserNode",
         "displayName": "Identify Existing User"
       },
-      "45d936c3-7d04-48d8-b7cb-02448fc9991e": {
-        "x": 1648,
-        "y": 172.015625,
-        "connections": {
-          "false": "c91bca42-14ab-44de-a17b-ca6201fddfcc",
-          "true": "1aeb1667-8dfe-417f-abaf-b02626fa5392"
-        },
-        "nodeType": "PageNode",
-        "displayName": "Enter OTP"
-      },
       "535f7949-b52e-4a8b-835d-ba46dff7ea51": {
         "x": 249,
         "y": 414.015625,
@@ -247,38 +123,9 @@
         "nodeType": "SessionDataNode",
         "displayName": "Get Session Data"
       },
-      "609cc371-1b68-4b18-8d95-4162b83662e9": {
-        "x": 1011,
-        "y": 332.015625,
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "6feedc53-41e0-49d0-b181-a8b43ccdadfe"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Create Notify JWT - SMS"
-      },
-      "6feedc53-41e0-49d0-b181-a8b43ccdadfe": {
-        "x": 1241,
-        "y": 73.015625,
-        "connections": {
-          "outcome": "816ad4ee-870e-473b-aac6-feb203f3811f"
-        },
-        "nodeType": "OneTimePasswordGeneratorNode",
-        "displayName": "HOTP Generator"
-      },
-      "816ad4ee-870e-473b-aac6-feb203f3811f": {
-        "x": 1386,
-        "y": 193.015625,
-        "connections": {
-          "false": "1df96f3f-82f1-4967-8d91-34488f4b0921",
-          "true": "45d936c3-7d04-48d8-b7cb-02448fc9991e"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Send OTP"
-      },
       "9cebfbba-00c4-41a2-9772-7d4e80699e47": {
-        "x": 1868,
-        "y": 750.015625,
+        "x": 1312,
+        "y": 534.015625,
         "connections": {},
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Max Number Exceeded"
@@ -289,20 +136,11 @@
         "connections": {
           "fail": "3ece9748-a455-43b1-99b2-20fea28ed6ee",
           "name_only": "1aeb1667-8dfe-417f-abaf-b02626fa5392",
-          "otp": "609cc371-1b68-4b18-8d95-4162b83662e9",
-          "skip": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+          "skip": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "otp": "59c4be80-649a-491e-b1be-92299e3b85ca"
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "complete profile"
-      },
-      "a892b1a6-5f10-4ea6-aa5c-31772a90c987": {
-        "x": 2098,
-        "y": 653.015625,
-        "connections": {
-          "true": "45d936c3-7d04-48d8-b7cb-02448fc9991e"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Raise OTP Error"
       },
       "b802b783-cae6-4b4e-849c-2ab9c7b80391": {
         "x": 74,
@@ -314,25 +152,15 @@
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Check for Session"
       },
-      "c91bca42-14ab-44de-a17b-ca6201fddfcc": {
-        "x": 1873,
-        "y": 620.015625,
+      "59c4be80-649a-491e-b1be-92299e3b85ca": {
+        "x": 1144,
+        "y": 339.015625,
         "connections": {
-          "Reject": "9cebfbba-00c4-41a2-9772-7d4e80699e47",
-          "Retry": "a892b1a6-5f10-4ea6-aa5c-31772a90c987"
+          "false": "9cebfbba-00c4-41a2-9772-7d4e80699e47",
+          "true": "1aeb1667-8dfe-417f-abaf-b02626fa5392"
         },
-        "nodeType": "RetryLimitDecisionNode",
-        "displayName": "Retry Limit Decision"
-      },
-      "1df96f3f-82f1-4967-8d91-34488f4b0921": {
-        "x": 1409,
-        "y": 421.015625,
-        "connections": {
-          "Reject": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "Retry": "a46a26c4-eb14-4f61-be94-1eca72022424"
-        },
-        "nodeType": "RetryLimitDecisionNode",
-        "displayName": "Retry Limit Decision"
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Check OTP SubFlow"
       }
     },
     "staticNodes": {
@@ -341,8 +169,8 @@
         "y": 103
       },
       "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 2196,
-        "y": 254
+        "x": 1818,
+        "y": 187
       },
       "e301438c-0bd0-429c-ab0c-66126501069a": {
         "x": 1615,

--- a/config/auth-trees/ch-webfiling-login.json
+++ b/config/auth-trees/ch-webfiling-login.json
@@ -75,13 +75,6 @@
       }
     },
     {
-      "_id": "3ef1391a-3bfb-4088-be5c-40713da8b6cc",
-      "nodeType": "OneTimePasswordGeneratorNode",
-      "details": {
-        "length": 6
-      }
-    },
-    {
       "_id": "6129ae01-2f10-4e6a-ab4f-eba00524c6b0",
       "nodeType": "ScriptedDecisionNode",
       "details": {
@@ -140,60 +133,10 @@
       }
     },
     {
-      "_id": "73252c50-1f11-468d-b5ee-aa0c44ec104d",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "b276c566-622e-11eb-ae93-0242ac130002",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
       "_id": "7f0f8fa9-357a-4139-b407-d9a0336faaa9",
       "nodeType": "InnerTreeEvaluatorNode",
       "details": {
         "tree": "CHManageEmailConsent"
-      }
-    },
-    {
-      "_id": "9760e4cc-d4f7-4bf0-8985-18a4c8a7c55d",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "a5778ce7-addf-4fb6-a7db-92929f1314c4",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "979fd32f-2242-4d08-b31b-722c1ed419b4",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df",
-        "outcomes": [
-          "true"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
       }
     },
     {
@@ -213,100 +156,10 @@
       }
     },
     {
-      "_id": "b07427f0-b984-4be6-a388-083e0111db19",
-      "nodeType": "RetryLimitDecisionNode",
-      "details": {
-        "incrementUserAttributeOnFailure": false,
-        "retryLimit": 3
-      }
-    },
-    {
       "_id": "bd62a4ef-dcf4-4952-904f-f7f3601b8ae3",
       "nodeType": "InnerTreeEvaluatorNode",
       "details": {
         "tree": "CHUpdateLegacyPassword"
-      }
-    },
-    {
-      "_id": "c13d3e4d-d2ed-47bc-acad-4ef3b70f62a5",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "c57cea8d-a2de-4422-8ccb-5ca9dcad5bde",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "b480d9f7-5908-45cf-91d1-bc1fe56fe8de",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "c5f45504-02d6-4370-b120-03c18d72a2a3",
-      "nodeType": "PageNode",
-      "details": {
-        "nodes": [
-          {
-            "_id": "ace51bd8-ed90-4227-bdce-98e9f42485a3",
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Scripted Decision"
-          },
-          {
-            "_id": "9ffd76c9-4624-4d2a-bc8a-8e621f8a7799",
-            "nodeType": "OneTimePasswordCollectorDecisionNode",
-            "displayName": "OTP Collector Decision"
-          }
-        ],
-        "pageDescription": {
-          "desc": "Please enter the code you received"
-        },
-        "stage": "EWF_LOGIN_OTP",
-        "pageHeader": {
-          "header": "Please enter your code"
-        }
-      }
-    },
-    {
-      "_id": "ace51bd8-ed90-4227-bdce-98e9f42485a3",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "ace951c8-d169-4426-9357-d5b44e0aa728",
-        "outcomes": [
-          "True"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "9ffd76c9-4624-4d2a-bc8a-8e621f8a7799",
-      "nodeType": "OneTimePasswordCollectorDecisionNode",
-      "details": {
-        "passwordExpiryTime": 30
       }
     },
     {
@@ -317,22 +170,6 @@
         "outcomes": [
           "true",
           "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "cdc774a7-c03c-4cf2-8514-9d7654aac599",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c",
-        "outcomes": [
-          "true"
         ],
         "outputs": [
           "*"
@@ -360,23 +197,6 @@
       }
     },
     {
-      "_id": "eb0917d3-88bb-47ff-adf2-4157edae8d7a",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
       "_id": "f79be846-2226-41d2-a8f1-7a53ef4b5a77",
       "nodeType": "ScriptedDecisionNode",
       "details": {
@@ -390,13 +210,6 @@
         "inputs": [
           "*"
         ]
-      }
-    },
-    {
-      "_id": "fa794bf3-ffbe-459d-9078-dbc19bfdf4c6",
-      "nodeType": "OneTimePasswordGeneratorNode",
-      "details": {
-        "length": 6
       }
     },
     {
@@ -571,20 +384,10 @@
       }
     },
     {
-      "_id": "101b5c24-cb88-4ed1-8db6-5d4fc07f3c10",
-      "nodeType": "ScriptedDecisionNode",
+      "_id": "c20d2d99-dc1a-4a02-9931-2a3885ca160b",
+      "nodeType": "InnerTreeEvaluatorNode",
       "details": {
-        "script": "610ba200-db35-4c44-80c9-a40d36cc6fc0",
-        "outcomes": [
-          "email",
-          "text"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
+        "tree": "CHMultiFactorGeneric"
       }
     }
   ],
@@ -605,8 +408,8 @@
         "displayName": "Reset Counter"
       },
       "0ac72f4f-039a-4843-a565-037fb0b8805d": {
-        "x": 1269,
-        "y": 436.015625,
+        "x": 1328,
+        "y": 195.015625,
         "connections": {
           "error": "b3f513ec-f284-476d-b040-00918b40b772",
           "success": "6538e894-475a-49f0-be1c-08d721f615df"
@@ -627,8 +430,8 @@
         "displayName": "Check soft lock"
       },
       "24d11b28-95b9-478c-aede-990c2471109c": {
-        "x": 2786,
-        "y": 56.5,
+        "x": 2171,
+        "y": 231.5,
         "connections": {
           "outcome": "f79be846-2226-41d2-a8f1-7a53ef4b5a77"
         },
@@ -636,8 +439,8 @@
         "displayName": "Increment Login Count"
       },
       "318d16a5-37ca-4d58-a3ec-54a4699881e3": {
-        "x": 3063,
-        "y": 20.015625,
+        "x": 2942,
+        "y": 202.015625,
         "connections": {
           "false": "b3f513ec-f284-476d-b040-00918b40b772",
           "true": "7f0f8fa9-357a-4139-b407-d9a0336faaa9"
@@ -646,27 +449,18 @@
         "displayName": "Complete Profile"
       },
       "31fa4b8d-9686-4bec-8db2-45d442533b22": {
-        "x": 2985,
-        "y": 197.5,
+        "x": 2676,
+        "y": 209.5,
         "connections": {
           "false": "b3f513ec-f284-476d-b040-00918b40b772",
           "true": "318d16a5-37ca-4d58-a3ec-54a4699881e3"
         },
         "nodeType": "InnerTreeEvaluatorNode",
-        "displayName": "Inner Tree Evaluator"
-      },
-      "3ef1391a-3bfb-4088-be5c-40713da8b6cc": {
-        "x": 1994,
-        "y": 285.66666666666663,
-        "connections": {
-          "outcome": "9760e4cc-d4f7-4bf0-8985-18a4c8a7c55d"
-        },
-        "nodeType": "OneTimePasswordGeneratorNode",
-        "displayName": "HOTP Generator"
+        "displayName": "Progressive Profiling"
       },
       "6129ae01-2f10-4e6a-ab4f-eba00524c6b0": {
-        "x": 1058,
-        "y": 554.015625,
+        "x": 1160,
+        "y": 399.015625,
         "connections": {
           "true": "0ac72f4f-039a-4843-a565-037fb0b8805d"
         },
@@ -684,11 +478,11 @@
         "displayName": "Soft Lock Increment Counter"
       },
       "6538e894-475a-49f0-be1c-08d721f615df": {
-        "x": 1044,
-        "y": 179.015625,
+        "x": 1624,
+        "y": 199.015625,
         "connections": {
           "error": "fb8f7fbe-2fa7-4de8-a5c1-c55c54b1fd3d",
-          "success": "c57cea8d-a2de-4422-8ccb-5ca9dcad5bde"
+          "success": "c20d2d99-dc1a-4a02-9931-2a3885ca160b"
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Reset Counter after login OK"
@@ -703,42 +497,15 @@
         "nodeType": "IdentifyExistingUserNode",
         "displayName": "Identify Existing User"
       },
-      "73252c50-1f11-468d-b5ee-aa0c44ec104d": {
-        "x": 2246,
-        "y": 83,
-        "connections": {
-          "false": "b3f513ec-f284-476d-b040-00918b40b772",
-          "true": "c5f45504-02d6-4370-b120-03c18d72a2a3"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Send MFA text via Notify"
-      },
       "7f0f8fa9-357a-4139-b407-d9a0336faaa9": {
-        "x": 3233,
-        "y": 191.015625,
+        "x": 3194,
+        "y": 206.015625,
         "connections": {
           "false": "b3f513ec-f284-476d-b040-00918b40b772",
           "true": "f9659606-3900-4580-8513-0e197e62452a"
         },
         "nodeType": "InnerTreeEvaluatorNode",
         "displayName": "Email Consent"
-      },
-      "9760e4cc-d4f7-4bf0-8985-18a4c8a7c55d": {
-        "x": 2239,
-        "y": 260,
-        "connections": {
-          "false": "b3f513ec-f284-476d-b040-00918b40b772",
-          "true": "c5f45504-02d6-4370-b120-03c18d72a2a3"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Send MFA email via Notify"
-      },
-      "979fd32f-2242-4d08-b31b-722c1ed419b4": {
-        "x": 2966,
-        "y": 423.015625,
-        "connections": {},
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "max attempts"
       },
       "a6ab1111-936e-49e9-86cf-45ced5596dde": {
         "x": 258,
@@ -748,16 +515,6 @@
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Email not exist msg"
-      },
-      "b07427f0-b984-4be6-a388-083e0111db19": {
-        "x": 2732,
-        "y": 318.015625,
-        "connections": {
-          "Reject": "979fd32f-2242-4d08-b31b-722c1ed419b4",
-          "Retry": "cdc774a7-c03c-4cf2-8514-9d7654aac599"
-        },
-        "nodeType": "RetryLimitDecisionNode",
-        "displayName": "Retry Limit Decision"
       },
       "bd62a4ef-dcf4-4952-904f-f7f3601b8ae3": {
         "x": 894,
@@ -769,36 +526,6 @@
         "nodeType": "InnerTreeEvaluatorNode",
         "displayName": "Update Legacy Password"
       },
-      "c13d3e4d-d2ed-47bc-acad-4ef3b70f62a5": {
-        "x": 1732,
-        "y": 75,
-        "connections": {
-          "false": "b3f513ec-f284-476d-b040-00918b40b772",
-          "true": "fa794bf3-ffbe-459d-9078-dbc19bfdf4c6"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Create Notify JWT - SMS"
-      },
-      "c57cea8d-a2de-4422-8ccb-5ca9dcad5bde": {
-        "x": 1240,
-        "y": 31.5,
-        "connections": {
-          "false": "eb0917d3-88bb-47ff-adf2-4157edae8d7a",
-          "true": "101b5c24-cb88-4ed1-8db6-5d4fc07f3c10"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Has Phone Number"
-      },
-      "c5f45504-02d6-4370-b120-03c18d72a2a3": {
-        "x": 2540,
-        "y": 64.015625,
-        "connections": {
-          "false": "b07427f0-b984-4be6-a388-083e0111db19",
-          "true": "24d11b28-95b9-478c-aede-990c2471109c"
-        },
-        "nodeType": "PageNode",
-        "displayName": "Enter OTP"
-      },
       "ca5a5885-e8be-4006-9004-28cf71922e75": {
         "x": 241,
         "y": 408.015625,
@@ -808,15 +535,6 @@
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Check Format"
-      },
-      "cdc774a7-c03c-4cf2-8514-9d7654aac599": {
-        "x": 2967,
-        "y": 351.015625,
-        "connections": {
-          "true": "c5f45504-02d6-4370-b120-03c18d72a2a3"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Raise Error"
       },
       "e69f6be3-d125-4f8c-9a54-d5960d481c7a": {
         "x": 614,
@@ -828,33 +546,14 @@
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Get IDM Token"
       },
-      "eb0917d3-88bb-47ff-adf2-4157edae8d7a": {
-        "x": 1732,
-        "y": 248,
-        "connections": {
-          "false": "b3f513ec-f284-476d-b040-00918b40b772",
-          "true": "3ef1391a-3bfb-4088-be5c-40713da8b6cc"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Create Notify JWT - Email"
-      },
       "f79be846-2226-41d2-a8f1-7a53ef4b5a77": {
-        "x": 2796,
-        "y": 155.5,
+        "x": 2423,
+        "y": 234.5,
         "connections": {
           "true": "31fa4b8d-9686-4bec-8db2-45d442533b22"
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Update Last Login"
-      },
-      "fa794bf3-ffbe-459d-9078-dbc19bfdf4c6": {
-        "x": 1992,
-        "y": 108.33333333333334,
-        "connections": {
-          "outcome": "73252c50-1f11-468d-b5ee-aa0c44ec104d"
-        },
-        "nodeType": "OneTimePasswordGeneratorNode",
-        "displayName": "HOTP Generator"
       },
       "fb8f7fbe-2fa7-4de8-a5c1-c55c54b1fd3d": {
         "x": 218,
@@ -866,8 +565,8 @@
         "displayName": "Login Form (EWF)"
       },
       "f9659606-3900-4580-8513-0e197e62452a": {
-        "x": 3372,
-        "y": 106.015625,
+        "x": 3453,
+        "y": 241.015625,
         "connections": {
           "success": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
         },
@@ -928,15 +627,15 @@
         "nodeType": "ScriptedDecisionNode",
         "displayName": "General Error"
       },
-      "101b5c24-cb88-4ed1-8db6-5d4fc07f3c10": {
-        "x": 1503,
-        "y": 50.015625,
+      "c20d2d99-dc1a-4a02-9931-2a3885ca160b": {
+        "x": 1934,
+        "y": 199.015625,
         "connections": {
-          "email": "eb0917d3-88bb-47ff-adf2-4157edae8d7a",
-          "text": "c13d3e4d-d2ed-47bc-acad-4ef3b70f62a5"
+          "true": "24d11b28-95b9-478c-aede-990c2471109c",
+          "false": "b3f513ec-f284-476d-b040-00918b40b772"
         },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Choose Email/SMS"
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Check OTP SubFlow"
       }
     },
     "staticNodes": {
@@ -945,8 +644,8 @@
         "y": 190
       },
       "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 3591,
-        "y": 34.66666666666666
+        "x": 3790,
+        "y": 236.66666666666666
       },
       "e301438c-0bd0-429c-ab0c-66126501069a": {
         "x": 3302,


### PR DESCRIPTION
# Description

* Roll out the use of the generic OTP subflow across other journeys

config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js

config/auth-trees/ch-password-reset.json
config/auth-trees/ch-registration-start.json
config/auth-trees/ch-webfiling-complete-profile.json
config/auth-trees/ch-webfiling-login.json

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [x] scripts (AM)
- [x] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
