### PR TITLE
Idam 1074/switch off user retry limit

### DIFF
--- a/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
+++ b/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
@@ -29,6 +29,9 @@ if (journeyName === 'CHChangePhoneNumber') {
 } else if (journeyName === 'CHWebFiling-Login') {
   useStageName = 'PHONE_OTP';
   useOutcome = NodeOutcome.FORCE_TEXT;
+} else if (journeyName === 'CHRegistration') {
+  useStageName = 'REGISTRATION_MFA';
+  useOutcome = NodeOutcome.FORCE_TEXT;
 }
 
 sharedState.put(config.otpCheckStageNameVariable, useStageName);

--- a/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
+++ b/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
@@ -26,6 +26,9 @@ if (journeyName === 'CHChangePhoneNumber') {
 } else if (journeyName === 'CHResetPassword') {
   useStageName = 'RESET_PASSWORD_3';
   useOutcome = NodeOutcome.FORCE_TEXT;
+} else if (journeyName === 'CHWebFiling-Login') {
+  useStageName = 'PHONE_OTP';
+  useOutcome = NodeOutcome.FORCE_TEXT;
 }
 
 sharedState.put(config.otpCheckStageNameVariable, useStageName);

--- a/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
+++ b/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
@@ -17,6 +17,9 @@ var NodeOutcome = {
 var useStageName = 'DEFAULT_OTP_STAGE_NAME';
 var useOutcome = NodeOutcome.DEFAULT;
 
+var isRegistrationMFA = sharedState.get('registrationMFA');
+_log('Is Registration MFA : ' + isRegistrationMFA);
+
 if (journeyName === 'CHChangePhoneNumber') {
   useStageName = 'UPDATE_PHONE_2';
   useOutcome = NodeOutcome.FORCE_TEXT;
@@ -26,9 +29,13 @@ if (journeyName === 'CHChangePhoneNumber') {
 } else if (journeyName === 'CHResetPassword') {
   useStageName = 'RESET_PASSWORD_3';
   useOutcome = NodeOutcome.FORCE_TEXT;
-} else if (journeyName === 'CHWebFiling-Login') {
+} else if (journeyName === 'CHWebFiling-Login' && isRegistrationMFA) {
+  // Complete Profile
   useStageName = 'PHONE_OTP';
   useOutcome = NodeOutcome.FORCE_TEXT;
+} else if (journeyName === 'CHWebFiling-Login') {
+  useStageName = 'EWF_LOGIN_OTP';
+  useOutcome = NodeOutcome.DEFAULT;
 } else if (journeyName === 'CHRegistration') {
   useStageName = 'REGISTRATION_MFA';
   useOutcome = NodeOutcome.FORCE_TEXT;

--- a/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
+++ b/config/am-scripts/scripts-content/ch-mfa-sub-flow-setup.js
@@ -23,6 +23,9 @@ if (journeyName === 'CHChangePhoneNumber') {
 } else if (journeyName === 'CHChangeEmailAddress') {
   useStageName = 'CHANGE_EMAIL_INPUT';
   useOutcome = NodeOutcome.FORCE_EMAIL;
+} else if (journeyName === 'CHResetPassword') {
+  useStageName = 'RESET_PASSWORD_3';
+  useOutcome = NodeOutcome.FORCE_TEXT;
 }
 
 sharedState.put(config.otpCheckStageNameVariable, useStageName);

--- a/config/auth-trees/ch-create-company-association.json
+++ b/config/auth-trees/ch-create-company-association.json
@@ -1,355 +1,454 @@
 {
-    "nodes": [
-        {
-            "_id":"0207683b-7437-4441-aa6b-a143ac0ab576",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["hasSession","noSession"],
-                "outputs":["*"],
-                "script":"c4001e02-469c-4cc4-bf95-9f43d7e46568"
-            }            
-        },
-        {
-            "_id":"54a93ee3-d273-49b6-8d23-0fd1dcb6320b",
-            "nodeType": "SessionDataNode", 
-            "details": {
-               "sharedStateKey":"userName",
-               "sessionDataKey":"UserToken"
-            }				
-        },
-        {
-            "_id":"e04ef6d2-daec-403e-93a1-f8b60a8f634b",
-            "nodeType": "IdentifyExistingUserNode", 
-            "details": {
-                "identifier":"userName",
-                "identityAttribute":"mail"
-            }
-        },
-        {
-            "_id":"3f37ce1b-c569-4229-a331-9bedf3ceb9af",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"838ab622-d892-44e6-a5c5-f45238aed210"
-            }            
-        },
-        {
-            "_id":"ef37be85-8d9f-4140-aa6a-b8c8cc19a695",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["success","error"],
-                "outputs":["*"],
-                "script":"c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
-        },
-        {
-            "_id":"e5c64e99-5259-4e93-bb25-1871b370f7cd",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["success","error"],
-                "outputs":["*"],
-                "script":"c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
-        },
-        {
-            "_id":"a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false", "error", "other"],
-                "outputs":["*"],
-                "script":"55801756-11bf-493d-b49c-195488cf939a"
-            }            
-        },
-        {
-            "_id":"b2401c4a-636f-43e4-b129-be18fccf30f3",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","error","already_associated", "auth_code_inactive"],
-                "outputs":["*"],
-                "script":"16975ea5-4f0a-4ac6-861f-00dbf39ca441"
-            }            
-        },
-        {
-            "_id":"78204b08-ebbd-4b61-8b1b-080a1061987a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"10f63087-b21b-40eb-9c90-8e3fb3fabfa1"
-            }            
-        },
-        {
-            "_id":"55ab38cb-458d-4c6c-ba34-3586bf34b06c",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"ad7a63a6-fae2-46c0-be70-bec1f059f064"
-            }            
-        },
-        {
-            "_id":"c5f729d0-922d-44f8-a480-aa34d2ca02d8",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"917f36a9-f21e-43e4-bed5-9b2171228387"
-            }            
-        },
-        {
-            "_id":"ba60739d-61f1-4ede-bf94-3f3dc628a38d",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit":3
-            }
-        },
-        {
-         "_id":"c7714228-4b3d-403c-8807-39c028bf549c",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-             "inputs":["*"],
-             "outcomes":["true"],
-             "outputs":["*"],
-             "script":"fdac4efb-d8b8-478b-8300-e11a4c3503df"
-         }            
-      },
-      {
-         "_id": "93328e47-3918-42c3-a27d-b5cf6c1abb67",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "outcomes": ["true", "false"],
-            "inputs": ["*"],
-            "outputs": ["*"],
-            "script": "df75d4ae-8f25-48f4-af14-bb87206e029d"
-         }
-      },
-      {
-         "_id": "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "outcomes": ["success", "error"],
-            "inputs": ["*"],
-            "outputs": ["*"],
-            "script": "1b3c84cf-411a-4e5b-998f-768191e735f1"
-         }
-      },
-      {
-         "_id": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "outcomes": ["true"],
-            "inputs": ["*"],
-            "outputs": ["*"],
-            "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-         }
-      },
-      {
-         "_id": "537ff588-0447-4938-b1be-bce4fe9869ce",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "outcomes": ["true", "false"],
-            "inputs": ["*"],
-            "outputs": ["*"],
-            "script": "df67765e-df3a-4503-9ba5-35c992b39259"
-         }
+  "nodes": [
+    {
+      "_id": "0207683b-7437-4441-aa6b-a143ac0ab576",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "hasSession",
+          "noSession"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c4001e02-469c-4cc4-bf95-9f43d7e46568"
       }
-   ],
-   "tree": {
-      "_id": "CHCompanyAssociation",
-      "description": "As an authenticated user, enter a company number, company auth code and create an association with that company",
-      "identityResource": "managed/alpha_user",
-      "uiConfig": {},
-      "entryNodeId": "0207683b-7437-4441-aa6b-a143ac0ab576",
-      "nodes": {
-         "0207683b-7437-4441-aa6b-a143ac0ab576": {
-            "x": 175,
-            "y": 402.015625,
-            "connections": {
-               "hasSession": "54a93ee3-d273-49b6-8d23-0fd1dcb6320b",
-               "noSession": "95966d43-e698-432d-b3d8-2f8fb0e98276"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "check session"
-         },
-         "3f37ce1b-c569-4229-a331-9bedf3ceb9af": {
-            "x": 559,
-            "y": 26.015625,
-            "connections": {
-               "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "ef37be85-8d9f-4140-aa6a-b8c8cc19a695"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Enter company No"
-         },
-         "54a93ee3-d273-49b6-8d23-0fd1dcb6320b": {
-            "x": 222,
-            "y": 238.015625,
-            "connections": {
-               "outcome": "e04ef6d2-daec-403e-93a1-f8b60a8f634b"
-            },
-            "nodeType": "SessionDataNode",
-            "displayName": "Get Session Data"
-         },
-         "55ab38cb-458d-4c6c-ba34-3586bf34b06c": {
-            "x": 1097,
-            "y": 30,
-            "connections": {
-               "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "93328e47-3918-42c3-a27d-b5cf6c1abb67"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Enter Auth Code"
-         },
-         "78204b08-ebbd-4b61-8b1b-080a1061987a": {
-            "x": 1707,
-            "y": 532.015625,
-            "connections": {
-               "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Confirmation"
-         },
-         "93328e47-3918-42c3-a27d-b5cf6c1abb67": {
-            "x": 1285,
-            "y": 33.015625,
-            "connections": {
-               "false": "c5f729d0-922d-44f8-a480-aa34d2ca02d8",
-               "true": "e5c64e99-5259-4e93-bb25-1871b370f7cd"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Validate Cleartext Auth Code"
-         },
-         "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6": {
-            "x": 916,
-            "y": 182.015625,
-            "connections": {
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "false": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
-               "true": "55ab38cb-458d-4c6c-ba34-3586bf34b06c",
-               "other": "3f37ce1b-c569-4229-a331-9bedf3ceb9af"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "get company data"
-         },
-         "b2401c4a-636f-43e4-b129-be18fccf30f3": {
-            "x": 1683,
-            "y": 142.015625,
-            "connections": {
-               "already_associated": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
-               "auth_code_inactive": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "537ff588-0447-4938-b1be-bce4fe9869ce"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Association"
-         },
-         "ba60739d-61f1-4ede-bf94-3f3dc628a38d": {
-            "x": 1289,
-            "y": 409.015625,
-            "connections": {
-               "Reject": "c7714228-4b3d-403c-8807-39c028bf549c",
-               "Retry": "55ab38cb-458d-4c6c-ba34-3586bf34b06c"
-            },
-            "nodeType": "RetryLimitDecisionNode",
-            "displayName": "Retry Limit Decision"
-         },
-         "c5f729d0-922d-44f8-a480-aa34d2ca02d8": {
-            "x": 1303,
-            "y": 247,
-            "connections": {
-               "true": "ba60739d-61f1-4ede-bf94-3f3dc628a38d"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Auth Code Error Message"
-         },
-         "c7714228-4b3d-403c-8807-39c028bf549c": {
-            "x": 1436,
-            "y": 629.015625,
-            "connections": {},
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "max attempts message"
-         },
-         "e04ef6d2-daec-403e-93a1-f8b60a8f634b": {
-            "x": 299.40625,
-            "y": 37.015625,
-            "connections": {
-               "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "3f37ce1b-c569-4229-a331-9bedf3ceb9af"
-            },
-            "nodeType": "IdentifyExistingUserNode",
-            "displayName": "Identify Existing User"
-         },
-         "e5c64e99-5259-4e93-bb25-1871b370f7cd": {
-            "x": 1534,
-            "y": 37.015625,
-            "connections": {
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "success": "b2401c4a-636f-43e4-b129-be18fccf30f3"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "get IDM token again"
-         },
-         "ef37be85-8d9f-4140-aa6a-b8c8cc19a695": {
-            "x": 790,
-            "y": 22.015625,
-            "connections": {
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "success": "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "get IDM token"
-         },
-         "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb": {
-            "x": 1629,
-            "y": 410.015625,
-            "connections": {
-               "success": "78204b08-ebbd-4b61-8b1b-080a1061987a",
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Notify Company Members"
-         },
-         "95966d43-e698-432d-b3d8-2f8fb0e98276": {
-            "x": 917,
-            "y": 755.015625,
-            "connections": {},
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Generic error"
-         },
-         "537ff588-0447-4938-b1be-bce4fe9869ce": {
-            "x": 1641,
-            "y": 303.015625,
-            "connections": {
-               "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Notify JWT"
-         }
-      },
-      "staticNodes": {
-         "startNode": {
-            "x": 50,
-            "y": 250
-         },
-         "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-            "x": 2020,
-            "y": 128
-         },
-         "e301438c-0bd0-429c-ab0c-66126501069a": {
-            "x": 1572,
-            "y": 777
-         }
+    },
+    {
+      "_id": "54a93ee3-d273-49b6-8d23-0fd1dcb6320b",
+      "nodeType": "SessionDataNode",
+      "details": {
+        "sharedStateKey": "userName",
+        "sessionDataKey": "UserToken"
       }
-   }
+    },
+    {
+      "_id": "e04ef6d2-daec-403e-93a1-f8b60a8f634b",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identifier": "userName",
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "838ab622-d892-44e6-a5c5-f45238aed210"
+      }
+    },
+    {
+      "_id": "ef37be85-8d9f-4140-aa6a-b8c8cc19a695",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "e5c64e99-5259-4e93-bb25-1871b370f7cd",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false",
+          "error",
+          "other"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "55801756-11bf-493d-b49c-195488cf939a"
+      }
+    },
+    {
+      "_id": "b2401c4a-636f-43e4-b129-be18fccf30f3",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "error",
+          "already_associated",
+          "auth_code_inactive"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "16975ea5-4f0a-4ac6-861f-00dbf39ca441"
+      }
+    },
+    {
+      "_id": "78204b08-ebbd-4b61-8b1b-080a1061987a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "10f63087-b21b-40eb-9c90-8e3fb3fabfa1"
+      }
+    },
+    {
+      "_id": "55ab38cb-458d-4c6c-ba34-3586bf34b06c",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ad7a63a6-fae2-46c0-be70-bec1f059f064"
+      }
+    },
+    {
+      "_id": "c5f729d0-922d-44f8-a480-aa34d2ca02d8",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "917f36a9-f21e-43e4-bed5-9b2171228387"
+      }
+    },
+    {
+      "_id": "ba60739d-61f1-4ede-bf94-3f3dc628a38d",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "c7714228-4b3d-403c-8807-39c028bf549c",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df"
+      }
+    },
+    {
+      "_id": "93328e47-3918-42c3-a27d-b5cf6c1abb67",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df75d4ae-8f25-48f4-af14-bb87206e029d"
+      }
+    },
+    {
+      "_id": "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "1b3c84cf-411a-4e5b-998f-768191e735f1"
+      }
+    },
+    {
+      "_id": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
+      }
+    },
+    {
+      "_id": "537ff588-0447-4938-b1be-bce4fe9869ce",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHCompanyAssociation",
+    "description": "As an authenticated user, enter a company number, company auth code and create an association with that company",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "0207683b-7437-4441-aa6b-a143ac0ab576",
+    "nodes": {
+      "0207683b-7437-4441-aa6b-a143ac0ab576": {
+        "x": 175,
+        "y": 402.015625,
+        "connections": {
+          "hasSession": "54a93ee3-d273-49b6-8d23-0fd1dcb6320b",
+          "noSession": "95966d43-e698-432d-b3d8-2f8fb0e98276"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "check session"
+      },
+      "3f37ce1b-c569-4229-a331-9bedf3ceb9af": {
+        "x": 559,
+        "y": 26.015625,
+        "connections": {
+          "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "ef37be85-8d9f-4140-aa6a-b8c8cc19a695"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Enter company No"
+      },
+      "54a93ee3-d273-49b6-8d23-0fd1dcb6320b": {
+        "x": 222,
+        "y": 238.015625,
+        "connections": {
+          "outcome": "e04ef6d2-daec-403e-93a1-f8b60a8f634b"
+        },
+        "nodeType": "SessionDataNode",
+        "displayName": "Get Session Data"
+      },
+      "55ab38cb-458d-4c6c-ba34-3586bf34b06c": {
+        "x": 1097,
+        "y": 30,
+        "connections": {
+          "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "93328e47-3918-42c3-a27d-b5cf6c1abb67"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Enter Auth Code"
+      },
+      "78204b08-ebbd-4b61-8b1b-080a1061987a": {
+        "x": 1707,
+        "y": 532.015625,
+        "connections": {
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Confirmation"
+      },
+      "93328e47-3918-42c3-a27d-b5cf6c1abb67": {
+        "x": 1285,
+        "y": 33.015625,
+        "connections": {
+          "false": "c5f729d0-922d-44f8-a480-aa34d2ca02d8",
+          "true": "e5c64e99-5259-4e93-bb25-1871b370f7cd"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Validate Cleartext Auth Code"
+      },
+      "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6": {
+        "x": 916,
+        "y": 182.015625,
+        "connections": {
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "false": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
+          "true": "55ab38cb-458d-4c6c-ba34-3586bf34b06c",
+          "other": "3f37ce1b-c569-4229-a331-9bedf3ceb9af"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "get company data"
+      },
+      "b2401c4a-636f-43e4-b129-be18fccf30f3": {
+        "x": 1683,
+        "y": 142.015625,
+        "connections": {
+          "already_associated": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
+          "auth_code_inactive": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "537ff588-0447-4938-b1be-bce4fe9869ce"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Association"
+      },
+      "ba60739d-61f1-4ede-bf94-3f3dc628a38d": {
+        "x": 1289,
+        "y": 409.015625,
+        "connections": {
+          "Reject": "c7714228-4b3d-403c-8807-39c028bf549c",
+          "Retry": "55ab38cb-458d-4c6c-ba34-3586bf34b06c"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "c5f729d0-922d-44f8-a480-aa34d2ca02d8": {
+        "x": 1303,
+        "y": 247,
+        "connections": {
+          "true": "ba60739d-61f1-4ede-bf94-3f3dc628a38d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Auth Code Error Message"
+      },
+      "c7714228-4b3d-403c-8807-39c028bf549c": {
+        "x": 1436,
+        "y": 629.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "max attempts message"
+      },
+      "e04ef6d2-daec-403e-93a1-f8b60a8f634b": {
+        "x": 299.40625,
+        "y": 37.015625,
+        "connections": {
+          "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "3f37ce1b-c569-4229-a331-9bedf3ceb9af"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "e5c64e99-5259-4e93-bb25-1871b370f7cd": {
+        "x": 1534,
+        "y": 37.015625,
+        "connections": {
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "success": "b2401c4a-636f-43e4-b129-be18fccf30f3"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "get IDM token again"
+      },
+      "ef37be85-8d9f-4140-aa6a-b8c8cc19a695": {
+        "x": 790,
+        "y": 22.015625,
+        "connections": {
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "success": "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "get IDM token"
+      },
+      "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb": {
+        "x": 1629,
+        "y": 410.015625,
+        "connections": {
+          "success": "78204b08-ebbd-4b61-8b1b-080a1061987a",
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Notify Company Members"
+      },
+      "95966d43-e698-432d-b3d8-2f8fb0e98276": {
+        "x": 917,
+        "y": 755.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Generic error"
+      },
+      "537ff588-0447-4938-b1be-bce4fe9869ce": {
+        "x": 1641,
+        "y": 303.015625,
+        "connections": {
+          "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 50,
+        "y": 250
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 2020,
+        "y": 128
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1572,
+        "y": 777
+      }
+    }
+  }
 }

--- a/config/auth-trees/ch-credential-validation.json
+++ b/config/auth-trees/ch-credential-validation.json
@@ -1,191 +1,208 @@
 {
-    "nodes": [
-        {
-            "_id": "73454ed9-828e-44a5-8ca2-c65085852d9f",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "outcomes": [
-                    "hasSession",
-                    "noSession"
-                ],
-                "script": "c4001e02-469c-4cc4-bf95-9f43d7e46568"
-            }
-        },
-        {
-            "_id": "f27fc95c-c74f-4778-8d53-8cb2a5e142a1",
-            "nodeType": "SessionDataNode",
-            "details": {
-                "sessionDataKey": "UserToken",
-                "sharedStateKey": "userName"
-            }
-        },
-        {
-            "_id": "78936cb2-2423-4b7e-9a45-528b8b386dcd",
-            "nodeType": "IdentifyExistingUserNode",
-            "details": {
-                "identifier": "userName",
-                "identityAttribute": "mail"
-            }
-        },
-        {
-            "_id": "956820bb-c811-41be-b09f-64406dce2e62",
-            "nodeType": "PageNode",
-            "details": {
-                "nodes": [
-                    {
-                        "_id": "1408b24a-ed80-47ab-b388-02a7cb6814e5",
-                        "nodeType": "ScriptedDecisionNode",
-                        "displayName": "Scripted Decision"
-                    }
-                ],
-                "pageHeader": {
-                    "header": "Please enter the credential"
-                },
-                "pageDescription": {
-                    "desc": "Please enter the credential to validate"
-                },
-                "stage": "VALIDATE_CREDENTIAL_1"
-            }
-        },
-        {
+  "nodes": [
+    {
+      "_id": "73454ed9-828e-44a5-8ca2-c65085852d9f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "outcomes": [
+          "hasSession",
+          "noSession"
+        ],
+        "script": "c4001e02-469c-4cc4-bf95-9f43d7e46568"
+      }
+    },
+    {
+      "_id": "f27fc95c-c74f-4778-8d53-8cb2a5e142a1",
+      "nodeType": "SessionDataNode",
+      "details": {
+        "sessionDataKey": "UserToken",
+        "sharedStateKey": "userName"
+      }
+    },
+    {
+      "_id": "78936cb2-2423-4b7e-9a45-528b8b386dcd",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identifier": "userName",
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "956820bb-c811-41be-b09f-64406dce2e62",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
             "_id": "1408b24a-ed80-47ab-b388-02a7cb6814e5",
             "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "7f9c55bb-9307-45b7-9b4f-7d1bf4e8ea49"
-            }
+            "displayName": "Scripted Decision"
+          }
+        ],
+        "pageHeader": {
+          "header": "Please enter the credential"
         },
-        {
-            "_id": "578be13f-34d4-412d-9dca-4a8e46b4008f",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "137e1fd5-19f4-425d-96eb-2a8c20cabcf8"
-            }
+        "pageDescription": {
+          "desc": "Please enter the credential to validate"
         },
-        {
-            "_id": "3b40ffa2-ad51-444f-a040-2748beab59a5",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "65d2099f-9583-47d3-8303-8051709cb436"
-            }
-        },
-        {
-            "_id": "5c2c9a13-626d-4058-8447-31c78d04acee",
-            "nodeType": "RetryLimitDecisionNode",
-            "details": {
-                "retryLimit": 3
-            }
-        }
-    ],
-    "tree": {
-        "_id": "CHCredentialValidation",
-        "description": "As an authenticated user, validate a supplied cleartext credential against a hashed version",
-        "identityResource": "managed/alpha_user",
-        "entryNodeId": "73454ed9-828e-44a5-8ca2-c65085852d9f",
-        "staticNodes": {
-            "startNode": {
-                "x": 62,
-                "y": 103
-            },
-            "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-                "x": 1925,
-                "y": 315
-            },
-            "e301438c-0bd0-429c-ab0c-66126501069a": {
-                "x": 1764,
-                "y": 747
-            }
-        },
-        "uiConfig": {},
-        "nodes": {
-            "3b40ffa2-ad51-444f-a040-2748beab59a5": {
-                "x": 1648,
-                "y": 334.015625,
-                "connections": {
-                    "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-                    "false": "5c2c9a13-626d-4058-8447-31c78d04acee"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Call Validation Service"
-            },
-            "578be13f-34d4-412d-9dca-4a8e46b4008f": {
-                "x": 1399,
-                "y": 340.015625,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "3b40ffa2-ad51-444f-a040-2748beab59a5"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Fetch Hashed Password"
-            },
-            "73454ed9-828e-44a5-8ca2-c65085852d9f": {
-                "x": 190,
-                "y": 531.015625,
-                "connections": {
-                    "hasSession": "f27fc95c-c74f-4778-8d53-8cb2a5e142a1",
-                    "noSession": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check for Session"
-            },
-            "78936cb2-2423-4b7e-9a45-528b8b386dcd": {
-                "x": 712.828125,
-                "y": 340.015625,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "956820bb-c811-41be-b09f-64406dce2e62"
-                },
-                "nodeType": "IdentifyExistingUserNode",
-                "displayName": "Identify Existing User"
-            },
-            "956820bb-c811-41be-b09f-64406dce2e62": {
-                "x": 1101,
-                "y": 295.015625,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "578be13f-34d4-412d-9dca-4a8e46b4008f"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Enter Credential"
-            },
-            "f27fc95c-c74f-4778-8d53-8cb2a5e142a1": {
-                "x": 443,
-                "y": 388.015625,
-                "connections": {
-                    "outcome": "78936cb2-2423-4b7e-9a45-528b8b386dcd"
-                },
-                "nodeType": "SessionDataNode",
-                "displayName": "Get Session Data"
-            },
-            "5c2c9a13-626d-4058-8447-31c78d04acee": {
-                "x": 1135,
-                "y": 537.015625,
-                "connections": {
-                    "Retry": "956820bb-c811-41be-b09f-64406dce2e62",
-                    "Reject": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "RetryLimitDecisionNode",
-                "displayName": "Retry Limit Decision"
-            }
-        }
+        "stage": "VALIDATE_CREDENTIAL_1"
+      }
+    },
+    {
+      "_id": "1408b24a-ed80-47ab-b388-02a7cb6814e5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "7f9c55bb-9307-45b7-9b4f-7d1bf4e8ea49"
+      }
+    },
+    {
+      "_id": "578be13f-34d4-412d-9dca-4a8e46b4008f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "137e1fd5-19f4-425d-96eb-2a8c20cabcf8"
+      }
+    },
+    {
+      "_id": "3b40ffa2-ad51-444f-a040-2748beab59a5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "65d2099f-9583-47d3-8303-8051709cb436"
+      }
+    },
+    {
+      "_id": "5c2c9a13-626d-4058-8447-31c78d04acee",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
     }
+  ],
+  "tree": {
+    "_id": "CHCredentialValidation",
+    "description": "As an authenticated user, validate a supplied cleartext credential against a hashed version",
+    "identityResource": "managed/alpha_user",
+    "entryNodeId": "73454ed9-828e-44a5-8ca2-c65085852d9f",
+    "staticNodes": {
+      "startNode": {
+        "x": 62,
+        "y": 103
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1925,
+        "y": 315
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1764,
+        "y": 747
+      }
+    },
+    "uiConfig": {},
+    "nodes": {
+      "3b40ffa2-ad51-444f-a040-2748beab59a5": {
+        "x": 1648,
+        "y": 334.015625,
+        "connections": {
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "false": "5c2c9a13-626d-4058-8447-31c78d04acee"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Call Validation Service"
+      },
+      "578be13f-34d4-412d-9dca-4a8e46b4008f": {
+        "x": 1399,
+        "y": 340.015625,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "3b40ffa2-ad51-444f-a040-2748beab59a5"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Fetch Hashed Password"
+      },
+      "73454ed9-828e-44a5-8ca2-c65085852d9f": {
+        "x": 190,
+        "y": 531.015625,
+        "connections": {
+          "hasSession": "f27fc95c-c74f-4778-8d53-8cb2a5e142a1",
+          "noSession": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check for Session"
+      },
+      "78936cb2-2423-4b7e-9a45-528b8b386dcd": {
+        "x": 712.828125,
+        "y": 340.015625,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "956820bb-c811-41be-b09f-64406dce2e62"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "956820bb-c811-41be-b09f-64406dce2e62": {
+        "x": 1101,
+        "y": 295.015625,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "578be13f-34d4-412d-9dca-4a8e46b4008f"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Enter Credential"
+      },
+      "f27fc95c-c74f-4778-8d53-8cb2a5e142a1": {
+        "x": 443,
+        "y": 388.015625,
+        "connections": {
+          "outcome": "78936cb2-2423-4b7e-9a45-528b8b386dcd"
+        },
+        "nodeType": "SessionDataNode",
+        "displayName": "Get Session Data"
+      },
+      "5c2c9a13-626d-4058-8447-31c78d04acee": {
+        "x": 1135,
+        "y": 537.015625,
+        "connections": {
+          "Retry": "956820bb-c811-41be-b09f-64406dce2e62",
+          "Reject": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      }
+    }
+  }
 }

--- a/config/auth-trees/ch-login.json
+++ b/config/auth-trees/ch-login.json
@@ -1,631 +1,769 @@
 {
-	"nodes": [
-		{
-			"_id": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-			"nodeType": "PageNode",
-			"details": {
-				"nodes": [ 
-					{
-						"_id": "a346e4e7-8490-4ec6-962f-ebb9ba51dbe6",
-						"nodeType": "ValidatedUsernameNode",
-						"displayName": "Platform Username"
-					}, 
-					{
-						"_id": "d28720a1-ad25-406b-baea-d3691f5122ea",
-						"nodeType": "ValidatedPasswordNode",
-						"displayName": "Platform Password"
-					},
-					{
-						"_id": "3b1940b6-a238-455e-8d13-ceb0f2848be4",
-						"nodeType": "ScriptedDecisionNode",
-						"displayName": "Error Handling"
-					}
-				],
-				"pageDescription": {
-					"en": "New here? <a href=\"#/service/Registration\">Create an account</a><br><a href=\"#/service/ForgottenUsername\">Forgot username?</a><a href=\"#/service/ResetPassword\"> Forgot password?</a>"
-				},
-				"pageHeader": {
-					"en": "Sign In"
-				},
-				"stage": "CH_LOGIN_1"
-			}
-		},
-		{
-			"_id": "a346e4e7-8490-4ec6-962f-ebb9ba51dbe6",
-			"nodeType": "ValidatedUsernameNode",
-			"details": {
-				"usernameAttribute": "userName",
-				"validateInput": false
-			}
-		},
-		{
-			"_id": "d28720a1-ad25-406b-baea-d3691f5122ea",
-			"nodeType": "ValidatedPasswordNode",
-			"details": {
-				"passwordAttribute": "password",
-				"validateInput": false
-			}
-		},
-		{
-			"_id": "4f019558-f468-46f2-8000-5bba1d9dac45",
-			"nodeType": "IdentifyExistingUserNode",
-			"details": {
-				"identifier": "userName",
-				"identityAttribute": "mail"
-			}
-		},
-		{
-			"_id": "758e3d0a-3211-4850-8847-86981f75888e",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "CHUpdateLegacyPassword"
-			}
-		},
-		{
-			"_id": "c32fab79-8836-4657-bef0-9f03a1e1165f",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "20a3599f-b742-4554-a8b7-27862f248dd5"
-			}
-		},
-		{
-			"_id": "0e91440f-8d40-4946-88c9-1a7e22da57bc",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "b480d9f7-5908-45cf-91d1-bc1fe56fe8de"
-			}
-		},
-		{
-			"_id": "9339d5b3-f917-46a5-918e-a8b4ce884d81",
-			"nodeType": "PageNode",
-			"details": {
-				"nodes": [{
-					"_id": "7c1389a2-2b21-483b-a2f2-2e2ad42f52b2",
-					"nodeType": "ChoiceCollectorNode",
-					"displayName": "Choice Collector"
-				}],
-				"pageDescription": {
-					"desc": "How do you want to confirm it's you?"
-				},
-				"pageHeader": {
-					"header": "How do you want to confirm it's you?"
-				},
-				"stage": "CH_LOGIN_2"
-			}
-		},
-		{
-			"_id": "7c1389a2-2b21-483b-a2f2-2e2ad42f52b2",
-			"nodeType": "ChoiceCollectorNode",
-			"details": {
-				"choices": ["email", "text"],
-				"defaultChoice": "email",
-				"prompt": "How do you want to confirm it's you?"
-			}
-		},
-		{
-			"_id": "3147767a-bb7b-47b2-9b43-6d297e7cc2fa",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "df67765e-df3a-4503-9ba5-35c992b39259"
-			}
-		},
-		{
-			"_id": "0e167098-4f1b-4a6d-a383-9a415b143dda",
-			"nodeType": "OneTimePasswordGeneratorNode",
-			"details": {
-				"length": 6
-			}
-		},
-		{
-			"_id": "860b9b8a-260a-4123-85f5-7cf50e20a291",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "b276c566-622e-11eb-ae93-0242ac130002"
-			}
-		},
-		{
-			"_id": "1031a228-600a-4325-82da-c93e6a13ab5b",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "df67765e-df3a-4503-9ba5-35c992b39259"
-			}
-		},
-		{
-			"_id": "c20b82fd-458d-4a46-8d0f-41d589f3976b",
-			"nodeType": "OneTimePasswordGeneratorNode",
-			"details": {
-				"length": 6
-			}
-		},
-		{
-			"_id": "5e76d32e-9180-4a20-b0bd-ff9b89773cbb",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "a5778ce7-addf-4fb6-a7db-92929f1314c4"
-			}
-		},
-		{
-			"_id": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0",
-			"nodeType": "PageNode",
-			"details": {
-				"nodes": [{
-					"_id": "60732b03-b048-432e-be0f-cb13e211586e",
-					"nodeType": "ScriptedDecisionNode",
-					"displayName": "Scripted Decision"
-				}, {
-					"_id": "3633da1e-04fc-4d44-a6c8-b199cfade38a",
-					"nodeType": "OneTimePasswordCollectorDecisionNode",
-					"displayName": "OTP Collector Decision"
-				}],
-				"pageDescription": {
-					"desc": "Please enter the code you received"
-				},
-				"pageHeader": {
-					"header": "Please enter your code"
-				},
-				"stage": "CH_LOGIN_3"
-			}
-		},
-		{
-			"_id": "60732b03-b048-432e-be0f-cb13e211586e",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["True"],
-				"outputs": ["*"],
-				"script": "ace951c8-d169-4426-9357-d5b44e0aa728"
-			}
-		},
-		{
-			"_id": "3633da1e-04fc-4d44-a6c8-b199cfade38a",
-			"nodeType": "OneTimePasswordCollectorDecisionNode",
-			"details": {
-				"passwordExpiryTime": 30
-			}
-		},
-		{
-			"_id": "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc",
-			"nodeType": "RetryLimitDecisionNode",
-			"details": {
-				"retryLimit": 3
-			}
-		},
-		{
-			"_id": "739919ca-5a2b-4788-a447-36fe83a011f9",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true"],
-				"outputs": ["*"],
-				"script": "bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c"
-			}
-		},
-		{
-			"_id": "ae62ed05-3a04-456b-8642-7bc222e0dd43",
-			"nodeType": "IncrementLoginCountNode",
-			"details": {
-				"identityAttribute": "userName"
-			}
-		},
-		{
-			"_id": "bf46b661-96c6-443a-b012-3b5608b7051f",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true"],
-				"outputs": ["*"],
-				"script": "d7da3b35-af63-499b-aa0a-bb03666508db"
-			}
-		},
-		{
-			"_id": "f8d1e6a3-14d1-4eda-9515-6e0dfacad539",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "ProgressiveProfile"
-			}
-		},
-		{
-			"_id": "3b1940b6-a238-455e-8d13-ceb0f2848be4",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "064705f3-93d3-482c-ad3f-4531a28ce0a0"
-			}
-		},
-		{
-			"_id": "c99c82c6-20f5-456d-a94e-680c4f4a6307",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true", "false"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "188d3f9d-ca04-4df7-bcd7-eed3fe27e21e"
-			}
-		},
-		{
-			"_id": "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "a1ebbcd2-39c1-47c2-a152-4bebcf8cfb5b"
-			}
-		},
-		{
-			"_id": "bd940aa3-c854-4934-b67a-1183d89be21f",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["success", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-			}
-		},
-		{
-			"_id": "fa88fc01-a7a2-429f-b7cc-546fe67a70b4",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["locked", "error", "lock_expired", "not_locked"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "7837ccb6-2e56-44bf-a5df-7cfdb0bfc38b"
-			}
-		},
-		{
-			"_id": "fc36693f-b04c-46f8-a683-1e1c1498c8bd",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["success", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "329154d4-5e55-4cc5-a17e-19d4fd3729aa"
-			}
-		},
-		{
-			"_id": "6486165d-fb00-4248-93c8-4f36ad2b2cb1",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["success", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "329154d4-5e55-4cc5-a17e-19d4fd3729aa"
-			}
-		},
-		{
-			"_id": "9d8e176e-3175-45a5-8ff3-ca0138c1b300",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["success", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-			}
-		},
-		{
-			"_id": "4a8df6a5-8e56-4765-8ea0-2ff6200b6297",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "e0aec02a-ad8b-427d-a72e-cdfd8cb6c0e0"
-			}
-		},
-		{
-			"_id": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-			}
-		}
-	],
-    "tree": {
-		"_id": "CHLogin",
-		"description": "CH Platform Login Tree with MFA and legacy password check",
-		"identityResource": "managed/alpha_user",
-		"uiConfig": {},
-		"entryNodeId": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-		"nodes": {
-			"0e167098-4f1b-4a6d-a383-9a415b143dda": {
-				"x": 1992,
-				"y": 108.33333333333334,
-				"connections": {
-					"outcome": "860b9b8a-260a-4123-85f5-7cf50e20a291"
-				},
-				"nodeType": "OneTimePasswordGeneratorNode",
-				"displayName": "HOTP Generator"
-			},
-			"0e91440f-8d40-4946-88c9-1a7e22da57bc": {
-				"x": 1240,
-				"y": 31.5,
-				"connections": {
-					"false": "1031a228-600a-4325-82da-c93e6a13ab5b",
-					"true": "9339d5b3-f917-46a5-918e-a8b4ce884d81"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Has Phone Number"
-			},
-			"1031a228-600a-4325-82da-c93e6a13ab5b": {
-				"x": 1732,
-				"y": 248,
-				"connections": {
-					"false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"true": "c20b82fd-458d-4a46-8d0f-41d589f3976b"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Create Notify JWT - Email"
-			},
-			"3147767a-bb7b-47b2-9b43-6d297e7cc2fa": {
-				"x": 1732,
-				"y": 75,
-				"connections": {
-					"false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"true": "0e167098-4f1b-4a6d-a383-9a415b143dda"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Create Notify JWT - SMS"
-			},
-			"35194bf4-8dcc-41a2-8545-4a965b8f6ec0": {
-				"x": 2540,
-				"y": 64.015625,
-				"connections": {
-					"false": "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc",
-					"true": "ae62ed05-3a04-456b-8642-7bc222e0dd43"
-				},
-				"nodeType": "PageNode",
-				"displayName": "Enter OTP"
-			},
-			"4f019558-f468-46f2-8000-5bba1d9dac45": {
-				"x": 432,
-				"y": 80.015625,
-				"connections": {
-					"true": "bd940aa3-c854-4934-b67a-1183d89be21f",
-					"false": "4a8df6a5-8e56-4765-8ea0-2ff6200b6297"
-				},
-				"nodeType": "IdentifyExistingUserNode",
-				"displayName": "Identify Existing User"
-			},
-			"5e76d32e-9180-4a20-b0bd-ff9b89773cbb": {
-				"x": 2239,
-				"y": 260,
-				"connections": {
-					"false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Send MFA email via Notify"
-			},
-			"6486165d-fb00-4248-93c8-4f36ad2b2cb1": {
-				"x": 1239,
-				"y": 251.015625,
-				"connections": {
-					"error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"success": "c32fab79-8836-4657-bef0-9f03a1e1165f"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Reset Counter after login OK"
-			},
-			"739919ca-5a2b-4788-a447-36fe83a011f9": {
-				"x": 2967,
-				"y": 351.015625,
-				"connections": {
-					"true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Raise Error"
-			},
-			"758e3d0a-3211-4850-8847-86981f75888e": {
-				"x": 894,
-				"y": 394.015625,
-				"connections": {
-					"false": "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4",
-					"true": "9d8e176e-3175-45a5-8ff3-ca0138c1b300"
-				},
-				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Update Legacy Password"
-			},
-			"860b9b8a-260a-4123-85f5-7cf50e20a291": {
-				"x": 2246,
-				"y": 83,
-				"connections": {
-					"false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Send MFA text via Notify"
-			},
-			"9339d5b3-f917-46a5-918e-a8b4ce884d81": {
-				"x": 1469,
-				"y": 52.015625,
-				"connections": {
-					"email": "1031a228-600a-4325-82da-c93e6a13ab5b",
-					"text": "3147767a-bb7b-47b2-9b43-6d297e7cc2fa"
-				},
-				"nodeType": "PageNode",
-				"displayName": "Choose Email/SMS"
-			},
-			"94a5f48e-d6e3-4bf4-8edc-45c028a70900": {
-				"x": 218,
-				"y": 136,
-				"connections": {
-					"true": "c99c82c6-20f5-456d-a94e-680c4f4a6307"
-				},
-				"nodeType": "PageNode",
-				"displayName": "Login Form"
-			},
-			"9d8e176e-3175-45a5-8ff3-ca0138c1b300": {
-				"x": 1171,
-				"y": 422.015625,
-				"connections": {
-					"error": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"success": "6486165d-fb00-4248-93c8-4f36ad2b2cb1"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get New IDM Token"
-			},
-			"a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc": {
-				"x": 2732,
-				"y": 318.015625,
-				"connections": {
-					"Reject": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"Retry": "739919ca-5a2b-4788-a447-36fe83a011f9"
-				},
-				"nodeType": "RetryLimitDecisionNode",
-				"displayName": "Retry Limit Decision"
-			},
-			"ae62ed05-3a04-456b-8642-7bc222e0dd43": {
-				"x": 2810,
-				"y": 195.5,
-				"connections": {
-					"outcome": "bf46b661-96c6-443a-b012-3b5608b7051f"
-				},
-				"nodeType": "IncrementLoginCountNode",
-				"displayName": "Increment Login Count"
-			},
-			"bd940aa3-c854-4934-b67a-1183d89be21f": {
-				"x": 614,
-				"y": 13.015625,
-				"connections": {
-					"error": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"success": "fa88fc01-a7a2-429f-b7cc-546fe67a70b4"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM Token"
-			},
-			"bf46b661-96c6-443a-b012-3b5608b7051f": {
-				"x": 3059,
-				"y": 194.5,
-				"connections": {
-					"true": "f8d1e6a3-14d1-4eda-9515-6e0dfacad539"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Update Last Login"
-			},
-			"c20b82fd-458d-4a46-8d0f-41d589f3976b": {
-				"x": 1994,
-				"y": 285.66666666666663,
-				"connections": {
-					"outcome": "5e76d32e-9180-4a20-b0bd-ff9b89773cbb"
-				},
-				"nodeType": "OneTimePasswordGeneratorNode",
-				"displayName": "HOTP Generator"
-			},
-			"c32fab79-8836-4657-bef0-9f03a1e1165f": {
-				"x": 1032,
-				"y": 39.5,
-				"connections": {
-					"false": "ae62ed05-3a04-456b-8642-7bc222e0dd43",
-					"true": "0e91440f-8d40-4946-88c9-1a7e22da57bc"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Require MFA"
-			},
-			"c99c82c6-20f5-456d-a94e-680c4f4a6307": {
-				"x": 324,
-				"y": 442.015625,
-				"connections": {
-					"true": "4f019558-f468-46f2-8000-5bba1d9dac45",
-					"false": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "check format"
-			},
-			"d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4": {
-				"x": 700,
-				"y": 552.015625,
-				"connections": {
-					"error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"true": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Soft Lock Increment Counter"
-			},
-			"f8d1e6a3-14d1-4eda-9515-6e0dfacad539": {
-				"x": 3311,
-				"y": 172.5,
-				"connections": {
-					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
-					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
-				},
-				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Inner Tree Evaluator"
-			},
-			"fa88fc01-a7a2-429f-b7cc-546fe67a70b4": {
-				"x": 788,
-				"y": 120.015625,
-				"connections": {
-					"error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"lock_expired": "fc36693f-b04c-46f8-a683-1e1c1498c8bd",
-					"locked": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"not_locked": "758e3d0a-3211-4850-8847-86981f75888e"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check soft lock"
-			},
-			"fc36693f-b04c-46f8-a683-1e1c1498c8bd": {
-				"x": 691,
-				"y": 316.015625,
-				"connections": {
-					"error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"success": "758e3d0a-3211-4850-8847-86981f75888e"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Reset Counter"
-			},
-			"4a8df6a5-8e56-4765-8ea0-2ff6200b6297": {
-				"x": 324,
-				"y": 597.015625,
-				"connections": {
-					"true": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Login Error message"
-			},
-			"7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a": {
-				"x": 2261,
-				"y": 700.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "General Error"
-			}
-		},
-		"staticNodes": {
-			"startNode": {
-				"x": 70,
-				"y": 190
-			},
-			"70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-				"x": 3625,
-				"y": 196.66666666666666
-			},
-			"e301438c-0bd0-429c-ab0c-66126501069a": {
-				"x": 3639,
-				"y": 797.3333333333334
-			}
-		}
-	}
+  "nodes": [
+    {
+      "_id": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "a346e4e7-8490-4ec6-962f-ebb9ba51dbe6",
+            "nodeType": "ValidatedUsernameNode",
+            "displayName": "Platform Username"
+          },
+          {
+            "_id": "d28720a1-ad25-406b-baea-d3691f5122ea",
+            "nodeType": "ValidatedPasswordNode",
+            "displayName": "Platform Password"
+          },
+          {
+            "_id": "3b1940b6-a238-455e-8d13-ceb0f2848be4",
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "Error Handling"
+          }
+        ],
+        "pageDescription": {
+          "en": "New here? <a href=\"#/service/Registration\">Create an account</a><br><a href=\"#/service/ForgottenUsername\">Forgot username?</a><a href=\"#/service/ResetPassword\"> Forgot password?</a>"
+        },
+        "pageHeader": {
+          "en": "Sign In"
+        },
+        "stage": "CH_LOGIN_1"
+      }
+    },
+    {
+      "_id": "a346e4e7-8490-4ec6-962f-ebb9ba51dbe6",
+      "nodeType": "ValidatedUsernameNode",
+      "details": {
+        "usernameAttribute": "userName",
+        "validateInput": false
+      }
+    },
+    {
+      "_id": "d28720a1-ad25-406b-baea-d3691f5122ea",
+      "nodeType": "ValidatedPasswordNode",
+      "details": {
+        "passwordAttribute": "password",
+        "validateInput": false
+      }
+    },
+    {
+      "_id": "4f019558-f468-46f2-8000-5bba1d9dac45",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identifier": "userName",
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "758e3d0a-3211-4850-8847-86981f75888e",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHUpdateLegacyPassword"
+      }
+    },
+    {
+      "_id": "c32fab79-8836-4657-bef0-9f03a1e1165f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "20a3599f-b742-4554-a8b7-27862f248dd5"
+      }
+    },
+    {
+      "_id": "0e91440f-8d40-4946-88c9-1a7e22da57bc",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "b480d9f7-5908-45cf-91d1-bc1fe56fe8de"
+      }
+    },
+    {
+      "_id": "9339d5b3-f917-46a5-918e-a8b4ce884d81",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "7c1389a2-2b21-483b-a2f2-2e2ad42f52b2",
+            "nodeType": "ChoiceCollectorNode",
+            "displayName": "Choice Collector"
+          }
+        ],
+        "pageDescription": {
+          "desc": "How do you want to confirm it's you?"
+        },
+        "pageHeader": {
+          "header": "How do you want to confirm it's you?"
+        },
+        "stage": "CH_LOGIN_2"
+      }
+    },
+    {
+      "_id": "7c1389a2-2b21-483b-a2f2-2e2ad42f52b2",
+      "nodeType": "ChoiceCollectorNode",
+      "details": {
+        "choices": [
+          "email",
+          "text"
+        ],
+        "defaultChoice": "email",
+        "prompt": "How do you want to confirm it's you?"
+      }
+    },
+    {
+      "_id": "3147767a-bb7b-47b2-9b43-6d297e7cc2fa",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259"
+      }
+    },
+    {
+      "_id": "0e167098-4f1b-4a6d-a383-9a415b143dda",
+      "nodeType": "OneTimePasswordGeneratorNode",
+      "details": {
+        "length": 6
+      }
+    },
+    {
+      "_id": "860b9b8a-260a-4123-85f5-7cf50e20a291",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "b276c566-622e-11eb-ae93-0242ac130002"
+      }
+    },
+    {
+      "_id": "1031a228-600a-4325-82da-c93e6a13ab5b",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259"
+      }
+    },
+    {
+      "_id": "c20b82fd-458d-4a46-8d0f-41d589f3976b",
+      "nodeType": "OneTimePasswordGeneratorNode",
+      "details": {
+        "length": 6
+      }
+    },
+    {
+      "_id": "5e76d32e-9180-4a20-b0bd-ff9b89773cbb",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "a5778ce7-addf-4fb6-a7db-92929f1314c4"
+      }
+    },
+    {
+      "_id": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "60732b03-b048-432e-be0f-cb13e211586e",
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "Scripted Decision"
+          },
+          {
+            "_id": "3633da1e-04fc-4d44-a6c8-b199cfade38a",
+            "nodeType": "OneTimePasswordCollectorDecisionNode",
+            "displayName": "OTP Collector Decision"
+          }
+        ],
+        "pageDescription": {
+          "desc": "Please enter the code you received"
+        },
+        "pageHeader": {
+          "header": "Please enter your code"
+        },
+        "stage": "CH_LOGIN_3"
+      }
+    },
+    {
+      "_id": "60732b03-b048-432e-be0f-cb13e211586e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "True"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ace951c8-d169-4426-9357-d5b44e0aa728"
+      }
+    },
+    {
+      "_id": "3633da1e-04fc-4d44-a6c8-b199cfade38a",
+      "nodeType": "OneTimePasswordCollectorDecisionNode",
+      "details": {
+        "passwordExpiryTime": 30
+      }
+    },
+    {
+      "_id": "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "739919ca-5a2b-4788-a447-36fe83a011f9",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c"
+      }
+    },
+    {
+      "_id": "ae62ed05-3a04-456b-8642-7bc222e0dd43",
+      "nodeType": "IncrementLoginCountNode",
+      "details": {
+        "identityAttribute": "userName"
+      }
+    },
+    {
+      "_id": "bf46b661-96c6-443a-b012-3b5608b7051f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "d7da3b35-af63-499b-aa0a-bb03666508db"
+      }
+    },
+    {
+      "_id": "f8d1e6a3-14d1-4eda-9515-6e0dfacad539",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "ProgressiveProfile"
+      }
+    },
+    {
+      "_id": "3b1940b6-a238-455e-8d13-ceb0f2848be4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "064705f3-93d3-482c-ad3f-4531a28ce0a0"
+      }
+    },
+    {
+      "_id": "c99c82c6-20f5-456d-a94e-680c4f4a6307",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "188d3f9d-ca04-4df7-bcd7-eed3fe27e21e"
+      }
+    },
+    {
+      "_id": "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "a1ebbcd2-39c1-47c2-a152-4bebcf8cfb5b"
+      }
+    },
+    {
+      "_id": "bd940aa3-c854-4934-b67a-1183d89be21f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "fa88fc01-a7a2-429f-b7cc-546fe67a70b4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "locked",
+          "error",
+          "lock_expired",
+          "not_locked"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "7837ccb6-2e56-44bf-a5df-7cfdb0bfc38b"
+      }
+    },
+    {
+      "_id": "fc36693f-b04c-46f8-a683-1e1c1498c8bd",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "329154d4-5e55-4cc5-a17e-19d4fd3729aa"
+      }
+    },
+    {
+      "_id": "6486165d-fb00-4248-93c8-4f36ad2b2cb1",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "329154d4-5e55-4cc5-a17e-19d4fd3729aa"
+      }
+    },
+    {
+      "_id": "9d8e176e-3175-45a5-8ff3-ca0138c1b300",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "4a8df6a5-8e56-4765-8ea0-2ff6200b6297",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e0aec02a-ad8b-427d-a72e-cdfd8cb6c0e0"
+      }
+    },
+    {
+      "_id": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHLogin",
+    "description": "CH Platform Login Tree with MFA and legacy password check",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+    "nodes": {
+      "0e167098-4f1b-4a6d-a383-9a415b143dda": {
+        "x": 1992,
+        "y": 108.33333333333334,
+        "connections": {
+          "outcome": "860b9b8a-260a-4123-85f5-7cf50e20a291"
+        },
+        "nodeType": "OneTimePasswordGeneratorNode",
+        "displayName": "HOTP Generator"
+      },
+      "0e91440f-8d40-4946-88c9-1a7e22da57bc": {
+        "x": 1240,
+        "y": 31.5,
+        "connections": {
+          "false": "1031a228-600a-4325-82da-c93e6a13ab5b",
+          "true": "9339d5b3-f917-46a5-918e-a8b4ce884d81"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Has Phone Number"
+      },
+      "1031a228-600a-4325-82da-c93e6a13ab5b": {
+        "x": 1732,
+        "y": 248,
+        "connections": {
+          "false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "true": "c20b82fd-458d-4a46-8d0f-41d589f3976b"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT - Email"
+      },
+      "3147767a-bb7b-47b2-9b43-6d297e7cc2fa": {
+        "x": 1732,
+        "y": 75,
+        "connections": {
+          "false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "true": "0e167098-4f1b-4a6d-a383-9a415b143dda"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT - SMS"
+      },
+      "35194bf4-8dcc-41a2-8545-4a965b8f6ec0": {
+        "x": 2540,
+        "y": 64.015625,
+        "connections": {
+          "false": "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc",
+          "true": "ae62ed05-3a04-456b-8642-7bc222e0dd43"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Enter OTP"
+      },
+      "4f019558-f468-46f2-8000-5bba1d9dac45": {
+        "x": 432,
+        "y": 80.015625,
+        "connections": {
+          "true": "bd940aa3-c854-4934-b67a-1183d89be21f",
+          "false": "4a8df6a5-8e56-4765-8ea0-2ff6200b6297"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "5e76d32e-9180-4a20-b0bd-ff9b89773cbb": {
+        "x": 2239,
+        "y": 260,
+        "connections": {
+          "false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Send MFA email via Notify"
+      },
+      "6486165d-fb00-4248-93c8-4f36ad2b2cb1": {
+        "x": 1239,
+        "y": 251.015625,
+        "connections": {
+          "error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "success": "c32fab79-8836-4657-bef0-9f03a1e1165f"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Reset Counter after login OK"
+      },
+      "739919ca-5a2b-4788-a447-36fe83a011f9": {
+        "x": 2967,
+        "y": 351.015625,
+        "connections": {
+          "true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Raise Error"
+      },
+      "758e3d0a-3211-4850-8847-86981f75888e": {
+        "x": 894,
+        "y": 394.015625,
+        "connections": {
+          "false": "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4",
+          "true": "9d8e176e-3175-45a5-8ff3-ca0138c1b300"
+        },
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Update Legacy Password"
+      },
+      "860b9b8a-260a-4123-85f5-7cf50e20a291": {
+        "x": 2246,
+        "y": 83,
+        "connections": {
+          "false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Send MFA text via Notify"
+      },
+      "9339d5b3-f917-46a5-918e-a8b4ce884d81": {
+        "x": 1469,
+        "y": 52.015625,
+        "connections": {
+          "email": "1031a228-600a-4325-82da-c93e6a13ab5b",
+          "text": "3147767a-bb7b-47b2-9b43-6d297e7cc2fa"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Choose Email/SMS"
+      },
+      "94a5f48e-d6e3-4bf4-8edc-45c028a70900": {
+        "x": 218,
+        "y": 136,
+        "connections": {
+          "true": "c99c82c6-20f5-456d-a94e-680c4f4a6307"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Login Form"
+      },
+      "9d8e176e-3175-45a5-8ff3-ca0138c1b300": {
+        "x": 1171,
+        "y": 422.015625,
+        "connections": {
+          "error": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "success": "6486165d-fb00-4248-93c8-4f36ad2b2cb1"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get New IDM Token"
+      },
+      "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc": {
+        "x": 2732,
+        "y": 318.015625,
+        "connections": {
+          "Reject": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "Retry": "739919ca-5a2b-4788-a447-36fe83a011f9"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "ae62ed05-3a04-456b-8642-7bc222e0dd43": {
+        "x": 2810,
+        "y": 195.5,
+        "connections": {
+          "outcome": "bf46b661-96c6-443a-b012-3b5608b7051f"
+        },
+        "nodeType": "IncrementLoginCountNode",
+        "displayName": "Increment Login Count"
+      },
+      "bd940aa3-c854-4934-b67a-1183d89be21f": {
+        "x": 614,
+        "y": 13.015625,
+        "connections": {
+          "error": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "success": "fa88fc01-a7a2-429f-b7cc-546fe67a70b4"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Token"
+      },
+      "bf46b661-96c6-443a-b012-3b5608b7051f": {
+        "x": 3059,
+        "y": 194.5,
+        "connections": {
+          "true": "f8d1e6a3-14d1-4eda-9515-6e0dfacad539"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Update Last Login"
+      },
+      "c20b82fd-458d-4a46-8d0f-41d589f3976b": {
+        "x": 1994,
+        "y": 285.66666666666663,
+        "connections": {
+          "outcome": "5e76d32e-9180-4a20-b0bd-ff9b89773cbb"
+        },
+        "nodeType": "OneTimePasswordGeneratorNode",
+        "displayName": "HOTP Generator"
+      },
+      "c32fab79-8836-4657-bef0-9f03a1e1165f": {
+        "x": 1032,
+        "y": 39.5,
+        "connections": {
+          "false": "ae62ed05-3a04-456b-8642-7bc222e0dd43",
+          "true": "0e91440f-8d40-4946-88c9-1a7e22da57bc"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Require MFA"
+      },
+      "c99c82c6-20f5-456d-a94e-680c4f4a6307": {
+        "x": 324,
+        "y": 442.015625,
+        "connections": {
+          "true": "4f019558-f468-46f2-8000-5bba1d9dac45",
+          "false": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "check format"
+      },
+      "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4": {
+        "x": 700,
+        "y": 552.015625,
+        "connections": {
+          "error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "true": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Soft Lock Increment Counter"
+      },
+      "f8d1e6a3-14d1-4eda-9515-6e0dfacad539": {
+        "x": 3311,
+        "y": 172.5,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+        },
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Inner Tree Evaluator"
+      },
+      "fa88fc01-a7a2-429f-b7cc-546fe67a70b4": {
+        "x": 788,
+        "y": 120.015625,
+        "connections": {
+          "error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "lock_expired": "fc36693f-b04c-46f8-a683-1e1c1498c8bd",
+          "locked": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "not_locked": "758e3d0a-3211-4850-8847-86981f75888e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check soft lock"
+      },
+      "fc36693f-b04c-46f8-a683-1e1c1498c8bd": {
+        "x": 691,
+        "y": 316.015625,
+        "connections": {
+          "error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "success": "758e3d0a-3211-4850-8847-86981f75888e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Reset Counter"
+      },
+      "4a8df6a5-8e56-4765-8ea0-2ff6200b6297": {
+        "x": 324,
+        "y": 597.015625,
+        "connections": {
+          "true": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Login Error message"
+      },
+      "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a": {
+        "x": 2261,
+        "y": 700.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "General Error"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 70,
+        "y": 190
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 3625,
+        "y": 196.66666666666666
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 3639,
+        "y": 797.3333333333334
+      }
+    }
+  }
 }

--- a/config/auth-trees/ch-multi-factor-generic.json
+++ b/config/auth-trees/ch-multi-factor-generic.json
@@ -151,23 +151,6 @@
       }
     },
     {
-      "_id": "98541a2b-eb47-4344-9136-020eba006a6c",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "20a3599f-b742-4554-a8b7-27862f248dd5",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
       "_id": "9a94e91d-e442-4c2c-8018-23f0f8672f7b",
       "nodeType": "ScriptedDecisionNode",
       "details": {
@@ -358,23 +341,13 @@
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Has Phone Number"
       },
-      "98541a2b-eb47-4344-9136-020eba006a6c": {
-        "x": 551,
-        "y": 429.5,
-        "connections": {
-          "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-          "true": "cfdd2637-5058-475e-80a5-984e2f1f7141"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Require MFA"
-      },
       "9a94e91d-e442-4c2c-8018-23f0f8672f7b": {
         "x": 237.33333333333337,
         "y": 423.69270833333337,
         "connections": {
-          "default": "98541a2b-eb47-4344-9136-020eba006a6c",
           "forceEmail": "5877bfca-a540-4c93-a9cf-6081b66f9fe8",
-          "forceText": "d8bd9341-0bb4-49ff-a119-964e51146f74"
+          "forceText": "d8bd9341-0bb4-49ff-a119-964e51146f74",
+          "default": "cfdd2637-5058-475e-80a5-984e2f1f7141"
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Setup based on Calling Journey"

--- a/config/auth-trees/ch-password-reset.json
+++ b/config/auth-trees/ch-password-reset.json
@@ -1,632 +1,594 @@
 {
-    "nodes": [
-        {
-            "_id":"29524a97-032e-40b1-8cd0-ef3938309671",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["resume","start"],
-                "outputs":["*"],
-                "script":"7fc79258-1c54-4df3-baa4-b51850ef3474"
-            }            
-        },
-        {
-            "_id":"4a0a458b-f374-4a7e-a5ec-5352aa21f834",
-            "nodeType": "PageNode",
-            "details": {
-                "pageHeader":{
-                    "en":"Reset Password"
-                },
-                "pageDescription":{
-                    "en":"Enter your email address or <a href=\"#/service/Login\">Sign in</a>"
-                },
-                "nodes":[
-                    {
-                        "_id":"fa9ca089-6a40-4f8a-87bd-4fbc3b133f2b",
-                        "nodeType":"AttributeCollectorNode",
-                        "displayName":"Attribute Collector"
-                    }
-                ],
-                "stage":"RESET_PASSWORD_1"
-            }
-        },
-        {
-            "_id":"fa9ca089-6a40-4f8a-87bd-4fbc3b133f2b",
-            "nodeType": "AttributeCollectorNode",
-            "details": {
-                "attributesToCollect":["mail"],
-                "identityAttribute":"mail",
-                "required":false,
-                "validateInputs":true
-            }
-        },
-        {
-            "_id":"6de1f9ea-0421-4065-8b70-bed9152c9a05",
-            "nodeType": "IdentifyExistingUserNode",
-            "details": {
-                "identifier":"userName",
-                "identityAttribute":"mail"
-            }
-        },
-        {
-            "_id":"e5b2d3d4-0995-48ad-bf0c-ae2b8560387e",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"b480d9f7-5908-45cf-91d1-bc1fe56fe8de"
-            }            
-        },
-        {
-            "_id":"5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e",
-            "nodeType": "PageNode",
-            "details": {
-                "nodes":[
-                    {
-                        "_id":"79b4e46e-034a-42b0-8f86-8435451f633e",
-                        "nodeType":"ChoiceCollectorNode",
-                        "displayName":"Choice Collector"
-                    }
-                ],
-                "pageDescription":{
-                    "desc":"How do you want to confirm it's you?"
-                },
-                "pageHeader":{
-                    "header":"How do you want to confirm it's you?"
-                },
-                "stage":"RESET_PASSWORD_2"
-            }    
-        },
-        {
-            "_id":"79b4e46e-034a-42b0-8f86-8435451f633e",
-            "nodeType": "ChoiceCollectorNode",
-            "details": {
-                "choices":["email","text"],
-                "defaultChoice":"Email",
-                "prompt":"How do you want to confirm it's you?"
-            }
-        },
-        {
-            "_id":"8e86cb2b-52ab-4341-a89b-1379976c790a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-            }  
-        },
-        {
-            "_id":"79c759fc-b836-42b4-afd4-ad564d1bbe60",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-            }
-        },
-        {
-            "_id":"bb5fc733-547b-41da-9b51-f709cac78764",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"c056951c-622e-11eb-ae93-0242ac130002"
-            }   
-        },
-        {
-            "_id":"b39ecc00-d42f-4cff-8f2e-3256bb8b3669",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"a39f3f71-1782-46dc-97cf-7cc417d4ca4a"
-            }
-        },
-        {
-            "_id":"cfb95e8e-a908-40f3-a756-f5959759e22e",
-            "nodeType": "OneTimePasswordGeneratorNode", 
-            "details": {
-                "length":6
-            }    
-        },
-        {
-            "_id":"70a15b0f-cb2a-48a9-81f0-6ba902a9e24a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"b276c566-622e-11eb-ae93-0242ac130002"
-            }    
-        },
-        {
-            "_id":"843b8111-3af6-49fa-bf8d-a650e04dec2e",
-            "nodeType": "PageNode", 
-            "details": {
-                "nodes":[
-                    {
-                        "_id":"5d337edd-8b0e-4c2d-a6cc-ab4e30f1ecbd",
-                        "nodeType":"ScriptedDecisionNode",
-                        "displayName":"Scripted Decision"
-                     },
-                    {
-                        "_id":"229f3a48-ddba-4528-8c72-dd7c2e7d53cd",
-                        "nodeType":"OneTimePasswordCollectorDecisionNode",
-                        "displayName":"OTP Collector Decision"
-                    }
-                ],
-                "pageDescription":{
-                    "desc":"Please enter the code you received via SMS"
-                },
-                "pageHeader":{
-                    "header":"Please enter your code"
-                },
-                "stage":"RESET_PASSWORD_3"
-            }
-        },
-        {
-            "_id":"ff7ee39c-e731-438a-8bf0-8492d9ee61bd",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c"
-            }    
-        },
-        {
-            "_id":"229f3a48-ddba-4528-8c72-dd7c2e7d53cd",
-            "nodeType": "OneTimePasswordCollectorDecisionNode", 
-            "details": {
-                "passwordExpiryTime":5   
-            }
-        },
-        {
-            "_id":"5d337edd-8b0e-4c2d-a6cc-ab4e30f1ecbd",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["True"],
-                "outputs":["*"],
-                "script":"24b1421b-8130-4eae-a999-a44dc6e94fa6"
-            }
-        },
-        {
-            "_id":"067ea40b-8eb7-48b9-8de3-c9bf73103e2d",
-            "nodeType": "PatchObjectNode", 
-            "details": {
-                "identityAttribute":"mail",
-                "identityResource":"managed/alpha_user",
-                "ignoredFields":[],
-                "patchAsObject":false
-            }
-        },
-        {
-            "_id":"129a2a4d-ea48-4ea4-a02f-eff667ffcc0e",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"ae90c22f-2613-49a6-9091-2238ec13eacb"
-            }
-        },
-        {
-            "_id":"4b011f55-d230-407d-8e91-8c5d0f573133",
-            "nodeType": "IdentifyExistingUserNode",
-            "details": {
-                "identifier":"userName",
-                "identityAttribute":"mail"
-            }
-        },
-        {
-            "_id":"56c8d746-4a57-467b-bc70-8cb944e98d8e",
-            "nodeType": "PageNode", 
-            "details": {
-                "nodes":[
-                    {
-                        "_id":"36437c17-0c4f-4c3e-9fd1-05ec0f0bab6a",
-                        "nodeType":"ScriptedDecisionNode",
-                        "displayName":"Cannot Find User"
-                    }
-                ],
-                "pageDescription":{
-                    "desc":"Cannot Find User"
-                },
-                "pageHeader":{
-                    "header":"Cannot Find User"
-                },
-                "stage":"PASSWORD_RESET_ERROR"
-            }
-        },
-        {
-            "_id":"36437c17-0c4f-4c3e-9fd1-05ec0f0bab6a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["false"],
-                "outputs":["*"],
-                "script":"8f08bdfd-08b9-42ce-8f45-99da5bc9dcfd"
-            }
-        },
-        {
-            "_id":"c98726b2-cee9-47ba-9677-40ae29223c65",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit": 3
-            }
-        },
-        {
-            "_id":"d085bafb-b361-4992-a766-7ffa1a73b4a1",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"fdac4efb-d8b8-478b-8300-e11a4c3503df"
-            }
-        },
-        {
-            "_id": "a248803f-1e17-4c42-975f-9b18c9477b7d",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "256dac17-1055-4798-9b98-a1321f3a8f09"
-            }
-        },
-        {
-            "_id": "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true", "false"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6"
-            }
-        },
-        {
-            "_id": "c94755f5-ea1e-4b8e-84ba-deeaf652d30d",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true", "false"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6"
-            }
-        },
-        {
-            "_id": "dab16163-28f8-484b-84c6-ed45763d3423",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-                "script": "a15a784a-489e-49ee-af79-a7153447c843"
-            }
-        },
-        {
-            "_id": "67cda865-3a06-452a-aa12-09b85b29bf73",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-                "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }
-        },
-        {
-            "_id": "fe52863d-fc41-41ee-ac16-07f1ac238088",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["pass", "fail", "error"],
-                "outputs":["*"],
-                "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
-            }
-        },
-        {
-            "_id": "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false"],
-                "outputs":["*"],
-                "script": "84caf8b3-813a-4998-85ff-a3dd8eee4bcf"
-            }
-        },
-        {
-            "_id": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-                "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-            }
-        }
-    ],
-    "tree" : {
-        "_id": "CHResetPassword",
-        "description": "CH Reset Password Tree",
+  "nodes": [
+    {
+      "_id": "067ea40b-8eb7-48b9-8de3-c9bf73103e2d",
+      "nodeType": "PatchObjectNode",
+      "details": {
         "identityResource": "managed/alpha_user",
-        "uiConfig": {},
-        "entryNodeId": "c94755f5-ea1e-4b8e-84ba-deeaf652d30d",
-        "nodes": {
-            "067ea40b-8eb7-48b9-8de3-c9bf73103e2d": {
-                "x": 1714,
-                "y": 554,
-                "connections": {
-                    "FAILURE": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "PATCHED": "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e"
-                },
-                "nodeType": "PatchObjectNode",
-                "displayName": "Update Password"
-            },
-            "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e": {
-                "x": 1928,
-                "y": 579,
-                "connections": {},
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Password Updated"
-            },
-            "29524a97-032e-40b1-8cd0-ef3938309671": {
-                "x": 233,
-                "y": 385,
-                "connections": {
-                    "resume": "4b011f55-d230-407d-8e91-8c5d0f573133",
-                    "start": "4a0a458b-f374-4a7e-a5ec-5352aa21f834"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Start or Resume"
-            },
-            "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27": {
-                "x": 1452,
-                "y": 483.015625,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "a248803f-1e17-4c42-975f-9b18c9477b7d"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Load password for patch"
-            },
-            "4a0a458b-f374-4a7e-a5ec-5352aa21f834": {
-                "x": 213,
-                "y": 27,
-                "connections": {
-                    "outcome": "6de1f9ea-0421-4065-8b70-bed9152c9a05"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Enter Email"
-            },
-            "4b011f55-d230-407d-8e91-8c5d0f573133": {
-                "x": 389,
-                "y": 622,
-                "connections": {
-                    "false": "56c8d746-4a57-467b-bc70-8cb944e98d8e",
-                    "true": "dab16163-28f8-484b-84c6-ed45763d3423"
-                },
-                "nodeType": "IdentifyExistingUserNode",
-                "displayName": "Identify Existing User 2"
-            },
-            "56c8d746-4a57-467b-bc70-8cb944e98d8e": {
-                "x": 720,
-                "y": 738,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Cannot Find User"
-            },
-            "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e": {
-                "x": 453,
-                "y": 286,
-                "connections": {
-                    "email": "8e86cb2b-52ab-4341-a89b-1379976c790a",
-                    "text": "79c759fc-b836-42b4-afd4-ad564d1bbe60"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Choose Email/SMS"
-            },
-            "67cda865-3a06-452a-aa12-09b85b29bf73": {
-                "x": 1323,
-                "y": 364.015625,
-                "connections": {
-                    "error": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "success": "fe52863d-fc41-41ee-ac16-07f1ac238088"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Get IDM token"
-            },
-            "6de1f9ea-0421-4065-8b70-bed9152c9a05": {
-                "x": 541,
-                "y": 29,
-                "connections": {
-                    "false": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669",
-                    "true": "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e"
-                },
-                "nodeType": "IdentifyExistingUserNode",
-                "displayName": "Identify Existing User 1"
-            },
-            "70a15b0f-cb2a-48a9-81f0-6ba902a9e24a": {
-                "x": 840,
-                "y": 528,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "843b8111-3af6-49fa-bf8d-a650e04dec2e"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Send MFA text"
-            },
-            "79c759fc-b836-42b4-afd4-ad564d1bbe60": {
-                "x": 690,
-                "y": 336,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "cfb95e8e-a908-40f3-a756-f5959759e22e"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Create Notify JWT - SMS"
-            },
-            "7caa061d-3986-453b-9e95-deeb3bd914f3": {
-                "x": 1790,
-                "y": 55.015625,
-                "connections": {},
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Generic Error"
-            },
-            "843b8111-3af6-49fa-bf8d-a650e04dec2e": {
-                "x": 1014,
-                "y": 618,
-                "connections": {
-                    "false": "c98726b2-cee9-47ba-9677-40ae29223c65",
-                    "true": "dab16163-28f8-484b-84c6-ed45763d3423"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Enter OTP"
-            },
-            "8e86cb2b-52ab-4341-a89b-1379976c790a": {
-                "x": 732,
-                "y": 171,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Create Notify JWT - Email"
-            },
-            "a248803f-1e17-4c42-975f-9b18c9477b7d": {
-                "x": 1689,
-                "y": 704.015625,
-                "connections": {
-                    "true": "067ea40b-8eb7-48b9-8de3-c9bf73103e2d"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Reset Parameters"
-            },
-            "b39ecc00-d42f-4cff-8f2e-3256bb8b3669": {
-                "x": 1425,
-                "y": 20,
-                "connections": {},
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Email sent ok "
-            },
-            "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5": {
-                "x": 934,
-                "y": 49.015625,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "bb5fc733-547b-41da-9b51-f709cac78764"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Load Keys"
-            },
-            "bb5fc733-547b-41da-9b51-f709cac78764": {
-                "x": 1142,
-                "y": 65,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Send Pwd Reset Email"
-            },
-            "c94755f5-ea1e-4b8e-84ba-deeaf652d30d": {
-                "x": 105,
-                "y": 268.015625,
-                "connections": {
-                    "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "true": "29524a97-032e-40b1-8cd0-ef3938309671"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Load Keys"
-            },
-            "c98726b2-cee9-47ba-9677-40ae29223c65": {
-                "x": 1250,
-                "y": 762.015625,
-                "connections": {
-                    "Reject": "d085bafb-b361-4992-a766-7ffa1a73b4a1",
-                    "Retry": "ff7ee39c-e731-438a-8bf0-8492d9ee61bd"
-                },
-                "nodeType": "RetryLimitDecisionNode",
-                "displayName": "Retry Limit Decision"
-            },
-            "cfb95e8e-a908-40f3-a756-f5959759e22e": {
-                "x": 763,
-                "y": 458,
-                "connections": {
-                    "outcome": "70a15b0f-cb2a-48a9-81f0-6ba902a9e24a"
-                },
-                "nodeType": "OneTimePasswordGeneratorNode",
-                "displayName": "HOTP Generator"
-            },
-            "d085bafb-b361-4992-a766-7ffa1a73b4a1": {
-                "x": 1461,
-                "y": 876.015625,
-                "connections": {},
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Max Attempts message"
-            },
-            "dab16163-28f8-484b-84c6-ed45763d3423": {
-                "x": 1188,
-                "y": 494.015625,
-                "connections": {
-                    "success": "67cda865-3a06-452a-aa12-09b85b29bf73",
-                    "error": "7caa061d-3986-453b-9e95-deeb3bd914f3"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Pwd Collector"
-            },
-            "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e": {
-                "x": 427,
-                "y": 151,
-                "connections": {
-                    "false": "8e86cb2b-52ab-4341-a89b-1379976c790a",
-                    "true": "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Has Phone Number"
-            },
-            "fe52863d-fc41-41ee-ac16-07f1ac238088": {
-                "x": 1628,
-                "y": 327.015625,
-                "connections": {
-                    "error": "7caa061d-3986-453b-9e95-deeb3bd914f3",
-                    "fail": "dab16163-28f8-484b-84c6-ed45763d3423",
-                    "pass": "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check Pwd policy"
-            },
-            "ff7ee39c-e731-438a-8bf0-8492d9ee61bd": {
-                "x": 1119,
-                "y": 942,
-                "connections": {
-                    "true": "843b8111-3af6-49fa-bf8d-a650e04dec2e"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Raise Error"
-            }
+        "patchAsObject": false,
+        "ignoredFields": [],
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "ae90c22f-2613-49a6-9091-2238ec13eacb",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "29524a97-032e-40b1-8cd0-ef3938309671",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "7fc79258-1c54-4df3-baa4-b51850ef3474",
+        "outcomes": [
+          "resume",
+          "start"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "84caf8b3-813a-4998-85ff-a3dd8eee4bcf",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "4a0a458b-f374-4a7e-a5ec-5352aa21f834",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "fa9ca089-6a40-4f8a-87bd-4fbc3b133f2b",
+            "nodeType": "AttributeCollectorNode",
+            "displayName": "Attribute Collector"
+          }
+        ],
+        "pageDescription": {
+          "en": "Enter your email address or <a href=\"#/service/Login\">Sign in</a>"
         },
-        "staticNodes": {
-            "startNode": {
-                "x": 25,
-                "y": 25
-            },
-            "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-                "x": 1896,
-                "y": 273
-            },
-            "e301438c-0bd0-429c-ab0c-66126501069a": {
-                "x": 1916,
-                "y": 154
-            }
+        "stage": "RESET_PASSWORD_1",
+        "pageHeader": {
+          "en": "Reset Password"
         }
+      }
+    },
+    {
+      "_id": "fa9ca089-6a40-4f8a-87bd-4fbc3b133f2b",
+      "nodeType": "AttributeCollectorNode",
+      "details": {
+        "attributesToCollect": [
+          "mail"
+        ],
+        "identityAttribute": "mail",
+        "validateInputs": true,
+        "required": false
+      }
+    },
+    {
+      "_id": "4b011f55-d230-407d-8e91-8c5d0f573133",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identityAttribute": "mail",
+        "identifier": "userName"
+      }
+    },
+    {
+      "_id": "56c8d746-4a57-467b-bc70-8cb944e98d8e",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "36437c17-0c4f-4c3e-9fd1-05ec0f0bab6a",
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "Cannot Find User"
+          }
+        ],
+        "pageDescription": {
+          "desc": "Cannot Find User"
+        },
+        "stage": "PASSWORD_RESET_ERROR",
+        "pageHeader": {
+          "header": "Cannot Find User"
+        }
+      }
+    },
+    {
+      "_id": "36437c17-0c4f-4c3e-9fd1-05ec0f0bab6a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "8f08bdfd-08b9-42ce-8f45-99da5bc9dcfd",
+        "outcomes": [
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "79b4e46e-034a-42b0-8f86-8435451f633e",
+            "nodeType": "ChoiceCollectorNode",
+            "displayName": "Choice Collector"
+          }
+        ],
+        "pageDescription": {
+          "desc": "How do you want to confirm it's you?"
+        },
+        "stage": "RESET_PASSWORD_2",
+        "pageHeader": {
+          "header": "How do you want to confirm it's you?"
+        }
+      }
+    },
+    {
+      "_id": "79b4e46e-034a-42b0-8f86-8435451f633e",
+      "nodeType": "ChoiceCollectorNode",
+      "details": {
+        "defaultChoice": "Email",
+        "choices": [
+          "email",
+          "text"
+        ],
+        "prompt": "How do you want to confirm it's you?"
+      }
+    },
+    {
+      "_id": "67cda865-3a06-452a-aa12-09b85b29bf73",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149",
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "6de1f9ea-0421-4065-8b70-bed9152c9a05",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identityAttribute": "mail",
+        "identifier": "userName"
+      }
+    },
+    {
+      "_id": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "8e86cb2b-52ab-4341-a89b-1379976c790a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "a248803f-1e17-4c42-975f-9b18c9477b7d",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "256dac17-1055-4798-9b98-a1321f3a8f09",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "a39f3f71-1782-46dc-97cf-7cc417d4ca4a",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "bb5fc733-547b-41da-9b51-f709cac78764",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "c056951c-622e-11eb-ae93-0242ac130002",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "c94755f5-ea1e-4b8e-84ba-deeaf652d30d",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "dab16163-28f8-484b-84c6-ed45763d3423",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "a15a784a-489e-49ee-af79-a7153447c843",
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "b480d9f7-5908-45cf-91d1-bc1fe56fe8de",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "fe52863d-fc41-41ee-ac16-07f1ac238088",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf",
+        "outcomes": [
+          "pass",
+          "fail",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "8727a90b-c53b-4e04-bdfd-e806654022bf",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHMultiFactorGeneric"
+      }
     }
+  ],
+  "tree": {
+    "_id": "CHResetPassword",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "c94755f5-ea1e-4b8e-84ba-deeaf652d30d",
+    "nodes": {
+      "067ea40b-8eb7-48b9-8de3-c9bf73103e2d": {
+        "x": 1714,
+        "y": 554,
+        "connections": {
+          "FAILURE": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "PATCHED": "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e"
+        },
+        "nodeType": "PatchObjectNode",
+        "displayName": "Update Password"
+      },
+      "129a2a4d-ea48-4ea4-a02f-eff667ffcc0e": {
+        "x": 1928,
+        "y": 579,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Password Updated"
+      },
+      "29524a97-032e-40b1-8cd0-ef3938309671": {
+        "x": 233,
+        "y": 385,
+        "connections": {
+          "resume": "4b011f55-d230-407d-8e91-8c5d0f573133",
+          "start": "4a0a458b-f374-4a7e-a5ec-5352aa21f834"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Start or Resume"
+      },
+      "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27": {
+        "x": 1327,
+        "y": 592.015625,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "a248803f-1e17-4c42-975f-9b18c9477b7d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load password for patch"
+      },
+      "4a0a458b-f374-4a7e-a5ec-5352aa21f834": {
+        "x": 213,
+        "y": 27,
+        "connections": {
+          "outcome": "6de1f9ea-0421-4065-8b70-bed9152c9a05"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Enter Email"
+      },
+      "4b011f55-d230-407d-8e91-8c5d0f573133": {
+        "x": 389,
+        "y": 622,
+        "connections": {
+          "false": "56c8d746-4a57-467b-bc70-8cb944e98d8e",
+          "true": "dab16163-28f8-484b-84c6-ed45763d3423"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User 2"
+      },
+      "56c8d746-4a57-467b-bc70-8cb944e98d8e": {
+        "x": 720,
+        "y": 738,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Cannot Find User"
+      },
+      "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e": {
+        "x": 453,
+        "y": 286,
+        "connections": {
+          "email": "8e86cb2b-52ab-4341-a89b-1379976c790a",
+          "text": "8727a90b-c53b-4e04-bdfd-e806654022bf"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Choose Email/SMS"
+      },
+      "67cda865-3a06-452a-aa12-09b85b29bf73": {
+        "x": 1323,
+        "y": 364.015625,
+        "connections": {
+          "error": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "success": "fe52863d-fc41-41ee-ac16-07f1ac238088"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM token"
+      },
+      "6de1f9ea-0421-4065-8b70-bed9152c9a05": {
+        "x": 541,
+        "y": 29,
+        "connections": {
+          "false": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669",
+          "true": "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User 1"
+      },
+      "7caa061d-3986-453b-9e95-deeb3bd914f3": {
+        "x": 1790,
+        "y": 55.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Generic Error"
+      },
+      "8e86cb2b-52ab-4341-a89b-1379976c790a": {
+        "x": 732,
+        "y": 171,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT - Email"
+      },
+      "a248803f-1e17-4c42-975f-9b18c9477b7d": {
+        "x": 1689,
+        "y": 704.015625,
+        "connections": {
+          "true": "067ea40b-8eb7-48b9-8de3-c9bf73103e2d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Reset Parameters"
+      },
+      "b39ecc00-d42f-4cff-8f2e-3256bb8b3669": {
+        "x": 1425,
+        "y": 20,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Email sent ok "
+      },
+      "b751ee34-7b44-4e4c-ae0c-9dc3b22199c5": {
+        "x": 934,
+        "y": 49.015625,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "bb5fc733-547b-41da-9b51-f709cac78764"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load Keys"
+      },
+      "bb5fc733-547b-41da-9b51-f709cac78764": {
+        "x": 1142,
+        "y": 65,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "b39ecc00-d42f-4cff-8f2e-3256bb8b3669"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Send Pwd Reset Email"
+      },
+      "c94755f5-ea1e-4b8e-84ba-deeaf652d30d": {
+        "x": 105,
+        "y": 268.015625,
+        "connections": {
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "true": "29524a97-032e-40b1-8cd0-ef3938309671"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load Keys"
+      },
+      "dab16163-28f8-484b-84c6-ed45763d3423": {
+        "x": 959,
+        "y": 460.015625,
+        "connections": {
+          "success": "67cda865-3a06-452a-aa12-09b85b29bf73",
+          "error": "7caa061d-3986-453b-9e95-deeb3bd914f3"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Pwd Collector"
+      },
+      "e5b2d3d4-0995-48ad-bf0c-ae2b8560387e": {
+        "x": 427,
+        "y": 151,
+        "connections": {
+          "false": "8e86cb2b-52ab-4341-a89b-1379976c790a",
+          "true": "5fc9e55b-6a0a-454d-89ce-b7c1b4d6a29e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Has Phone Number"
+      },
+      "fe52863d-fc41-41ee-ac16-07f1ac238088": {
+        "x": 1628,
+        "y": 327.015625,
+        "connections": {
+          "error": "7caa061d-3986-453b-9e95-deeb3bd914f3",
+          "fail": "dab16163-28f8-484b-84c6-ed45763d3423",
+          "pass": "3d9bdc2a-ffb7-4ba3-8259-4bc98dcbac27"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Pwd policy"
+      },
+      "8727a90b-c53b-4e04-bdfd-e806654022bf": {
+        "x": 751,
+        "y": 359.015625,
+        "connections": {
+          "true": "dab16163-28f8-484b-84c6-ed45763d3423",
+          "false": "7caa061d-3986-453b-9e95-deeb3bd914f3"
+        },
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Check OTP SubFlow"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 25,
+        "y": 25
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1896,
+        "y": 273
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1916,
+        "y": 154
+      }
+    },
+    "description": "CH Reset Password Tree"
+  }
 }

--- a/config/auth-trees/ch-registration-start.json
+++ b/config/auth-trees/ch-registration-start.json
@@ -1,448 +1,397 @@
 {
-   "nodes": [
-      {
-         "_id":"eb711261-5253-4e17-9357-43e175a5005d",
-         "nodeType": "PageNode",
-         "details": {
-            "stage":"REGISTRATION_1",
-            "nodes":[
-               {
-                  "_id":"f07f1b4a-8aef-4c53-b04f-e41fd06ed859",
-                  "nodeType":"AttributeCollectorNode",
-                  "displayName":"Attribute Collector"
-               }
-            ],
-            "pageDescription":{
-               "en":"Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>"
-            },
-            "pageHeader":{
-               "en":"Sign Up"
-            }
-         }         
-      },
-      {
-         "_id":"f07f1b4a-8aef-4c53-b04f-e41fd06ed859",     
-         "nodeType": "AttributeCollectorNode",
-         "details": {
-            "attributesToCollect":[
-               "givenName",
-               "mail",
-               "telephoneNumber"
-            ],
-            "identityAttribute":"userName",
-            "required":false,
-            "validateInputs":true
-         }
-      },
-      {
-         "_id":"997cc39b-afde-4935-b9b5-a0d4e3034072",
-         "nodeType": "ScriptedDecisionNode",    
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-         }      
-      },
-      {
-         "_id":"9e02588a-e4ac-4b08-b10f-ad8f298ae720",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"b6ca4a1f-573f-4a3a-a410-d18b01207f6e"
-         }
-      },
-      {
-         "_id":"a87fa542-b6d3-49a1-bbdf-30370ae7042e",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["false","true"],
-            "outputs":["*"],
-            "script":"000c65e1-c9c6-4edb-96d2-298a9b152b40"
-         }
-      },
-      {
-         "_id":"5c7f4247-3b01-4dae-b18b-1d90ee710891",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["false","true"],
-            "outputs":["*"],
-            "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-         }
-      },
-      {
-         "_id":"27ec8bc7-d2ed-4877-b8bd-ebd84d5b9994",
-         "nodeType": "OneTimePasswordGeneratorNode", 
-         "details": {
-            "length":6
-         }
-      },
-      {
-         "_id":"37a1f12f-1e7b-4ca2-a870-040bf63291a0",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"b276c566-622e-11eb-ae93-0242ac130002"
-         }
-      },   
-      {
-         "_id":"42d22a17-4022-4d9a-8cc2-2ef7b2fd331c",
-         "nodeType": "PageNode", 
-         "details": {
-             "nodes":[
-                 {
-                     "_id":"6b8324ab-700c-40f9-a138-f03f25c425aa",
-                     "nodeType":"ScriptedDecisionNode",
-                     "displayName":"Scripted Decision"
-                  },
-                 {
-                     "_id":"0ab69626-b411-41d0-8744-c2313b74fd93",
-                     "nodeType":"OneTimePasswordCollectorDecisionNode",
-                     "displayName":"OTP Collector Decision"
-                 }
-             ],
-             "pageDescription":{
-                 "desc":"Please enter the code you received via SMS"
-             },
-             "pageHeader":{
-                 "header":"Please enter your code"
-             },
-             "stage":"REGISTRATION_MFA"
-         }
-     },
-     {
-         "_id":"6b8324ab-700c-40f9-a138-f03f25c425aa",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["True"],
-            "outputs":["*"],
-            "script":"24b1421b-8130-4eae-a999-a44dc6e94fa6"
-         }
-      },
-      {
-            "_id":"0ab69626-b411-41d0-8744-c2313b74fd93",
-            "nodeType": "OneTimePasswordCollectorDecisionNode", 
-            "details": {
-               "passwordExpiryTime":5   
-            }
-      },
-      {
-         "_id":"2eaa7c69-f97d-4bbf-b8b0-2214832cbc6f",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true"],
-            "outputs":["*"],
-            "script":"bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c"
-         }    
-      },
-      {
-         "_id":"14a23247-eeb0-436c-99dd-1b046fc1204f",
-         "nodeType": "RetryLimitDecisionNode", 
-         "details": {
-            "retryLimit": 3
-         }
-      },
-      {
-         "_id":"30518af8-5af3-45e1-bd23-d404e13d922b",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes": ["resend", "change_email"],
-            "outputs":["*"],
-            "script":"8b203967-fa57-4ce2-9dad-2f387ca52a61"
-         }    
-      },
-      {
-         "_id":"817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea",
-         "nodeType": "IdentifyExistingUserNode", 
-         "details": {
-            "identifier":"userName",
-            "identityAttribute":"mail"
-         }
-      },
-      {
-         "_id":"453352a5-1e8a-4696-a439-0f09555ebc4f",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true"],
-            "outputs":["*"],
-            "script":"d67457d4-b0ed-4b77-9ca1-23295246c9fd"
-         }    
-      },
-      {
-         "_id":"26f0bca6-8070-4d16-a5bc-8c3136e0057e",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"df67765e-df3a-4503-9ba5-35c992b39259"
-         }
-      },   
-      {
-         "_id":"24595c6d-40a2-4592-a8f2-7823bb5d84be",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script":"c056951c-622e-11eb-ae93-0242ac130002"
-         }
-      },
-      {
-         "_id": "0245c9e5-297b-4092-9e40-e3453f3581b6",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6"
-         }
-      },
-      {
-         "_id": "d4cff847-705b-44ed-81c9-c9da0ece05b5",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes":["true","false"],
-            "outputs":["*"],
-            "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6"
-         }
-      },
-      {
-         "_id": "6ca3881c-7762-4280-a8be-692395b136d4",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes": ["true"],
-            "outputs":["*"],
-            "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-         }
-      },
-      {
-         "_id": "781e185e-f4da-442b-9fcd-827a4f235066",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "inputs":["*"],
-            "outcomes": ["resend", "change_email", "error"],
-            "outputs":["*"],
-            "script": "3e1aa9b2-7ca9-4292-8378-a08b27f09fd5"
-         }
-      }      
-   ],
-   "tree": {
-      "_id": "CHRegistration",
-      "description": "Registration Tree for CH Users - First part (email sending)",
-      "identityResource": "managed/alpha_user",
-      "uiConfig": {},
-      "entryNodeId": "eb711261-5253-4e17-9357-43e175a5005d",
-      "nodes": {
-         "0245c9e5-297b-4092-9e40-e3453f3581b6": {
-            "x": 497,
-            "y": 747.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "24595c6d-40a2-4592-a8f2-7823bb5d84be"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Load Keys"
-         },
-         "14a23247-eeb0-436c-99dd-1b046fc1204f": {
-            "x": 1276,
-            "y": 346.015625,
-            "connections": {
-               "Reject": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "Retry": "2eaa7c69-f97d-4bbf-b8b0-2214832cbc6f"
-            },
-            "nodeType": "RetryLimitDecisionNode",
-            "displayName": "Retry Limit Decision"
-         },
-         "24595c6d-40a2-4592-a8f2-7823bb5d84be": {
-            "x": 714,
-            "y": 829.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "30518af8-5af3-45e1-bd23-d404e13d922b"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Send Pwd Reset email"
-         },
-         "26f0bca6-8070-4d16-a5bc-8c3136e0057e": {
-            "x": 436,
-            "y": 601.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "0245c9e5-297b-4092-9e40-e3453f3581b6"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Notify JWT"
-         },
-         "27ec8bc7-d2ed-4877-b8bd-ebd84d5b9994": {
-            "x": 772,
-            "y": 586.015625,
-            "connections": {
-               "outcome": "37a1f12f-1e7b-4ca2-a870-040bf63291a0"
-            },
-            "nodeType": "OneTimePasswordGeneratorNode",
-            "displayName": "HOTP Generator"
-         },
-         "2eaa7c69-f97d-4bbf-b8b0-2214832cbc6f": {
-            "x": 1195,
-            "y": 606.015625,
-            "connections": {
-               "true": "42d22a17-4022-4d9a-8cc2-2ef7b2fd331c"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "OTP not valid"
-         },
-         "30518af8-5af3-45e1-bd23-d404e13d922b": {
-            "x": 1724,
-            "y": 143.015625,
-            "connections": {
-               "resend": "781e185e-f4da-442b-9fcd-827a4f235066",
-               "change_email": "eb711261-5253-4e17-9357-43e175a5005d"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Email Sent Confirmation"
-         },
-         "37a1f12f-1e7b-4ca2-a870-040bf63291a0": {
-            "x": 981,
-            "y": 715.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "42d22a17-4022-4d9a-8cc2-2ef7b2fd331c"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Send OTP"
-         },
-         "42d22a17-4022-4d9a-8cc2-2ef7b2fd331c": {
-            "x": 1013,
-            "y": 369.015625,
-            "connections": {
-               "false": "14a23247-eeb0-436c-99dd-1b046fc1204f",
-               "true": "997cc39b-afde-4935-b9b5-a0d4e3034072"
-            },
-            "nodeType": "PageNode",
-            "displayName": "OTP page"
-         },
-         "453352a5-1e8a-4696-a439-0f09555ebc4f": {
-            "x": 342,
-            "y": 484.015625,
-            "connections": {
-               "true": "26f0bca6-8070-4d16-a5bc-8c3136e0057e"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Set User Existing"
-         },
-         "5c7f4247-3b01-4dae-b18b-1d90ee710891": {
-            "x": 654,
-            "y": 365.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "27ec8bc7-d2ed-4877-b8bd-ebd84d5b9994"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Notify JWT - SMS"
-         },
-         "6ca3881c-7762-4280-a8be-692395b136d4": {
-            "x": 1847,
-            "y": 302.015625,
-            "connections": {},
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "General Error"
-         },
-         "781e185e-f4da-442b-9fcd-827a4f235066": {
-            "x": 1171,
-            "y": 213.015625,
-            "connections": {
-               "change_email": "eb711261-5253-4e17-9357-43e175a5005d",
-               "resend": "997cc39b-afde-4935-b9b5-a0d4e3034072"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Resend Or Change address"
-         },
-         "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea": {
-            "x": 245,
-            "y": 244.015625,
-            "connections": {
-               "false": "a87fa542-b6d3-49a1-bbdf-30370ae7042e",
-               "true": "453352a5-1e8a-4696-a439-0f09555ebc4f"
-            },
-            "nodeType": "IdentifyExistingUserNode",
-            "displayName": "Identify Existing User"
-         },
-         "997cc39b-afde-4935-b9b5-a0d4e3034072": {
-            "x": 894,
-            "y": 110,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "d4cff847-705b-44ed-81c9-c9da0ece05b5"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Notify JWT - Email"
-         },
-         "9e02588a-e4ac-4b08-b10f-ad8f298ae720": {
-            "x": 1465,
-            "y": 57.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "30518af8-5af3-45e1-bd23-d404e13d922b"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create & Email link"
-         },
-         "a87fa542-b6d3-49a1-bbdf-30370ae7042e": {
-            "x": 588,
-            "y": 107.015625,
-            "connections": {
-               "false": "997cc39b-afde-4935-b9b5-a0d4e3034072",
-               "true": "5c7f4247-3b01-4dae-b18b-1d90ee710891"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Check phone entered"
-         },
-         "d4cff847-705b-44ed-81c9-c9da0ece05b5": {
-            "x": 1198,
-            "y": 36.015625,
-            "connections": {
-               "false": "6ca3881c-7762-4280-a8be-692395b136d4",
-               "true": "9e02588a-e4ac-4b08-b10f-ad8f298ae720"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Load Keys"
-         },
-         "eb711261-5253-4e17-9357-43e175a5005d": {
-            "x": 231,
-            "y": 57,
-            "connections": {
-               "outcome": "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea"
-            },
-            "nodeType": "PageNode",
-            "displayName": "Email Collector"
-         }
-      },
-      "staticNodes": {
-         "startNode": {
-            "x": 70,
-            "y": 80
-         },
-         "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-            "x": 1764,
-            "y": 501
-         },
-         "e301438c-0bd0-429c-ab0c-66126501069a": {
-            "x": 1901,
-            "y": 502
-         }
+  "nodes": [
+    {
+      "_id": "0245c9e5-297b-4092-9e40-e3453f3581b6",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
       }
-   }
+    },
+    {
+      "_id": "24595c6d-40a2-4592-a8f2-7823bb5d84be",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "c056951c-622e-11eb-ae93-0242ac130002",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "26f0bca6-8070-4d16-a5bc-8c3136e0057e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "30518af8-5af3-45e1-bd23-d404e13d922b",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "8b203967-fa57-4ce2-9dad-2f387ca52a61",
+        "outcomes": [
+          "resend",
+          "change_email"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "453352a5-1e8a-4696-a439-0f09555ebc4f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "d67457d4-b0ed-4b77-9ca1-23295246c9fd",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "6ca3881c-7762-4280-a8be-692395b136d4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "781e185e-f4da-442b-9fcd-827a4f235066",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "3e1aa9b2-7ca9-4292-8378-a08b27f09fd5",
+        "outcomes": [
+          "resend",
+          "change_email",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identityAttribute": "mail",
+        "identifier": "userName"
+      }
+    },
+    {
+      "_id": "997cc39b-afde-4935-b9b5-a0d4e3034072",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "9e02588a-e4ac-4b08-b10f-ad8f298ae720",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "b6ca4a1f-573f-4a3a-a410-d18b01207f6e",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "a87fa542-b6d3-49a1-bbdf-30370ae7042e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "000c65e1-c9c6-4edb-96d2-298a9b152b40",
+        "outcomes": [
+          "false",
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "d4cff847-705b-44ed-81c9-c9da0ece05b5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "1a6815f1-0272-490b-8d6b-69609c3ee9d6",
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
+    },
+    {
+      "_id": "eb711261-5253-4e17-9357-43e175a5005d",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "f07f1b4a-8aef-4c53-b04f-e41fd06ed859",
+            "nodeType": "AttributeCollectorNode",
+            "displayName": "Attribute Collector"
+          }
+        ],
+        "stage": "REGISTRATION_1",
+        "pageDescription": {
+          "en": "Signing up is fast and easy.<br>Already have an account? <a href='#/service/Login'>Sign In</a>"
+        },
+        "pageHeader": {
+          "en": "Sign Up"
+        }
+      }
+    },
+    {
+      "_id": "f07f1b4a-8aef-4c53-b04f-e41fd06ed859",
+      "nodeType": "AttributeCollectorNode",
+      "details": {
+        "attributesToCollect": [
+          "givenName",
+          "mail",
+          "telephoneNumber"
+        ],
+        "identityAttribute": "userName",
+        "validateInputs": true,
+        "required": false
+      }
+    },
+    {
+      "_id": "17c4c923-5d2d-4b22-8850-a4a4d8904a3d",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHMultiFactorGeneric"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHRegistration",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "eb711261-5253-4e17-9357-43e175a5005d",
+    "nodes": {
+      "0245c9e5-297b-4092-9e40-e3453f3581b6": {
+        "x": 497,
+        "y": 747.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "24595c6d-40a2-4592-a8f2-7823bb5d84be"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load Keys"
+      },
+      "24595c6d-40a2-4592-a8f2-7823bb5d84be": {
+        "x": 714,
+        "y": 829.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "30518af8-5af3-45e1-bd23-d404e13d922b"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Send Pwd Reset email"
+      },
+      "26f0bca6-8070-4d16-a5bc-8c3136e0057e": {
+        "x": 436,
+        "y": 601.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "0245c9e5-297b-4092-9e40-e3453f3581b6"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT"
+      },
+      "30518af8-5af3-45e1-bd23-d404e13d922b": {
+        "x": 1724,
+        "y": 143.015625,
+        "connections": {
+          "resend": "781e185e-f4da-442b-9fcd-827a4f235066",
+          "change_email": "eb711261-5253-4e17-9357-43e175a5005d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Email Sent Confirmation"
+      },
+      "453352a5-1e8a-4696-a439-0f09555ebc4f": {
+        "x": 342,
+        "y": 484.015625,
+        "connections": {
+          "true": "26f0bca6-8070-4d16-a5bc-8c3136e0057e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Set User Existing"
+      },
+      "6ca3881c-7762-4280-a8be-692395b136d4": {
+        "x": 1519,
+        "y": 684.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "General Error"
+      },
+      "781e185e-f4da-442b-9fcd-827a4f235066": {
+        "x": 1068,
+        "y": 228.015625,
+        "connections": {
+          "change_email": "eb711261-5253-4e17-9357-43e175a5005d",
+          "resend": "997cc39b-afde-4935-b9b5-a0d4e3034072"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Resend Or Change address"
+      },
+      "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea": {
+        "x": 169,
+        "y": 254.015625,
+        "connections": {
+          "false": "a87fa542-b6d3-49a1-bbdf-30370ae7042e",
+          "true": "453352a5-1e8a-4696-a439-0f09555ebc4f"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "997cc39b-afde-4935-b9b5-a0d4e3034072": {
+        "x": 886,
+        "y": 39,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "d4cff847-705b-44ed-81c9-c9da0ece05b5"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT - Email"
+      },
+      "9e02588a-e4ac-4b08-b10f-ad8f298ae720": {
+        "x": 1465,
+        "y": 57.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "30518af8-5af3-45e1-bd23-d404e13d922b"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create & Email link"
+      },
+      "a87fa542-b6d3-49a1-bbdf-30370ae7042e": {
+        "x": 496,
+        "y": 232.015625,
+        "connections": {
+          "false": "997cc39b-afde-4935-b9b5-a0d4e3034072",
+          "true": "17c4c923-5d2d-4b22-8850-a4a4d8904a3d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check phone entered"
+      },
+      "d4cff847-705b-44ed-81c9-c9da0ece05b5": {
+        "x": 1198,
+        "y": 36.015625,
+        "connections": {
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4",
+          "true": "9e02588a-e4ac-4b08-b10f-ad8f298ae720"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load Keys"
+      },
+      "eb711261-5253-4e17-9357-43e175a5005d": {
+        "x": 231,
+        "y": 57,
+        "connections": {
+          "outcome": "817f8595-f2cc-45ce-b4f8-ad7aa6fdd1ea"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Email Collector"
+      },
+      "17c4c923-5d2d-4b22-8850-a4a4d8904a3d": {
+        "x": 749,
+        "y": 396.015625,
+        "connections": {
+          "true": "997cc39b-afde-4935-b9b5-a0d4e3034072",
+          "false": "6ca3881c-7762-4280-a8be-692395b136d4"
+        },
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Check OTP SubFlow"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 70,
+        "y": 80
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1764,
+        "y": 501
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1901,
+        "y": 502
+      }
+    },
+    "description": "Registration Tree for CH Users - First part (email sending)"
+  }
 }

--- a/config/auth-trees/ch-update-legacy-password.json
+++ b/config/auth-trees/ch-update-legacy-password.json
@@ -1,358 +1,359 @@
 {
-    "nodes": [
-        {
-            "_id": "b1e2f7d4-cd1e-4433-a020-d445bbd76d28",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "valid",
-                    "update"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "2c9f9d6a-4b93-493a-bf0d-44fe53d8d1d1"
-            }
-        },
-        {
-            "_id": "704fbf38-6a45-4842-8e70-60cae68c9524",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "inputs": [
-                    "*"
-                ],
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "137e1fd5-19f4-425d-96eb-2a8c20cabcf8"
-            }
-        },
-        {
-            "_id": "39276a55-2540-4d26-9231-56bd3113a612",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "inputs": [
-                    "*"
-                ],
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "65d2099f-9583-47d3-8303-8051709cb436"
-            }
-        },
-        {
-            "_id": "4893e08c-e3f0-47a7-ab74-742fc22e74c8",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "inputs": [
-                    "*"
-                ],
-                "outcomes": [
-                    "success",
-                    "error"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }
-        },
-        {
-            "_id": "fab99cf3-086a-4f01-a12d-165dd5792c14",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false",
-                    "invalid"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "9bab9cb5-c723-4fb1-aa02-825aaaa7a266"
-            }
-        },
-        {
-            "_id": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
-            "nodeType": "DataStoreDecisionNode",
-            "details": {}
-        },
-        {
-            "_id": "a979a1c2-8474-4fdb-8c59-406bd39f5f0b",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "14c3cb5d-1010-459d-9747-6ff19a8de70d"
-            }
-        },
-        {
-            "_id": "8b77e445-2462-48ff-959b-a6c4cb515fb2",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "match",
-                    "mismatch"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "a5042601-6867-4566-81d1-fad4ecd61487"
-            }
-        },
-        {
-            "_id": "e2c86578-2128-429d-bb98-2fde50ce422c",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "success",
-                    "error"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }
-        },
-        {
-            "_id": "641a7ada-844c-4eec-8de4-aeab76c41465",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "pass",
-                    "fail",
-                    "error"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
-            }
-        },
-        {
-            "_id": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "success",
-                    "mismatch"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "52014433-9b16-4f21-a00c-1ab477c918f8"
-            }
-        },
-        {
-            "_id": "836b56d3-403a-4510-87d4-725b502fc0e1",
-            "nodeType": "RetryLimitDecisionNode",
-            "details": {
-                "retryLimit": 3
-            }
-        },
-        {
-            "_id": "9208332b-9c36-4064-a82b-6835de853e36",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "13e9d2a5-e93a-47f2-894d-4d732918c383"
-            }
-        }
-    ],
-    "tree": {
-        "_id": "CHUpdateLegacyPassword",
-        "description": "Update user password if entered cleartext password matches hashed value",
-        "identityResource": "managed/alpha_user",
-        "uiConfig": {},
-        "entryNodeId": "b1e2f7d4-cd1e-4433-a020-d445bbd76d28",
-        "nodes": {
-            "e2c86578-2128-429d-bb98-2fde50ce422c": {
-                "x": 2231,
-                "y": 213.5,
-                "connections": {
-                    "success": "641a7ada-844c-4eec-8de4-aeab76c41465",
-                    "error": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Get IDM Access Token"
-            },
-            "fab99cf3-086a-4f01-a12d-165dd5792c14": {
-                "x": 1334,
-                "y": 190,
-                "connections": {
-                    "true": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "invalid": "a979a1c2-8474-4fdb-8c59-406bd39f5f0b"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Update User Password"
-            },
-            "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed": {
-                "x": 1567,
-                "y": 45,
-                "connections": {
-                    "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-                    "false": "9208332b-9c36-4064-a82b-6835de853e36"
-                },
-                "nodeType": "DataStoreDecisionNode",
-                "displayName": "Data Store Decision"
-            },
-            "4893e08c-e3f0-47a7-ab74-742fc22e74c8": {
-                "x": 1013,
-                "y": 172.5,
-                "connections": {
-                    "error": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "success": "fab99cf3-086a-4f01-a12d-165dd5792c14"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Get IDM Access Token"
-            },
-            "704fbf38-6a45-4842-8e70-60cae68c9524": {
-                "x": 495,
-                "y": 280.5,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "39276a55-2540-4d26-9231-56bd3113a612"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Fetch Legacy Password"
-            },
-            "39276a55-2540-4d26-9231-56bd3113a612": {
-                "x": 760,
-                "y": 172.5,
-                "connections": {
-                    "true": "4893e08c-e3f0-47a7-ab74-742fc22e74c8",
-                    "false": "9208332b-9c36-4064-a82b-6835de853e36"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Call Validation Service"
-            },
-            "57d915a9-a414-4d14-bae4-e811ba80d0ce": {
-                "x": 2254,
-                "y": 772.6666666666666,
-                "connections": {
-                    "mismatch": "836b56d3-403a-4510-87d4-725b502fc0e1",
-                    "success": "8b77e445-2462-48ff-959b-a6c4cb515fb2"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Change Password Collector"
-            },
-            "641a7ada-844c-4eec-8de4-aeab76c41465": {
-                "x": 2250,
-                "y": 410.3333333333333,
-                "connections": {
-                    "fail": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
-                    "error": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
-                    "pass": "fab99cf3-086a-4f01-a12d-165dd5792c14"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check Password Policy"
-            },
-            "a979a1c2-8474-4fdb-8c59-406bd39f5f0b": {
-                "x": 1575,
-                "y": 486,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "57d915a9-a414-4d14-bae4-e811ba80d0ce"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Change Password Required"
-            },
-            "b1e2f7d4-cd1e-4433-a020-d445bbd76d28": {
-                "x": 210,
-                "y": 172.5,
-                "connections": {
-                    "valid": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
-                    "update": "704fbf38-6a45-4842-8e70-60cae68c9524"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check Password Status"
-            },
-            "836b56d3-403a-4510-87d4-725b502fc0e1": {
-                "x": 2269,
-                "y": 992,
-                "connections": {
-                    "Retry": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
-                    "Reject": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "RetryLimitDecisionNode",
-                "displayName": "Retry Limit Decision"
-            },
-            "8b77e445-2462-48ff-959b-a6c4cb515fb2": {
-                "x": 1894,
-                "y": 234,
-                "connections": {
-                    "match": "e2c86578-2128-429d-bb98-2fde50ce422c",
-                    "mismatch": "57d915a9-a414-4d14-bae4-e811ba80d0ce"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check Original Password"
-            },
-            "9208332b-9c36-4064-a82b-6835de853e36": {
-                "x": 2237,
-                "y": 126.015625,
-                "connections": {
-                    "true": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Generate Error Message"
-            }
-        },
-        "staticNodes": {
-            "startNode": {
-                "x": 70,
-                "y": 190
-            },
-            "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-                "x": 1940,
-                "y": 56.833333333333314
-            },
-            "e301438c-0bd0-429c-ab0c-66126501069a": {
-                "x": 2890,
-                "y": 526.6666666666667
-            }
-        }
+  "nodes": [
+    {
+      "_id": "b1e2f7d4-cd1e-4433-a020-d445bbd76d28",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "valid",
+          "update"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "2c9f9d6a-4b93-493a-bf0d-44fe53d8d1d1"
+      }
+    },
+    {
+      "_id": "704fbf38-6a45-4842-8e70-60cae68c9524",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "137e1fd5-19f4-425d-96eb-2a8c20cabcf8"
+      }
+    },
+    {
+      "_id": "39276a55-2540-4d26-9231-56bd3113a612",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "65d2099f-9583-47d3-8303-8051709cb436"
+      }
+    },
+    {
+      "_id": "4893e08c-e3f0-47a7-ab74-742fc22e74c8",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "fab99cf3-086a-4f01-a12d-165dd5792c14",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false",
+          "invalid"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "9bab9cb5-c723-4fb1-aa02-825aaaa7a266"
+      }
+    },
+    {
+      "_id": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
+      "nodeType": "DataStoreDecisionNode",
+      "details": {}
+    },
+    {
+      "_id": "a979a1c2-8474-4fdb-8c59-406bd39f5f0b",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "14c3cb5d-1010-459d-9747-6ff19a8de70d"
+      }
+    },
+    {
+      "_id": "8b77e445-2462-48ff-959b-a6c4cb515fb2",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "match",
+          "mismatch"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "a5042601-6867-4566-81d1-fad4ecd61487"
+      }
+    },
+    {
+      "_id": "e2c86578-2128-429d-bb98-2fde50ce422c",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "641a7ada-844c-4eec-8de4-aeab76c41465",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "pass",
+          "fail",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
+      }
+    },
+    {
+      "_id": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "mismatch"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "52014433-9b16-4f21-a00c-1ab477c918f8"
+      }
+    },
+    {
+      "_id": "836b56d3-403a-4510-87d4-725b502fc0e1",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "9208332b-9c36-4064-a82b-6835de853e36",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "13e9d2a5-e93a-47f2-894d-4d732918c383"
+      }
     }
+  ],
+  "tree": {
+    "_id": "CHUpdateLegacyPassword",
+    "description": "Update user password if entered cleartext password matches hashed value",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "b1e2f7d4-cd1e-4433-a020-d445bbd76d28",
+    "nodes": {
+      "e2c86578-2128-429d-bb98-2fde50ce422c": {
+        "x": 2231,
+        "y": 213.5,
+        "connections": {
+          "success": "641a7ada-844c-4eec-8de4-aeab76c41465",
+          "error": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Access Token"
+      },
+      "fab99cf3-086a-4f01-a12d-165dd5792c14": {
+        "x": 1334,
+        "y": 190,
+        "connections": {
+          "true": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "invalid": "a979a1c2-8474-4fdb-8c59-406bd39f5f0b"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Update User Password"
+      },
+      "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed": {
+        "x": 1567,
+        "y": 45,
+        "connections": {
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "false": "9208332b-9c36-4064-a82b-6835de853e36"
+        },
+        "nodeType": "DataStoreDecisionNode",
+        "displayName": "Data Store Decision"
+      },
+      "4893e08c-e3f0-47a7-ab74-742fc22e74c8": {
+        "x": 1013,
+        "y": 172.5,
+        "connections": {
+          "error": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "success": "fab99cf3-086a-4f01-a12d-165dd5792c14"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Access Token"
+      },
+      "704fbf38-6a45-4842-8e70-60cae68c9524": {
+        "x": 495,
+        "y": 280.5,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "39276a55-2540-4d26-9231-56bd3113a612"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Fetch Legacy Password"
+      },
+      "39276a55-2540-4d26-9231-56bd3113a612": {
+        "x": 760,
+        "y": 172.5,
+        "connections": {
+          "true": "4893e08c-e3f0-47a7-ab74-742fc22e74c8",
+          "false": "9208332b-9c36-4064-a82b-6835de853e36"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Call Validation Service"
+      },
+      "57d915a9-a414-4d14-bae4-e811ba80d0ce": {
+        "x": 2254,
+        "y": 772.6666666666666,
+        "connections": {
+          "mismatch": "836b56d3-403a-4510-87d4-725b502fc0e1",
+          "success": "8b77e445-2462-48ff-959b-a6c4cb515fb2"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Change Password Collector"
+      },
+      "641a7ada-844c-4eec-8de4-aeab76c41465": {
+        "x": 2250,
+        "y": 410.3333333333333,
+        "connections": {
+          "fail": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
+          "error": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
+          "pass": "fab99cf3-086a-4f01-a12d-165dd5792c14"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Password Policy"
+      },
+      "a979a1c2-8474-4fdb-8c59-406bd39f5f0b": {
+        "x": 1575,
+        "y": 486,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "57d915a9-a414-4d14-bae4-e811ba80d0ce"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Change Password Required"
+      },
+      "b1e2f7d4-cd1e-4433-a020-d445bbd76d28": {
+        "x": 210,
+        "y": 172.5,
+        "connections": {
+          "valid": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
+          "update": "704fbf38-6a45-4842-8e70-60cae68c9524"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Password Status"
+      },
+      "836b56d3-403a-4510-87d4-725b502fc0e1": {
+        "x": 2269,
+        "y": 992,
+        "connections": {
+          "Retry": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
+          "Reject": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "8b77e445-2462-48ff-959b-a6c4cb515fb2": {
+        "x": 1894,
+        "y": 234,
+        "connections": {
+          "match": "e2c86578-2128-429d-bb98-2fde50ce422c",
+          "mismatch": "57d915a9-a414-4d14-bae4-e811ba80d0ce"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Original Password"
+      },
+      "9208332b-9c36-4064-a82b-6835de853e36": {
+        "x": 2237,
+        "y": 126.015625,
+        "connections": {
+          "true": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Generate Error Message"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 70,
+        "y": 190
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1940,
+        "y": 56.833333333333314
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 2890,
+        "y": 526.6666666666667
+      }
+    }
+  }
 }

--- a/config/auth-trees/ch-update-password.json
+++ b/config/auth-trees/ch-update-password.json
@@ -1,288 +1,349 @@
 {
-	"nodes": [
-		{
-            "_id":"c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["hasSession","noSession"],
-                "outputs":["*"],
-                "script":"c4001e02-469c-4cc4-bf95-9f43d7e46568"
-            }            
+  "nodes": [
+    {
+      "_id": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "hasSession",
+          "noSession"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c4001e02-469c-4cc4-bf95-9f43d7e46568"
+      }
+    },
+    {
+      "_id": "72c2688d-910a-4fd3-b094-25803bc9626a",
+      "nodeType": "SessionDataNode",
+      "details": {
+        "sharedStateKey": "userName",
+        "sessionDataKey": "UserToken"
+      }
+    },
+    {
+      "_id": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "mismatch"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "52014433-9b16-4f21-a00c-1ab477c918f8"
+      }
+    },
+    {
+      "_id": "99568072-5a13-48ec-8d07-c06a8c82b425",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "23448f95-703e-4605-b7f5-1ff78fa8def2",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "pass",
+          "fail",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
+      }
+    },
+    {
+      "_id": "ad3af2c3-f67d-4d7a-b954-698a764c4791",
+      "nodeType": "DataStoreDecisionNode",
+      "details": {}
+    },
+    {
+      "_id": "81fec77e-909d-4a6b-bd6a-4dee5964e956",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "1495201c-23da-46b1-8537-73d508cf8358",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "84caf8b3-813a-4998-85ff-a3dd8eee4bcf"
+      }
+    },
+    {
+      "_id": "81f81b53-416f-465a-8ca3-ecbc3216162d",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "04e99c63-2875-43ca-9e5f-84832bf59a34"
+      }
+    },
+    {
+      "_id": "5dbba61f-e063-4264-bc63-1e71927419b1",
+      "nodeType": "PatchObjectNode",
+      "details": {
+        "patchAsObject": false,
+        "ignoredFields": [
+          "userName"
+        ],
+        "identityResource": "managed/alpha_user",
+        "identityAttribute": "userName"
+      }
+    },
+    {
+      "_id": "0c2e7c10-63fb-4e25-8218-68e742672fd1",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "1a7ced42-93f3-4739-a9b8-b773b489ed1d"
+      }
+    },
+    {
+      "_id": "b2e1eb3f-6276-4437-b52d-606a9c05fa59",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df"
+      }
+    },
+    {
+      "_id": "c036600d-18b5-4186-a122-227bea684ba8",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHChangePassword",
+    "description": "Update password using active session",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
+    "nodes": {
+      "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3": {
+        "x": 166,
+        "y": 254.015625,
+        "connections": {
+          "noSession": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
+          "hasSession": "72c2688d-910a-4fd3-b094-25803bc9626a"
         },
-		{
-			"_id":"72c2688d-910a-4fd3-b094-25803bc9626a",
-			"nodeType": "SessionDataNode", 
-			"details": {
-				"sharedStateKey":"userName",
-				"sessionDataKey":"UserToken"
-			}				
-		},
-		{
-            "_id":"c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["success","mismatch"],
-                "outputs":["*"],
-                "script":"52014433-9b16-4f21-a00c-1ab477c918f8"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check for Session"
+      },
+      "72c2688d-910a-4fd3-b094-25803bc9626a": {
+        "x": 373,
+        "y": 129.015625,
+        "connections": {
+          "outcome": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
         },
-		{
-            "_id":"99568072-5a13-48ec-8d07-c06a8c82b425",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["success","error"],
-                "outputs":["*"],
-                "script":"c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
+        "nodeType": "SessionDataNode",
+        "displayName": "Get Session Data"
+      },
+      "c0ddbe48-e4f5-48a9-8879-79762611c5e4": {
+        "x": 672,
+        "y": 100.015625,
+        "connections": {
+          "success": "99568072-5a13-48ec-8d07-c06a8c82b425",
+          "mismatch": "81fec77e-909d-4a6b-bd6a-4dee5964e956"
         },
-		{
-            "_id":"23448f95-703e-4605-b7f5-1ff78fa8def2",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["pass","fail","error"],
-                "outputs":["*"],
-                "script":"c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Change Password Collector"
+      },
+      "99568072-5a13-48ec-8d07-c06a8c82b425": {
+        "x": 965,
+        "y": 231.015625,
+        "connections": {
+          "error": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
+          "success": "23448f95-703e-4605-b7f5-1ff78fa8def2"
         },
-		{
-			"_id":"ad3af2c3-f67d-4d7a-b954-698a764c4791",
-			"nodeType": "DataStoreDecisionNode", 
-			"details":{}
-		},
-		{
-            "_id":"81fec77e-909d-4a6b-bd6a-4dee5964e956",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit": 3
-            }
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Access Token"
+      },
+      "81fec77e-909d-4a6b-bd6a-4dee5964e956": {
+        "x": 748,
+        "y": 296.015625,
+        "connections": {
+          "Retry": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+          "Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59"
         },
-		{
-            "_id":"1495201c-23da-46b1-8537-73d508cf8358",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"84caf8b3-813a-4998-85ff-a3dd8eee4bcf"
-            }            
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "23448f95-703e-4605-b7f5-1ff78fa8def2": {
+        "x": 1210,
+        "y": 45,
+        "connections": {
+          "fail": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+          "error": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+          "pass": "ad3af2c3-f67d-4d7a-b954-698a764c4791"
         },
-		{
-            "_id":"81f81b53-416f-465a-8ca3-ecbc3216162d",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"04e99c63-2875-43ca-9e5f-84832bf59a34"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Pwd Policy"
+      },
+      "ad3af2c3-f67d-4d7a-b954-698a764c4791": {
+        "x": 1339,
+        "y": 218.015625,
+        "connections": {
+          "true": "1495201c-23da-46b1-8537-73d508cf8358",
+          "false": "c036600d-18b5-4186-a122-227bea684ba8"
         },
-		{
-			"_id":"5dbba61f-e063-4264-bc63-1e71927419b1",
-			"nodeType": "PatchObjectNode", 
-			"details": {
-				"patchAsObject":false,
-				"ignoredFields":[
-			   		"userName"
-				],
-				"identityResource":"managed/alpha_user",
-				"identityAttribute":"userName"
-			}
-		},
-		{
-            "_id":"0c2e7c10-63fb-4e25-8218-68e742672fd1",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"1a7ced42-93f3-4739-a9b8-b773b489ed1d"
-            }            
+        "nodeType": "DataStoreDecisionNode",
+        "displayName": "Data Store Decision"
+      },
+      "81f81b53-416f-465a-8ca3-ecbc3216162d": {
+        "x": 1653,
+        "y": 369.015625,
+        "connections": {
+          "true": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
         },
-		{
-            "_id":"b2e1eb3f-6276-4437-b52d-606a9c05fa59",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"fdac4efb-d8b8-478b-8300-e11a4c3503df"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Pwd Error Message"
+      },
+      "1495201c-23da-46b1-8537-73d508cf8358": {
+        "x": 1451,
+        "y": 88.015625,
+        "connections": {
+          "true": "5dbba61f-e063-4264-bc63-1e71927419b1"
         },
-		{
-            "_id":"c036600d-18b5-4186-a122-227bea684ba8",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit": 3
-            }
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load New Pwd for Patch"
+      },
+      "5dbba61f-e063-4264-bc63-1e71927419b1": {
+        "x": 1558,
+        "y": 203.015625,
+        "connections": {
+          "PATCHED": "0c2e7c10-63fb-4e25-8218-68e742672fd1",
+          "FAILURE": "a1293502-4cf4-435e-888c-47a5dd5ed62f"
         },
-		{
-            "_id": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-                "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-            }            
-        }
-  	],
-	"tree": {
-		"_id": "CHChangePassword",
-		"description": "Update password using active session",
-		"identityResource": "managed/alpha_user",
-		"uiConfig": {},
-		"entryNodeId": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
-		"nodes": {
-			"c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3": {
-				"x": 166,
-				"y": 254.015625,
-				"connections": {
-					"noSession": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
-					"hasSession": "72c2688d-910a-4fd3-b094-25803bc9626a"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check for Session"
-			},
-			"72c2688d-910a-4fd3-b094-25803bc9626a": {
-				"x": 373,
-				"y": 129.015625,
-				"connections": {
-					"outcome": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
-				},
-				"nodeType": "SessionDataNode",
-				"displayName": "Get Session Data"
-			},
-			"c0ddbe48-e4f5-48a9-8879-79762611c5e4": {
-				"x": 672,
-				"y": 100.015625,
-				"connections": {
-					"success": "99568072-5a13-48ec-8d07-c06a8c82b425",
-					"mismatch": "81fec77e-909d-4a6b-bd6a-4dee5964e956"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Change Password Collector"
-			},
-			"99568072-5a13-48ec-8d07-c06a8c82b425": {
-				"x": 965,
-				"y": 231.015625,
-				"connections": {
-					"error": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
-					"success": "23448f95-703e-4605-b7f5-1ff78fa8def2"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM Access Token"
-			},
-			"81fec77e-909d-4a6b-bd6a-4dee5964e956": {
-				"x": 748,
-				"y": 296.015625,
-				"connections": {
-					"Retry": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-					"Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59"
-				},
-				"nodeType": "RetryLimitDecisionNode",
-				"displayName": "Retry Limit Decision"
-			},
-			"23448f95-703e-4605-b7f5-1ff78fa8def2": {
-				"x": 1210,
-				"y": 45,
-				"connections": {
-					"fail": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-					"error": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-					"pass": "ad3af2c3-f67d-4d7a-b954-698a764c4791"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check Pwd Policy"
-			},
-			"ad3af2c3-f67d-4d7a-b954-698a764c4791": {
-				"x": 1339,
-				"y": 218.015625,
-				"connections": {
-					"true": "1495201c-23da-46b1-8537-73d508cf8358",
-					"false": "c036600d-18b5-4186-a122-227bea684ba8"
-				},
-				"nodeType": "DataStoreDecisionNode",
-				"displayName": "Data Store Decision"
-			},
-			"81f81b53-416f-465a-8ca3-ecbc3216162d": {
-				"x": 1653,
-				"y": 369.015625,
-				"connections": {
-					"true": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Pwd Error Message"
-			},
-			"1495201c-23da-46b1-8537-73d508cf8358": {
-				"x": 1451,
-				"y": 88.015625,
-				"connections": {
-					"true": "5dbba61f-e063-4264-bc63-1e71927419b1"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Load New Pwd for Patch"
-			},
-			"5dbba61f-e063-4264-bc63-1e71927419b1": {
-				"x": 1558,
-				"y": 203.015625,
-				"connections": {
-					"PATCHED": "0c2e7c10-63fb-4e25-8218-68e742672fd1",
-					"FAILURE": "a1293502-4cf4-435e-888c-47a5dd5ed62f"
-				},
-				"nodeType": "PatchObjectNode",
-				"displayName": "Patch Object"
-			},
-			"0c2e7c10-63fb-4e25-8218-68e742672fd1": {
-				"x": 1749,
-				"y": 81.015625,
-				"connections": {
-					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Confirmation"
-			},
-			"c036600d-18b5-4186-a122-227bea684ba8": {
-				"x": 1399,
-				"y": 384.015625,
-				"connections": {
-					"Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59",
-					"Retry": "81f81b53-416f-465a-8ca3-ecbc3216162d"
-				},
-				"nodeType": "RetryLimitDecisionNode",
-				"displayName": "Retry Limit Decision"
-			},
-			"b2e1eb3f-6276-4437-b52d-606a9c05fa59": {
-				"x": 1618,
-				"y": 566.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "max attempts message"
-			},
-			"a1293502-4cf4-435e-888c-47a5dd5ed62f": {
-				"x": 1542,
-				"y": 787.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "General Error"
-			}
-		},
-		"staticNodes": {
-			"startNode": {
-				"x": 62,
-				"y": 103
-			},
-			"70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-				"x": 1867,
-				"y": 257
-			},
-			"e301438c-0bd0-429c-ab0c-66126501069a": {
-				"x": 1816,
-				"y": 755
-			}
-		}
-	}
+        "nodeType": "PatchObjectNode",
+        "displayName": "Patch Object"
+      },
+      "0c2e7c10-63fb-4e25-8218-68e742672fd1": {
+        "x": 1749,
+        "y": 81.015625,
+        "connections": {
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Confirmation"
+      },
+      "c036600d-18b5-4186-a122-227bea684ba8": {
+        "x": 1399,
+        "y": 384.015625,
+        "connections": {
+          "Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59",
+          "Retry": "81f81b53-416f-465a-8ca3-ecbc3216162d"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "b2e1eb3f-6276-4437-b52d-606a9c05fa59": {
+        "x": 1618,
+        "y": 566.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "max attempts message"
+      },
+      "a1293502-4cf4-435e-888c-47a5dd5ed62f": {
+        "x": 1542,
+        "y": 787.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "General Error"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 62,
+        "y": 103
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1867,
+        "y": 257
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1816,
+        "y": 755
+      }
+    }
+  }
 }
 

--- a/config/auth-trees/ch-webfiling-complete-profile.json
+++ b/config/auth-trees/ch-webfiling-complete-profile.json
@@ -21,100 +21,11 @@
       }
     },
     {
-      "_id": "45d936c3-7d04-48d8-b7cb-02448fc9991e",
-      "nodeType": "PageNode",
-      "details": {
-        "nodes": [
-          {
-            "_id": "50869d72-4bbf-4ab5-b331-037ab48ada38",
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Callback Show Number"
-          },
-          {
-            "_id": "02d1400e-cf84-4b6e-984e-7958d8a11636",
-            "nodeType": "OneTimePasswordCollectorDecisionNode",
-            "displayName": "OTP Collector Decision"
-          }
-        ],
-        "pageDescription": {
-          "desc": "Please enter the code you received"
-        },
-        "stage": "PHONE_OTP",
-        "pageHeader": {
-          "header": "Please enter your code"
-        }
-      }
-    },
-    {
-      "_id": "50869d72-4bbf-4ab5-b331-037ab48ada38",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "72e60c8b-f4e9-4696-8218-6efee1f5d97b",
-        "outcomes": [
-          "True"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "02d1400e-cf84-4b6e-984e-7958d8a11636",
-      "nodeType": "OneTimePasswordCollectorDecisionNode",
-      "details": {
-        "passwordExpiryTime": 5
-      }
-    },
-    {
       "_id": "535f7949-b52e-4a8b-835d-ba46dff7ea51",
       "nodeType": "SessionDataNode",
       "details": {
         "sessionDataKey": "UserToken",
         "sharedStateKey": "userName"
-      }
-    },
-    {
-      "_id": "609cc371-1b68-4b18-8d95-4162b83662e9",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "6feedc53-41e0-49d0-b181-a8b43ccdadfe",
-      "nodeType": "OneTimePasswordGeneratorNode",
-      "details": {
-        "length": 6
-      }
-    },
-    {
-      "_id": "816ad4ee-870e-473b-aac6-feb203f3811f",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "b276c566-622e-11eb-ae93-0242ac130002",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
       }
     },
     {
@@ -153,22 +64,6 @@
       }
     },
     {
-      "_id": "a892b1a6-5f10-4ea6-aa5c-31772a90c987",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c",
-        "outcomes": [
-          "true"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
       "_id": "b802b783-cae6-4b4e-849c-2ab9c7b80391",
       "nodeType": "ScriptedDecisionNode",
       "details": {
@@ -186,19 +81,10 @@
       }
     },
     {
-      "_id": "c91bca42-14ab-44de-a17b-ca6201fddfcc",
-      "nodeType": "RetryLimitDecisionNode",
+      "_id": "59c4be80-649a-491e-b1be-92299e3b85ca",
+      "nodeType": "InnerTreeEvaluatorNode",
       "details": {
-        "incrementUserAttributeOnFailure": false,
-        "retryLimit": 3
-      }
-    },
-    {
-      "_id": "1df96f3f-82f1-4967-8d91-34488f4b0921",
-      "nodeType": "RetryLimitDecisionNode",
-      "details": {
-        "incrementUserAttributeOnFailure": false,
-        "retryLimit": 3
+        "tree": "CHMultiFactorGeneric"
       }
     }
   ],
@@ -209,8 +95,8 @@
     "entryNodeId": "3ece9748-a455-43b1-99b2-20fea28ed6ee",
     "nodes": {
       "1aeb1667-8dfe-417f-abaf-b02626fa5392": {
-        "x": 1907,
-        "y": 122.015625,
+        "x": 1542,
+        "y": 278.015625,
         "connections": {
           "FAILURE": "e301438c-0bd0-429c-ab0c-66126501069a",
           "PATCHED": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
@@ -228,16 +114,6 @@
         "nodeType": "IdentifyExistingUserNode",
         "displayName": "Identify Existing User"
       },
-      "45d936c3-7d04-48d8-b7cb-02448fc9991e": {
-        "x": 1648,
-        "y": 172.015625,
-        "connections": {
-          "false": "c91bca42-14ab-44de-a17b-ca6201fddfcc",
-          "true": "1aeb1667-8dfe-417f-abaf-b02626fa5392"
-        },
-        "nodeType": "PageNode",
-        "displayName": "Enter OTP"
-      },
       "535f7949-b52e-4a8b-835d-ba46dff7ea51": {
         "x": 249,
         "y": 414.015625,
@@ -247,38 +123,9 @@
         "nodeType": "SessionDataNode",
         "displayName": "Get Session Data"
       },
-      "609cc371-1b68-4b18-8d95-4162b83662e9": {
-        "x": 1011,
-        "y": 332.015625,
-        "connections": {
-          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "true": "6feedc53-41e0-49d0-b181-a8b43ccdadfe"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Create Notify JWT - SMS"
-      },
-      "6feedc53-41e0-49d0-b181-a8b43ccdadfe": {
-        "x": 1241,
-        "y": 73.015625,
-        "connections": {
-          "outcome": "816ad4ee-870e-473b-aac6-feb203f3811f"
-        },
-        "nodeType": "OneTimePasswordGeneratorNode",
-        "displayName": "HOTP Generator"
-      },
-      "816ad4ee-870e-473b-aac6-feb203f3811f": {
-        "x": 1386,
-        "y": 193.015625,
-        "connections": {
-          "false": "1df96f3f-82f1-4967-8d91-34488f4b0921",
-          "true": "45d936c3-7d04-48d8-b7cb-02448fc9991e"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Send OTP"
-      },
       "9cebfbba-00c4-41a2-9772-7d4e80699e47": {
-        "x": 1868,
-        "y": 750.015625,
+        "x": 1312,
+        "y": 534.015625,
         "connections": {},
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Max Number Exceeded"
@@ -289,20 +136,11 @@
         "connections": {
           "fail": "3ece9748-a455-43b1-99b2-20fea28ed6ee",
           "name_only": "1aeb1667-8dfe-417f-abaf-b02626fa5392",
-          "otp": "609cc371-1b68-4b18-8d95-4162b83662e9",
-          "skip": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+          "skip": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "otp": "59c4be80-649a-491e-b1be-92299e3b85ca"
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "complete profile"
-      },
-      "a892b1a6-5f10-4ea6-aa5c-31772a90c987": {
-        "x": 2098,
-        "y": 653.015625,
-        "connections": {
-          "true": "45d936c3-7d04-48d8-b7cb-02448fc9991e"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Raise OTP Error"
       },
       "b802b783-cae6-4b4e-849c-2ab9c7b80391": {
         "x": 74,
@@ -314,25 +152,15 @@
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Check for Session"
       },
-      "c91bca42-14ab-44de-a17b-ca6201fddfcc": {
-        "x": 1873,
-        "y": 620.015625,
+      "59c4be80-649a-491e-b1be-92299e3b85ca": {
+        "x": 1144,
+        "y": 339.015625,
         "connections": {
-          "Reject": "9cebfbba-00c4-41a2-9772-7d4e80699e47",
-          "Retry": "a892b1a6-5f10-4ea6-aa5c-31772a90c987"
+          "false": "9cebfbba-00c4-41a2-9772-7d4e80699e47",
+          "true": "1aeb1667-8dfe-417f-abaf-b02626fa5392"
         },
-        "nodeType": "RetryLimitDecisionNode",
-        "displayName": "Retry Limit Decision"
-      },
-      "1df96f3f-82f1-4967-8d91-34488f4b0921": {
-        "x": 1409,
-        "y": 421.015625,
-        "connections": {
-          "Reject": "e301438c-0bd0-429c-ab0c-66126501069a",
-          "Retry": "a46a26c4-eb14-4f61-be94-1eca72022424"
-        },
-        "nodeType": "RetryLimitDecisionNode",
-        "displayName": "Retry Limit Decision"
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Check OTP SubFlow"
       }
     },
     "staticNodes": {
@@ -341,8 +169,8 @@
         "y": 103
       },
       "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 2196,
-        "y": 254
+        "x": 1818,
+        "y": 187
       },
       "e301438c-0bd0-429c-ab0c-66126501069a": {
         "x": 1615,

--- a/config/auth-trees/ch-webfiling-login.json
+++ b/config/auth-trees/ch-webfiling-login.json
@@ -75,13 +75,6 @@
       }
     },
     {
-      "_id": "3ef1391a-3bfb-4088-be5c-40713da8b6cc",
-      "nodeType": "OneTimePasswordGeneratorNode",
-      "details": {
-        "length": 6
-      }
-    },
-    {
       "_id": "6129ae01-2f10-4e6a-ab4f-eba00524c6b0",
       "nodeType": "ScriptedDecisionNode",
       "details": {
@@ -140,60 +133,10 @@
       }
     },
     {
-      "_id": "73252c50-1f11-468d-b5ee-aa0c44ec104d",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "b276c566-622e-11eb-ae93-0242ac130002",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
       "_id": "7f0f8fa9-357a-4139-b407-d9a0336faaa9",
       "nodeType": "InnerTreeEvaluatorNode",
       "details": {
         "tree": "CHManageEmailConsent"
-      }
-    },
-    {
-      "_id": "9760e4cc-d4f7-4bf0-8985-18a4c8a7c55d",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "a5778ce7-addf-4fb6-a7db-92929f1314c4",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "979fd32f-2242-4d08-b31b-722c1ed419b4",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df",
-        "outcomes": [
-          "true"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
       }
     },
     {
@@ -213,100 +156,10 @@
       }
     },
     {
-      "_id": "b07427f0-b984-4be6-a388-083e0111db19",
-      "nodeType": "RetryLimitDecisionNode",
-      "details": {
-        "incrementUserAttributeOnFailure": false,
-        "retryLimit": 3
-      }
-    },
-    {
       "_id": "bd62a4ef-dcf4-4952-904f-f7f3601b8ae3",
       "nodeType": "InnerTreeEvaluatorNode",
       "details": {
         "tree": "CHUpdateLegacyPassword"
-      }
-    },
-    {
-      "_id": "c13d3e4d-d2ed-47bc-acad-4ef3b70f62a5",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "c57cea8d-a2de-4422-8ccb-5ca9dcad5bde",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "b480d9f7-5908-45cf-91d1-bc1fe56fe8de",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "c5f45504-02d6-4370-b120-03c18d72a2a3",
-      "nodeType": "PageNode",
-      "details": {
-        "nodes": [
-          {
-            "_id": "ace51bd8-ed90-4227-bdce-98e9f42485a3",
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Scripted Decision"
-          },
-          {
-            "_id": "9ffd76c9-4624-4d2a-bc8a-8e621f8a7799",
-            "nodeType": "OneTimePasswordCollectorDecisionNode",
-            "displayName": "OTP Collector Decision"
-          }
-        ],
-        "pageDescription": {
-          "desc": "Please enter the code you received"
-        },
-        "stage": "EWF_LOGIN_OTP",
-        "pageHeader": {
-          "header": "Please enter your code"
-        }
-      }
-    },
-    {
-      "_id": "ace51bd8-ed90-4227-bdce-98e9f42485a3",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "ace951c8-d169-4426-9357-d5b44e0aa728",
-        "outcomes": [
-          "True"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "9ffd76c9-4624-4d2a-bc8a-8e621f8a7799",
-      "nodeType": "OneTimePasswordCollectorDecisionNode",
-      "details": {
-        "passwordExpiryTime": 30
       }
     },
     {
@@ -317,22 +170,6 @@
         "outcomes": [
           "true",
           "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
-      "_id": "cdc774a7-c03c-4cf2-8514-9d7654aac599",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c",
-        "outcomes": [
-          "true"
         ],
         "outputs": [
           "*"
@@ -360,23 +197,6 @@
       }
     },
     {
-      "_id": "eb0917d3-88bb-47ff-adf2-4157edae8d7a",
-      "nodeType": "ScriptedDecisionNode",
-      "details": {
-        "script": "df67765e-df3a-4503-9ba5-35c992b39259",
-        "outcomes": [
-          "true",
-          "false"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
-      }
-    },
-    {
       "_id": "f79be846-2226-41d2-a8f1-7a53ef4b5a77",
       "nodeType": "ScriptedDecisionNode",
       "details": {
@@ -390,13 +210,6 @@
         "inputs": [
           "*"
         ]
-      }
-    },
-    {
-      "_id": "fa794bf3-ffbe-459d-9078-dbc19bfdf4c6",
-      "nodeType": "OneTimePasswordGeneratorNode",
-      "details": {
-        "length": 6
       }
     },
     {
@@ -571,20 +384,10 @@
       }
     },
     {
-      "_id": "101b5c24-cb88-4ed1-8db6-5d4fc07f3c10",
-      "nodeType": "ScriptedDecisionNode",
+      "_id": "c20d2d99-dc1a-4a02-9931-2a3885ca160b",
+      "nodeType": "InnerTreeEvaluatorNode",
       "details": {
-        "script": "610ba200-db35-4c44-80c9-a40d36cc6fc0",
-        "outcomes": [
-          "email",
-          "text"
-        ],
-        "outputs": [
-          "*"
-        ],
-        "inputs": [
-          "*"
-        ]
+        "tree": "CHMultiFactorGeneric"
       }
     }
   ],
@@ -605,8 +408,8 @@
         "displayName": "Reset Counter"
       },
       "0ac72f4f-039a-4843-a565-037fb0b8805d": {
-        "x": 1269,
-        "y": 436.015625,
+        "x": 1328,
+        "y": 195.015625,
         "connections": {
           "error": "b3f513ec-f284-476d-b040-00918b40b772",
           "success": "6538e894-475a-49f0-be1c-08d721f615df"
@@ -627,8 +430,8 @@
         "displayName": "Check soft lock"
       },
       "24d11b28-95b9-478c-aede-990c2471109c": {
-        "x": 2786,
-        "y": 56.5,
+        "x": 2171,
+        "y": 231.5,
         "connections": {
           "outcome": "f79be846-2226-41d2-a8f1-7a53ef4b5a77"
         },
@@ -636,8 +439,8 @@
         "displayName": "Increment Login Count"
       },
       "318d16a5-37ca-4d58-a3ec-54a4699881e3": {
-        "x": 3063,
-        "y": 20.015625,
+        "x": 2942,
+        "y": 202.015625,
         "connections": {
           "false": "b3f513ec-f284-476d-b040-00918b40b772",
           "true": "7f0f8fa9-357a-4139-b407-d9a0336faaa9"
@@ -646,27 +449,18 @@
         "displayName": "Complete Profile"
       },
       "31fa4b8d-9686-4bec-8db2-45d442533b22": {
-        "x": 2985,
-        "y": 197.5,
+        "x": 2676,
+        "y": 209.5,
         "connections": {
           "false": "b3f513ec-f284-476d-b040-00918b40b772",
           "true": "318d16a5-37ca-4d58-a3ec-54a4699881e3"
         },
         "nodeType": "InnerTreeEvaluatorNode",
-        "displayName": "Inner Tree Evaluator"
-      },
-      "3ef1391a-3bfb-4088-be5c-40713da8b6cc": {
-        "x": 1994,
-        "y": 285.66666666666663,
-        "connections": {
-          "outcome": "9760e4cc-d4f7-4bf0-8985-18a4c8a7c55d"
-        },
-        "nodeType": "OneTimePasswordGeneratorNode",
-        "displayName": "HOTP Generator"
+        "displayName": "Progressive Profiling"
       },
       "6129ae01-2f10-4e6a-ab4f-eba00524c6b0": {
-        "x": 1058,
-        "y": 554.015625,
+        "x": 1160,
+        "y": 399.015625,
         "connections": {
           "true": "0ac72f4f-039a-4843-a565-037fb0b8805d"
         },
@@ -684,11 +478,11 @@
         "displayName": "Soft Lock Increment Counter"
       },
       "6538e894-475a-49f0-be1c-08d721f615df": {
-        "x": 1044,
-        "y": 179.015625,
+        "x": 1624,
+        "y": 199.015625,
         "connections": {
           "error": "fb8f7fbe-2fa7-4de8-a5c1-c55c54b1fd3d",
-          "success": "c57cea8d-a2de-4422-8ccb-5ca9dcad5bde"
+          "success": "c20d2d99-dc1a-4a02-9931-2a3885ca160b"
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Reset Counter after login OK"
@@ -703,42 +497,15 @@
         "nodeType": "IdentifyExistingUserNode",
         "displayName": "Identify Existing User"
       },
-      "73252c50-1f11-468d-b5ee-aa0c44ec104d": {
-        "x": 2246,
-        "y": 83,
-        "connections": {
-          "false": "b3f513ec-f284-476d-b040-00918b40b772",
-          "true": "c5f45504-02d6-4370-b120-03c18d72a2a3"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Send MFA text via Notify"
-      },
       "7f0f8fa9-357a-4139-b407-d9a0336faaa9": {
-        "x": 3233,
-        "y": 191.015625,
+        "x": 3194,
+        "y": 206.015625,
         "connections": {
           "false": "b3f513ec-f284-476d-b040-00918b40b772",
           "true": "f9659606-3900-4580-8513-0e197e62452a"
         },
         "nodeType": "InnerTreeEvaluatorNode",
         "displayName": "Email Consent"
-      },
-      "9760e4cc-d4f7-4bf0-8985-18a4c8a7c55d": {
-        "x": 2239,
-        "y": 260,
-        "connections": {
-          "false": "b3f513ec-f284-476d-b040-00918b40b772",
-          "true": "c5f45504-02d6-4370-b120-03c18d72a2a3"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Send MFA email via Notify"
-      },
-      "979fd32f-2242-4d08-b31b-722c1ed419b4": {
-        "x": 2966,
-        "y": 423.015625,
-        "connections": {},
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "max attempts"
       },
       "a6ab1111-936e-49e9-86cf-45ced5596dde": {
         "x": 258,
@@ -748,16 +515,6 @@
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Email not exist msg"
-      },
-      "b07427f0-b984-4be6-a388-083e0111db19": {
-        "x": 2732,
-        "y": 318.015625,
-        "connections": {
-          "Reject": "979fd32f-2242-4d08-b31b-722c1ed419b4",
-          "Retry": "cdc774a7-c03c-4cf2-8514-9d7654aac599"
-        },
-        "nodeType": "RetryLimitDecisionNode",
-        "displayName": "Retry Limit Decision"
       },
       "bd62a4ef-dcf4-4952-904f-f7f3601b8ae3": {
         "x": 894,
@@ -769,36 +526,6 @@
         "nodeType": "InnerTreeEvaluatorNode",
         "displayName": "Update Legacy Password"
       },
-      "c13d3e4d-d2ed-47bc-acad-4ef3b70f62a5": {
-        "x": 1732,
-        "y": 75,
-        "connections": {
-          "false": "b3f513ec-f284-476d-b040-00918b40b772",
-          "true": "fa794bf3-ffbe-459d-9078-dbc19bfdf4c6"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Create Notify JWT - SMS"
-      },
-      "c57cea8d-a2de-4422-8ccb-5ca9dcad5bde": {
-        "x": 1240,
-        "y": 31.5,
-        "connections": {
-          "false": "eb0917d3-88bb-47ff-adf2-4157edae8d7a",
-          "true": "101b5c24-cb88-4ed1-8db6-5d4fc07f3c10"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Has Phone Number"
-      },
-      "c5f45504-02d6-4370-b120-03c18d72a2a3": {
-        "x": 2540,
-        "y": 64.015625,
-        "connections": {
-          "false": "b07427f0-b984-4be6-a388-083e0111db19",
-          "true": "24d11b28-95b9-478c-aede-990c2471109c"
-        },
-        "nodeType": "PageNode",
-        "displayName": "Enter OTP"
-      },
       "ca5a5885-e8be-4006-9004-28cf71922e75": {
         "x": 241,
         "y": 408.015625,
@@ -808,15 +535,6 @@
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Check Format"
-      },
-      "cdc774a7-c03c-4cf2-8514-9d7654aac599": {
-        "x": 2967,
-        "y": 351.015625,
-        "connections": {
-          "true": "c5f45504-02d6-4370-b120-03c18d72a2a3"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Raise Error"
       },
       "e69f6be3-d125-4f8c-9a54-d5960d481c7a": {
         "x": 614,
@@ -828,33 +546,14 @@
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Get IDM Token"
       },
-      "eb0917d3-88bb-47ff-adf2-4157edae8d7a": {
-        "x": 1732,
-        "y": 248,
-        "connections": {
-          "false": "b3f513ec-f284-476d-b040-00918b40b772",
-          "true": "3ef1391a-3bfb-4088-be5c-40713da8b6cc"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Create Notify JWT - Email"
-      },
       "f79be846-2226-41d2-a8f1-7a53ef4b5a77": {
-        "x": 2796,
-        "y": 155.5,
+        "x": 2423,
+        "y": 234.5,
         "connections": {
           "true": "31fa4b8d-9686-4bec-8db2-45d442533b22"
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Update Last Login"
-      },
-      "fa794bf3-ffbe-459d-9078-dbc19bfdf4c6": {
-        "x": 1992,
-        "y": 108.33333333333334,
-        "connections": {
-          "outcome": "73252c50-1f11-468d-b5ee-aa0c44ec104d"
-        },
-        "nodeType": "OneTimePasswordGeneratorNode",
-        "displayName": "HOTP Generator"
       },
       "fb8f7fbe-2fa7-4de8-a5c1-c55c54b1fd3d": {
         "x": 218,
@@ -866,8 +565,8 @@
         "displayName": "Login Form (EWF)"
       },
       "f9659606-3900-4580-8513-0e197e62452a": {
-        "x": 3372,
-        "y": 106.015625,
+        "x": 3453,
+        "y": 241.015625,
         "connections": {
           "success": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
         },
@@ -928,15 +627,15 @@
         "nodeType": "ScriptedDecisionNode",
         "displayName": "General Error"
       },
-      "101b5c24-cb88-4ed1-8db6-5d4fc07f3c10": {
-        "x": 1503,
-        "y": 50.015625,
+      "c20d2d99-dc1a-4a02-9931-2a3885ca160b": {
+        "x": 1934,
+        "y": 199.015625,
         "connections": {
-          "email": "eb0917d3-88bb-47ff-adf2-4157edae8d7a",
-          "text": "c13d3e4d-d2ed-47bc-acad-4ef3b70f62a5"
+          "true": "24d11b28-95b9-478c-aede-990c2471109c",
+          "false": "b3f513ec-f284-476d-b040-00918b40b772"
         },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Choose Email/SMS"
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Check OTP SubFlow"
       }
     },
     "staticNodes": {
@@ -945,8 +644,8 @@
         "y": 190
       },
       "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 3591,
-        "y": 34.66666666666666
+        "x": 3790,
+        "y": 236.66666666666666
       },
       "e301438c-0bd0-429c-ab0c-66126501069a": {
         "x": 3302,

--- a/config/auth-trees/ch-webfiling.json
+++ b/config/auth-trees/ch-webfiling.json
@@ -1,419 +1,532 @@
 {
-	"nodes": [
-		{
-            "_id":"35f0b7c1-ac55-406d-aebe-12e33ab6125a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["noSession", "hasSession"],
-                "outputs":["*"],
-                "script": "ddce54ff-70fe-4ef7-bdfe-3c83488ef266"
-            }            
+  "nodes": [
+    {
+      "_id": "35f0b7c1-ac55-406d-aebe-12e33ab6125a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "noSession",
+          "hasSession"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ddce54ff-70fe-4ef7-bdfe-3c83488ef266"
+      }
+    },
+    {
+      "_id": "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHWebFiling-Login"
+      }
+    },
+    {
+      "_id": "ffad651d-d017-43dc-bc3e-ec4768de5cc5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "19a9ba97-3eaf-46ed-9b59-ea9315d81407"
+      }
+    },
+    {
+      "_id": "61877889-8233-4048-b76c-39f882081e40",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ca6cbc1b-d83b-4946-b327-be15402894fa"
+      }
+    },
+    {
+      "_id": "9e1930dd-6045-417c-9286-d2083f454f01",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "0dc8c791-4b84-4f63-af32-5f10a58c54c1",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false",
+          "error",
+          "other"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "55801756-11bf-493d-b49c-195488cf939a"
+      }
+    },
+    {
+      "_id": "fc86f06d-b17e-4cda-b10c-fb9fae255d59",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ad7a63a6-fae2-46c0-be70-bec1f059f064"
+      }
+    },
+    {
+      "_id": "4b27ff9e-407a-4880-8c81-92be95c0e46f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "917f36a9-f21e-43e4-bed5-9b2171228387"
+      }
+    },
+    {
+      "_id": "3b9435a8-96c5-4b54-8877-1a494e9ab6e7",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "9f02e20d-5cee-4608-af7c-3732d3838d88",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "460f8d31-5f90-440a-9f47-f5951778ea4f"
+      }
+    },
+    {
+      "_id": "eba4be16-8b25-4ffd-ac41-97d7354a860d",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "78da2828-68cc-4f63-b003-b8a250b1753d"
+      }
+    },
+    {
+      "_id": "304e305a-a2f4-4380-a5db-3bca9b5da30e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "09352d71-046f-4fbf-b831-aefb8954705a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "error",
+          "already_associated",
+          "auth_code_inactive"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "16975ea5-4f0a-4ac6-861f-00dbf39ca441"
+      }
+    },
+    {
+      "_id": "c549d83a-f796-4a27-b6da-91cb626a0bd1",
+      "nodeType": "SessionDataNode",
+      "details": {
+        "sharedStateKey": "userName",
+        "sessionDataKey": "UserToken"
+      }
+    },
+    {
+      "_id": "b13495ba-6ac2-4877-8535-4f63dffb813f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "user_associated",
+          "user_not_associated",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "d8d0c71c-ddfb-47f6-a577-33aa0b7c2bcd"
+      }
+    },
+    {
+      "_id": "fbf0037d-0557-4111-bd01-edeb685c836f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df75d4ae-8f25-48f4-af14-bb87206e029d"
+      }
+    },
+    {
+      "_id": "bfcdaf66-5730-40b7-a847-00f62cd539ca",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df"
+      }
+    },
+    {
+      "_id": "cd37f8c8-249f-4d7c-be85-4c2bd262225b",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identifier": "userName",
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "22ba2520-ea77-4eb7-b9fb-6767cb98e54e",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHManageEmailConsent"
+      }
+    },
+    {
+      "_id": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHWebFiling",
+    "description": "Journey for WebFiling users",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "35f0b7c1-ac55-406d-aebe-12e33ab6125a",
+    "nodes": {
+      "09352d71-046f-4fbf-b831-aefb8954705a": {
+        "x": 1546,
+        "y": 425.015625,
+        "connections": {
+          "already_associated": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "auth_code_inactive": "61877889-8233-4048-b76c-39f882081e40",
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
         },
-		{
-			"_id": "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "CHWebFiling-Login"
-			}
-		},
-		{
-            "_id": "ffad651d-d017-43dc-bc3e-ec4768de5cc5",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-                "script": "19a9ba97-3eaf-46ed-9b59-ea9315d81407"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Association"
+      },
+      "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01": {
+        "x": 417,
+        "y": 164.015625,
+        "connections": {
+          "false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "ffad651d-d017-43dc-bc3e-ec4768de5cc5"
         },
-		{
-            "_id": "61877889-8233-4048-b76c-39f882081e40",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false"],
-                "outputs":["*"],
-                "script": "ca6cbc1b-d83b-4946-b327-be15402894fa"
-            }            
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Login"
+      },
+      "0dc8c791-4b84-4f63-af32-5f10a58c54c1": {
+        "x": 840,
+        "y": 391.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "false": "61877889-8233-4048-b76c-39f882081e40",
+          "other": "61877889-8233-4048-b76c-39f882081e40",
+          "true": "b13495ba-6ac2-4877-8535-4f63dffb813f"
         },
-		{
-            "_id": "9e1930dd-6045-417c-9286-d2083f454f01",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-                "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get Company Data"
+      },
+      "304e305a-a2f4-4380-a5db-3bca9b5da30e": {
+        "x": 1552,
+        "y": 304.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "success": "09352d71-046f-4fbf-b831-aefb8954705a"
         },
-		{
-            "_id": "0dc8c791-4b84-4f63-af32-5f10a58c54c1",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false", "error", "other"],
-                "outputs":["*"],
-                "script": "55801756-11bf-493d-b49c-195488cf939a"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM token again"
+      },
+      "35f0b7c1-ac55-406d-aebe-12e33ab6125a": {
+        "x": 195,
+        "y": 60.015625,
+        "connections": {
+          "hasSession": "c549d83a-f796-4a27-b6da-91cb626a0bd1",
+          "noSession": "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01"
         },
-		{
-			"_id": "fc86f06d-b17e-4cda-b10c-fb9fae255d59",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false"],
-                "outputs":["*"],
-                "script": "ad7a63a6-fae2-46c0-be70-bec1f059f064"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Session"
+      },
+      "3b9435a8-96c5-4b54-8877-1a494e9ab6e7": {
+        "x": 1337,
+        "y": 497.015625,
+        "connections": {
+          "Reject": "bfcdaf66-5730-40b7-a847-00f62cd539ca",
+          "Retry": "fc86f06d-b17e-4cda-b10c-fb9fae255d59"
         },
-		{
-			"_id": "4b27ff9e-407a-4880-8c81-92be95c0e46f",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-				"script": "917f36a9-f21e-43e4-bed5-9b2171228387"
-            }            
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "4b27ff9e-407a-4880-8c81-92be95c0e46f": {
+        "x": 1333,
+        "y": 422.015625,
+        "connections": {
+          "true": "3b9435a8-96c5-4b54-8877-1a494e9ab6e7"
         },
-		{
-            "_id": "3b9435a8-96c5-4b54-8877-1a494e9ab6e7",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit":3
-            }
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Auth code error msg"
+      },
+      "61877889-8233-4048-b76c-39f882081e40": {
+        "x": 810,
+        "y": 147.015625,
+        "connections": {
+          "false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "9e1930dd-6045-417c-9286-d2083f454f01"
         },
-		{
-			"_id": "9f02e20d-5cee-4608-af7c-3732d3838d88",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-				"script": "460f8d31-5f90-440a-9f47-f5951778ea4f"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Prompt for Company No"
+      },
+      "9e1930dd-6045-417c-9286-d2083f454f01": {
+        "x": 831,
+        "y": 264.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "success": "0dc8c791-4b84-4f63-af32-5f10a58c54c1"
         },
-		{
-			"_id": "eba4be16-8b25-4ffd-ac41-97d7354a860d",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false"],
-                "outputs":["*"],
-				"script": "78da2828-68cc-4f63-b003-b8a250b1753d"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Token"
+      },
+      "9f02e20d-5cee-4608-af7c-3732d3838d88": {
+        "x": 1549,
+        "y": 108.015625,
+        "connections": {
+          "true": "eba4be16-8b25-4ffd-ac41-97d7354a860d"
         },
-		{
-			"_id": "304e305a-a2f4-4380-a5db-3bca9b5da30e",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-				"script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Add Auth code to session"
+      },
+      "b13495ba-6ac2-4877-8535-4f63dffb813f": {
+        "x": 1053,
+        "y": 86.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "success": "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c"
         },
-		{
-			"_id": "09352d71-046f-4fbf-b831-aefb8954705a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "error", "already_associated", "auth_code_inactive"],
-                "outputs":["*"],
-				"script": "16975ea5-4f0a-4ac6-861f-00dbf39ca441"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Token for company check"
+      },
+      "bfcdaf66-5730-40b7-a847-00f62cd539ca": {
+        "x": 1343,
+        "y": 620.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "max attempts error"
+      },
+      "c549d83a-f796-4a27-b6da-91cb626a0bd1": {
+        "x": 380,
+        "y": 34.015625,
+        "connections": {
+          "outcome": "cd37f8c8-249f-4d7c-be85-4c2bd262225b"
         },
-		{
-			"_id": "c549d83a-f796-4a27-b6da-91cb626a0bd1",
-			"nodeType": "SessionDataNode", 
-			"details": {
-				"sharedStateKey":"userName",
-				"sessionDataKey":"UserToken"
-			}				
-		},
-		{
-			"_id": "b13495ba-6ac2-4877-8535-4f63dffb813f",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-				"script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
+        "nodeType": "SessionDataNode",
+        "displayName": "Get Session Data"
+      },
+      "cd37f8c8-249f-4d7c-be85-4c2bd262225b": {
+        "x": 616.640625,
+        "y": 60.015625,
+        "connections": {
+          "false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "61877889-8233-4048-b76c-39f882081e40"
         },
-		{
-			"_id": "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["user_associated", "user_not_associated", "error"],
-                "outputs":["*"],
-				"script": "d8d0c71c-ddfb-47f6-a577-33aa0b7c2bcd"
-            }            
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c": {
+        "x": 1071,
+        "y": 211.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "user_associated": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "user_not_associated": "fc86f06d-b17e-4cda-b10c-fb9fae255d59"
         },
-		{
-			"_id": "fbf0037d-0557-4111-bd01-edeb685c836f",
-			"nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true", "false"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "df75d4ae-8f25-48f4-af14-bb87206e029d"
-			}
-		},
-		{
-			"_id": "bfcdaf66-5730-40b7-a847-00f62cd539ca",
-			"nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df"
-			}
-		},
-		{
-			"_id": "cd37f8c8-249f-4d7c-be85-4c2bd262225b",
-			"nodeType": "IdentifyExistingUserNode",
-			"details": {
-				"identifier": "userName",
-				"identityAttribute": "mail"
-			}
-		},
-		{
-			"_id": "22ba2520-ea77-4eb7-b9fb-6767cb98e54e",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "CHManageEmailConsent"
-			}
-		},
-		{
-			"_id": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-			"nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-			}
-		}
-    ],
-    "tree": {
-		"_id": "CHWebFiling",
-		"description": "Journey for WebFiling users",
-		"identityResource": "managed/alpha_user",
-		"uiConfig": {},
-		"entryNodeId": "35f0b7c1-ac55-406d-aebe-12e33ab6125a",
-		"nodes": {
-			"09352d71-046f-4fbf-b831-aefb8954705a": {
-				"x": 1546,
-				"y": 425.015625,
-				"connections": {
-					"already_associated": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-					"auth_code_inactive": "61877889-8233-4048-b76c-39f882081e40",
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Create Association"
-			},
-			"0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01": {
-				"x": 417,
-				"y": 164.015625,
-				"connections": {
-					"false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "ffad651d-d017-43dc-bc3e-ec4768de5cc5"
-				},
-				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Login"
-			},
-			"0dc8c791-4b84-4f63-af32-5f10a58c54c1": {
-				"x": 840,
-				"y": 391.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"false": "61877889-8233-4048-b76c-39f882081e40",
-					"other": "61877889-8233-4048-b76c-39f882081e40",
-					"true": "b13495ba-6ac2-4877-8535-4f63dffb813f"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get Company Data"
-			},
-			"304e305a-a2f4-4380-a5db-3bca9b5da30e": {
-				"x": 1552,
-				"y": 304.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"success": "09352d71-046f-4fbf-b831-aefb8954705a"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM token again"
-			},
-			"35f0b7c1-ac55-406d-aebe-12e33ab6125a": {
-				"x": 195,
-				"y": 60.015625,
-				"connections": {
-					"hasSession": "c549d83a-f796-4a27-b6da-91cb626a0bd1",
-					"noSession": "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check Session"
-			},
-			"3b9435a8-96c5-4b54-8877-1a494e9ab6e7": {
-				"x": 1337,
-				"y": 497.015625,
-				"connections": {
-					"Reject": "bfcdaf66-5730-40b7-a847-00f62cd539ca",
-					"Retry": "fc86f06d-b17e-4cda-b10c-fb9fae255d59"
-				},
-				"nodeType": "RetryLimitDecisionNode",
-				"displayName": "Retry Limit Decision"
-			},
-			"4b27ff9e-407a-4880-8c81-92be95c0e46f": {
-				"x": 1333,
-				"y": 422.015625,
-				"connections": {
-					"true": "3b9435a8-96c5-4b54-8877-1a494e9ab6e7"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Auth code error msg"
-			},
-			"61877889-8233-4048-b76c-39f882081e40": {
-				"x": 810,
-				"y": 147.015625,
-				"connections": {
-					"false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "9e1930dd-6045-417c-9286-d2083f454f01"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Prompt for Company No"
-			},
-			"9e1930dd-6045-417c-9286-d2083f454f01": {
-				"x": 831,
-				"y": 264.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"success": "0dc8c791-4b84-4f63-af32-5f10a58c54c1"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM Token"
-			},
-			"9f02e20d-5cee-4608-af7c-3732d3838d88": {
-				"x": 1549,
-				"y": 108.015625,
-				"connections": {
-					"true": "eba4be16-8b25-4ffd-ac41-97d7354a860d"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Add Auth code to session"
-			},
-			"b13495ba-6ac2-4877-8535-4f63dffb813f": {
-				"x": 1053,
-				"y": 86.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"success": "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM Token for company check"
-			},
-			"bfcdaf66-5730-40b7-a847-00f62cd539ca": {
-				"x": 1343,
-				"y": 620.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "max attempts error"
-			},
-			"c549d83a-f796-4a27-b6da-91cb626a0bd1": {
-				"x": 380,
-				"y": 34.015625,
-				"connections": {
-					"outcome": "cd37f8c8-249f-4d7c-be85-4c2bd262225b"
-				},
-				"nodeType": "SessionDataNode",
-				"displayName": "Get Session Data"
-			},
-			"cd37f8c8-249f-4d7c-be85-4c2bd262225b": {
-				"x": 616.640625,
-				"y": 60.015625,
-				"connections": {
-					"false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "61877889-8233-4048-b76c-39f882081e40"
-				},
-				"nodeType": "IdentifyExistingUserNode",
-				"displayName": "Identify Existing User"
-			},
-			"dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c": {
-				"x": 1071,
-				"y": 211.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"user_associated": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-					"user_not_associated": "fc86f06d-b17e-4cda-b10c-fb9fae255d59"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check Company Association"
-			},
-			"eba4be16-8b25-4ffd-ac41-97d7354a860d": {
-				"x": 1552,
-				"y": 180.015625,
-				"connections": {
-					"false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-					"true": "304e305a-a2f4-4380-a5db-3bca9b5da30e"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Confirm association"
-			},
-			"fbf0037d-0557-4111-bd01-edeb685c836f": {
-				"x": 1308,
-				"y": 302.015625,
-				"connections": {
-					"false": "4b27ff9e-407a-4880-8c81-92be95c0e46f",
-					"true": "9f02e20d-5cee-4608-af7c-3732d3838d88"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Validate Cleartext Auth Code"
-			},
-			"fc86f06d-b17e-4cda-b10c-fb9fae255d59": {
-				"x": 1335,
-				"y": 178.015625,
-				"connections": {
-					"false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "fbf0037d-0557-4111-bd01-edeb685c836f"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Enter Auth Code"
-			},
-			"ffad651d-d017-43dc-bc3e-ec4768de5cc5": {
-				"x": 418,
-				"y": 290.015625,
-				"connections": {
-					"true": "61877889-8233-4048-b76c-39f882081e40"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Add to Session"
-			},
-			"074551cb-6074-4ded-b08e-03c638bfd1a1": {
-				"x": 1106,
-				"y": 780.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "General Error"
-			}
-		},
-		"staticNodes": {
-			"startNode": {
-				"x": 70,
-				"y": 80
-			},
-			"70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-				"x": 1819,
-				"y": 487
-			},
-			"e301438c-0bd0-429c-ab0c-66126501069a": {
-				"x": 1323,
-				"y": 769
-			}
-		}
-	}
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Company Association"
+      },
+      "eba4be16-8b25-4ffd-ac41-97d7354a860d": {
+        "x": 1552,
+        "y": 180.015625,
+        "connections": {
+          "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "true": "304e305a-a2f4-4380-a5db-3bca9b5da30e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Confirm association"
+      },
+      "fbf0037d-0557-4111-bd01-edeb685c836f": {
+        "x": 1308,
+        "y": 302.015625,
+        "connections": {
+          "false": "4b27ff9e-407a-4880-8c81-92be95c0e46f",
+          "true": "9f02e20d-5cee-4608-af7c-3732d3838d88"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Validate Cleartext Auth Code"
+      },
+      "fc86f06d-b17e-4cda-b10c-fb9fae255d59": {
+        "x": 1335,
+        "y": 178.015625,
+        "connections": {
+          "false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "fbf0037d-0557-4111-bd01-edeb685c836f"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Enter Auth Code"
+      },
+      "ffad651d-d017-43dc-bc3e-ec4768de5cc5": {
+        "x": 418,
+        "y": 290.015625,
+        "connections": {
+          "true": "61877889-8233-4048-b76c-39f882081e40"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Add to Session"
+      },
+      "074551cb-6074-4ded-b08e-03c638bfd1a1": {
+        "x": 1106,
+        "y": 780.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "General Error"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 70,
+        "y": 80
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1819,
+        "y": 487
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1323,
+        "y": 769
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Description

* switch off save of user retry limit to the user record, instead relying on current session state

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [ ] scripts (AM)
- [x] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
