### PR TITLE
idam-1074/modify retry limit decision nodes to not save to user state

### DIFF
--- a/config/auth-trees/ch-create-company-association.json
+++ b/config/auth-trees/ch-create-company-association.json
@@ -1,355 +1,454 @@
 {
-    "nodes": [
-        {
-            "_id":"0207683b-7437-4441-aa6b-a143ac0ab576",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["hasSession","noSession"],
-                "outputs":["*"],
-                "script":"c4001e02-469c-4cc4-bf95-9f43d7e46568"
-            }            
-        },
-        {
-            "_id":"54a93ee3-d273-49b6-8d23-0fd1dcb6320b",
-            "nodeType": "SessionDataNode", 
-            "details": {
-               "sharedStateKey":"userName",
-               "sessionDataKey":"UserToken"
-            }				
-        },
-        {
-            "_id":"e04ef6d2-daec-403e-93a1-f8b60a8f634b",
-            "nodeType": "IdentifyExistingUserNode", 
-            "details": {
-                "identifier":"userName",
-                "identityAttribute":"mail"
-            }
-        },
-        {
-            "_id":"3f37ce1b-c569-4229-a331-9bedf3ceb9af",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"838ab622-d892-44e6-a5c5-f45238aed210"
-            }            
-        },
-        {
-            "_id":"ef37be85-8d9f-4140-aa6a-b8c8cc19a695",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["success","error"],
-                "outputs":["*"],
-                "script":"c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
-        },
-        {
-            "_id":"e5c64e99-5259-4e93-bb25-1871b370f7cd",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["success","error"],
-                "outputs":["*"],
-                "script":"c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
-        },
-        {
-            "_id":"a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false", "error", "other"],
-                "outputs":["*"],
-                "script":"55801756-11bf-493d-b49c-195488cf939a"
-            }            
-        },
-        {
-            "_id":"b2401c4a-636f-43e4-b129-be18fccf30f3",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","error","already_associated", "auth_code_inactive"],
-                "outputs":["*"],
-                "script":"16975ea5-4f0a-4ac6-861f-00dbf39ca441"
-            }            
-        },
-        {
-            "_id":"78204b08-ebbd-4b61-8b1b-080a1061987a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"10f63087-b21b-40eb-9c90-8e3fb3fabfa1"
-            }            
-        },
-        {
-            "_id":"55ab38cb-458d-4c6c-ba34-3586bf34b06c",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true","false"],
-                "outputs":["*"],
-                "script":"ad7a63a6-fae2-46c0-be70-bec1f059f064"
-            }            
-        },
-        {
-            "_id":"c5f729d0-922d-44f8-a480-aa34d2ca02d8",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"917f36a9-f21e-43e4-bed5-9b2171228387"
-            }            
-        },
-        {
-            "_id":"ba60739d-61f1-4ede-bf94-3f3dc628a38d",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit":3
-            }
-        },
-        {
-         "_id":"c7714228-4b3d-403c-8807-39c028bf549c",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-             "inputs":["*"],
-             "outcomes":["true"],
-             "outputs":["*"],
-             "script":"fdac4efb-d8b8-478b-8300-e11a4c3503df"
-         }            
-      },
-      {
-         "_id": "93328e47-3918-42c3-a27d-b5cf6c1abb67",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "outcomes": ["true", "false"],
-            "inputs": ["*"],
-            "outputs": ["*"],
-            "script": "df75d4ae-8f25-48f4-af14-bb87206e029d"
-         }
-      },
-      {
-         "_id": "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "outcomes": ["success", "error"],
-            "inputs": ["*"],
-            "outputs": ["*"],
-            "script": "1b3c84cf-411a-4e5b-998f-768191e735f1"
-         }
-      },
-      {
-         "_id": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "outcomes": ["true"],
-            "inputs": ["*"],
-            "outputs": ["*"],
-            "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-         }
-      },
-      {
-         "_id": "537ff588-0447-4938-b1be-bce4fe9869ce",
-         "nodeType": "ScriptedDecisionNode", 
-         "details": {
-            "outcomes": ["true", "false"],
-            "inputs": ["*"],
-            "outputs": ["*"],
-            "script": "df67765e-df3a-4503-9ba5-35c992b39259"
-         }
+  "nodes": [
+    {
+      "_id": "0207683b-7437-4441-aa6b-a143ac0ab576",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "hasSession",
+          "noSession"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c4001e02-469c-4cc4-bf95-9f43d7e46568"
       }
-   ],
-   "tree": {
-      "_id": "CHCompanyAssociation",
-      "description": "As an authenticated user, enter a company number, company auth code and create an association with that company",
-      "identityResource": "managed/alpha_user",
-      "uiConfig": {},
-      "entryNodeId": "0207683b-7437-4441-aa6b-a143ac0ab576",
-      "nodes": {
-         "0207683b-7437-4441-aa6b-a143ac0ab576": {
-            "x": 175,
-            "y": 402.015625,
-            "connections": {
-               "hasSession": "54a93ee3-d273-49b6-8d23-0fd1dcb6320b",
-               "noSession": "95966d43-e698-432d-b3d8-2f8fb0e98276"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "check session"
-         },
-         "3f37ce1b-c569-4229-a331-9bedf3ceb9af": {
-            "x": 559,
-            "y": 26.015625,
-            "connections": {
-               "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "ef37be85-8d9f-4140-aa6a-b8c8cc19a695"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Enter company No"
-         },
-         "54a93ee3-d273-49b6-8d23-0fd1dcb6320b": {
-            "x": 222,
-            "y": 238.015625,
-            "connections": {
-               "outcome": "e04ef6d2-daec-403e-93a1-f8b60a8f634b"
-            },
-            "nodeType": "SessionDataNode",
-            "displayName": "Get Session Data"
-         },
-         "55ab38cb-458d-4c6c-ba34-3586bf34b06c": {
-            "x": 1097,
-            "y": 30,
-            "connections": {
-               "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "93328e47-3918-42c3-a27d-b5cf6c1abb67"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Enter Auth Code"
-         },
-         "78204b08-ebbd-4b61-8b1b-080a1061987a": {
-            "x": 1707,
-            "y": 532.015625,
-            "connections": {
-               "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Confirmation"
-         },
-         "93328e47-3918-42c3-a27d-b5cf6c1abb67": {
-            "x": 1285,
-            "y": 33.015625,
-            "connections": {
-               "false": "c5f729d0-922d-44f8-a480-aa34d2ca02d8",
-               "true": "e5c64e99-5259-4e93-bb25-1871b370f7cd"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Validate Cleartext Auth Code"
-         },
-         "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6": {
-            "x": 916,
-            "y": 182.015625,
-            "connections": {
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "false": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
-               "true": "55ab38cb-458d-4c6c-ba34-3586bf34b06c",
-               "other": "3f37ce1b-c569-4229-a331-9bedf3ceb9af"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "get company data"
-         },
-         "b2401c4a-636f-43e4-b129-be18fccf30f3": {
-            "x": 1683,
-            "y": 142.015625,
-            "connections": {
-               "already_associated": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
-               "auth_code_inactive": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "537ff588-0447-4938-b1be-bce4fe9869ce"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Association"
-         },
-         "ba60739d-61f1-4ede-bf94-3f3dc628a38d": {
-            "x": 1289,
-            "y": 409.015625,
-            "connections": {
-               "Reject": "c7714228-4b3d-403c-8807-39c028bf549c",
-               "Retry": "55ab38cb-458d-4c6c-ba34-3586bf34b06c"
-            },
-            "nodeType": "RetryLimitDecisionNode",
-            "displayName": "Retry Limit Decision"
-         },
-         "c5f729d0-922d-44f8-a480-aa34d2ca02d8": {
-            "x": 1303,
-            "y": 247,
-            "connections": {
-               "true": "ba60739d-61f1-4ede-bf94-3f3dc628a38d"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Auth Code Error Message"
-         },
-         "c7714228-4b3d-403c-8807-39c028bf549c": {
-            "x": 1436,
-            "y": 629.015625,
-            "connections": {},
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "max attempts message"
-         },
-         "e04ef6d2-daec-403e-93a1-f8b60a8f634b": {
-            "x": 299.40625,
-            "y": 37.015625,
-            "connections": {
-               "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "3f37ce1b-c569-4229-a331-9bedf3ceb9af"
-            },
-            "nodeType": "IdentifyExistingUserNode",
-            "displayName": "Identify Existing User"
-         },
-         "e5c64e99-5259-4e93-bb25-1871b370f7cd": {
-            "x": 1534,
-            "y": 37.015625,
-            "connections": {
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "success": "b2401c4a-636f-43e4-b129-be18fccf30f3"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "get IDM token again"
-         },
-         "ef37be85-8d9f-4140-aa6a-b8c8cc19a695": {
-            "x": 790,
-            "y": 22.015625,
-            "connections": {
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "success": "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "get IDM token"
-         },
-         "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb": {
-            "x": 1629,
-            "y": 410.015625,
-            "connections": {
-               "success": "78204b08-ebbd-4b61-8b1b-080a1061987a",
-               "error": "95966d43-e698-432d-b3d8-2f8fb0e98276"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Notify Company Members"
-         },
-         "95966d43-e698-432d-b3d8-2f8fb0e98276": {
-            "x": 917,
-            "y": 755.015625,
-            "connections": {},
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Generic error"
-         },
-         "537ff588-0447-4938-b1be-bce4fe9869ce": {
-            "x": 1641,
-            "y": 303.015625,
-            "connections": {
-               "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
-               "true": "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb"
-            },
-            "nodeType": "ScriptedDecisionNode",
-            "displayName": "Create Notify JWT"
-         }
-      },
-      "staticNodes": {
-         "startNode": {
-            "x": 50,
-            "y": 250
-         },
-         "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-            "x": 2020,
-            "y": 128
-         },
-         "e301438c-0bd0-429c-ab0c-66126501069a": {
-            "x": 1572,
-            "y": 777
-         }
+    },
+    {
+      "_id": "54a93ee3-d273-49b6-8d23-0fd1dcb6320b",
+      "nodeType": "SessionDataNode",
+      "details": {
+        "sharedStateKey": "userName",
+        "sessionDataKey": "UserToken"
       }
-   }
+    },
+    {
+      "_id": "e04ef6d2-daec-403e-93a1-f8b60a8f634b",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identifier": "userName",
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "838ab622-d892-44e6-a5c5-f45238aed210"
+      }
+    },
+    {
+      "_id": "ef37be85-8d9f-4140-aa6a-b8c8cc19a695",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "e5c64e99-5259-4e93-bb25-1871b370f7cd",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false",
+          "error",
+          "other"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "55801756-11bf-493d-b49c-195488cf939a"
+      }
+    },
+    {
+      "_id": "b2401c4a-636f-43e4-b129-be18fccf30f3",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "error",
+          "already_associated",
+          "auth_code_inactive"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "16975ea5-4f0a-4ac6-861f-00dbf39ca441"
+      }
+    },
+    {
+      "_id": "78204b08-ebbd-4b61-8b1b-080a1061987a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "10f63087-b21b-40eb-9c90-8e3fb3fabfa1"
+      }
+    },
+    {
+      "_id": "55ab38cb-458d-4c6c-ba34-3586bf34b06c",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ad7a63a6-fae2-46c0-be70-bec1f059f064"
+      }
+    },
+    {
+      "_id": "c5f729d0-922d-44f8-a480-aa34d2ca02d8",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "917f36a9-f21e-43e4-bed5-9b2171228387"
+      }
+    },
+    {
+      "_id": "ba60739d-61f1-4ede-bf94-3f3dc628a38d",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "c7714228-4b3d-403c-8807-39c028bf549c",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df"
+      }
+    },
+    {
+      "_id": "93328e47-3918-42c3-a27d-b5cf6c1abb67",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df75d4ae-8f25-48f4-af14-bb87206e029d"
+      }
+    },
+    {
+      "_id": "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "1b3c84cf-411a-4e5b-998f-768191e735f1"
+      }
+    },
+    {
+      "_id": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
+      }
+    },
+    {
+      "_id": "537ff588-0447-4938-b1be-bce4fe9869ce",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHCompanyAssociation",
+    "description": "As an authenticated user, enter a company number, company auth code and create an association with that company",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "0207683b-7437-4441-aa6b-a143ac0ab576",
+    "nodes": {
+      "0207683b-7437-4441-aa6b-a143ac0ab576": {
+        "x": 175,
+        "y": 402.015625,
+        "connections": {
+          "hasSession": "54a93ee3-d273-49b6-8d23-0fd1dcb6320b",
+          "noSession": "95966d43-e698-432d-b3d8-2f8fb0e98276"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "check session"
+      },
+      "3f37ce1b-c569-4229-a331-9bedf3ceb9af": {
+        "x": 559,
+        "y": 26.015625,
+        "connections": {
+          "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "ef37be85-8d9f-4140-aa6a-b8c8cc19a695"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Enter company No"
+      },
+      "54a93ee3-d273-49b6-8d23-0fd1dcb6320b": {
+        "x": 222,
+        "y": 238.015625,
+        "connections": {
+          "outcome": "e04ef6d2-daec-403e-93a1-f8b60a8f634b"
+        },
+        "nodeType": "SessionDataNode",
+        "displayName": "Get Session Data"
+      },
+      "55ab38cb-458d-4c6c-ba34-3586bf34b06c": {
+        "x": 1097,
+        "y": 30,
+        "connections": {
+          "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "93328e47-3918-42c3-a27d-b5cf6c1abb67"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Enter Auth Code"
+      },
+      "78204b08-ebbd-4b61-8b1b-080a1061987a": {
+        "x": 1707,
+        "y": 532.015625,
+        "connections": {
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Confirmation"
+      },
+      "93328e47-3918-42c3-a27d-b5cf6c1abb67": {
+        "x": 1285,
+        "y": 33.015625,
+        "connections": {
+          "false": "c5f729d0-922d-44f8-a480-aa34d2ca02d8",
+          "true": "e5c64e99-5259-4e93-bb25-1871b370f7cd"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Validate Cleartext Auth Code"
+      },
+      "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6": {
+        "x": 916,
+        "y": 182.015625,
+        "connections": {
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "false": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
+          "true": "55ab38cb-458d-4c6c-ba34-3586bf34b06c",
+          "other": "3f37ce1b-c569-4229-a331-9bedf3ceb9af"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "get company data"
+      },
+      "b2401c4a-636f-43e4-b129-be18fccf30f3": {
+        "x": 1683,
+        "y": 142.015625,
+        "connections": {
+          "already_associated": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
+          "auth_code_inactive": "3f37ce1b-c569-4229-a331-9bedf3ceb9af",
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "537ff588-0447-4938-b1be-bce4fe9869ce"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Association"
+      },
+      "ba60739d-61f1-4ede-bf94-3f3dc628a38d": {
+        "x": 1289,
+        "y": 409.015625,
+        "connections": {
+          "Reject": "c7714228-4b3d-403c-8807-39c028bf549c",
+          "Retry": "55ab38cb-458d-4c6c-ba34-3586bf34b06c"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "c5f729d0-922d-44f8-a480-aa34d2ca02d8": {
+        "x": 1303,
+        "y": 247,
+        "connections": {
+          "true": "ba60739d-61f1-4ede-bf94-3f3dc628a38d"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Auth Code Error Message"
+      },
+      "c7714228-4b3d-403c-8807-39c028bf549c": {
+        "x": 1436,
+        "y": 629.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "max attempts message"
+      },
+      "e04ef6d2-daec-403e-93a1-f8b60a8f634b": {
+        "x": 299.40625,
+        "y": 37.015625,
+        "connections": {
+          "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "3f37ce1b-c569-4229-a331-9bedf3ceb9af"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "e5c64e99-5259-4e93-bb25-1871b370f7cd": {
+        "x": 1534,
+        "y": 37.015625,
+        "connections": {
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "success": "b2401c4a-636f-43e4-b129-be18fccf30f3"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "get IDM token again"
+      },
+      "ef37be85-8d9f-4140-aa6a-b8c8cc19a695": {
+        "x": 790,
+        "y": 22.015625,
+        "connections": {
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "success": "a011052d-bbf2-4dd9-93fc-bf96e3d9b7f6"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "get IDM token"
+      },
+      "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb": {
+        "x": 1629,
+        "y": 410.015625,
+        "connections": {
+          "success": "78204b08-ebbd-4b61-8b1b-080a1061987a",
+          "error": "95966d43-e698-432d-b3d8-2f8fb0e98276"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Notify Company Members"
+      },
+      "95966d43-e698-432d-b3d8-2f8fb0e98276": {
+        "x": 917,
+        "y": 755.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Generic error"
+      },
+      "537ff588-0447-4938-b1be-bce4fe9869ce": {
+        "x": 1641,
+        "y": 303.015625,
+        "connections": {
+          "false": "95966d43-e698-432d-b3d8-2f8fb0e98276",
+          "true": "a35dc8d4-66a5-4e6e-b3e0-9a7612d52bbb"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 50,
+        "y": 250
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 2020,
+        "y": 128
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1572,
+        "y": 777
+      }
+    }
+  }
 }

--- a/config/auth-trees/ch-credential-validation.json
+++ b/config/auth-trees/ch-credential-validation.json
@@ -1,191 +1,208 @@
 {
-    "nodes": [
-        {
-            "_id": "73454ed9-828e-44a5-8ca2-c65085852d9f",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "outcomes": [
-                    "hasSession",
-                    "noSession"
-                ],
-                "script": "c4001e02-469c-4cc4-bf95-9f43d7e46568"
-            }
-        },
-        {
-            "_id": "f27fc95c-c74f-4778-8d53-8cb2a5e142a1",
-            "nodeType": "SessionDataNode",
-            "details": {
-                "sessionDataKey": "UserToken",
-                "sharedStateKey": "userName"
-            }
-        },
-        {
-            "_id": "78936cb2-2423-4b7e-9a45-528b8b386dcd",
-            "nodeType": "IdentifyExistingUserNode",
-            "details": {
-                "identifier": "userName",
-                "identityAttribute": "mail"
-            }
-        },
-        {
-            "_id": "956820bb-c811-41be-b09f-64406dce2e62",
-            "nodeType": "PageNode",
-            "details": {
-                "nodes": [
-                    {
-                        "_id": "1408b24a-ed80-47ab-b388-02a7cb6814e5",
-                        "nodeType": "ScriptedDecisionNode",
-                        "displayName": "Scripted Decision"
-                    }
-                ],
-                "pageHeader": {
-                    "header": "Please enter the credential"
-                },
-                "pageDescription": {
-                    "desc": "Please enter the credential to validate"
-                },
-                "stage": "VALIDATE_CREDENTIAL_1"
-            }
-        },
-        {
+  "nodes": [
+    {
+      "_id": "73454ed9-828e-44a5-8ca2-c65085852d9f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "outcomes": [
+          "hasSession",
+          "noSession"
+        ],
+        "script": "c4001e02-469c-4cc4-bf95-9f43d7e46568"
+      }
+    },
+    {
+      "_id": "f27fc95c-c74f-4778-8d53-8cb2a5e142a1",
+      "nodeType": "SessionDataNode",
+      "details": {
+        "sessionDataKey": "UserToken",
+        "sharedStateKey": "userName"
+      }
+    },
+    {
+      "_id": "78936cb2-2423-4b7e-9a45-528b8b386dcd",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identifier": "userName",
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "956820bb-c811-41be-b09f-64406dce2e62",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
             "_id": "1408b24a-ed80-47ab-b388-02a7cb6814e5",
             "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "7f9c55bb-9307-45b7-9b4f-7d1bf4e8ea49"
-            }
+            "displayName": "Scripted Decision"
+          }
+        ],
+        "pageHeader": {
+          "header": "Please enter the credential"
         },
-        {
-            "_id": "578be13f-34d4-412d-9dca-4a8e46b4008f",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "137e1fd5-19f4-425d-96eb-2a8c20cabcf8"
-            }
+        "pageDescription": {
+          "desc": "Please enter the credential to validate"
         },
-        {
-            "_id": "3b40ffa2-ad51-444f-a040-2748beab59a5",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "65d2099f-9583-47d3-8303-8051709cb436"
-            }
-        },
-        {
-            "_id": "5c2c9a13-626d-4058-8447-31c78d04acee",
-            "nodeType": "RetryLimitDecisionNode",
-            "details": {
-                "retryLimit": 3
-            }
-        }
-    ],
-    "tree": {
-        "_id": "CHCredentialValidation",
-        "description": "As an authenticated user, validate a supplied cleartext credential against a hashed version",
-        "identityResource": "managed/alpha_user",
-        "entryNodeId": "73454ed9-828e-44a5-8ca2-c65085852d9f",
-        "staticNodes": {
-            "startNode": {
-                "x": 62,
-                "y": 103
-            },
-            "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-                "x": 1925,
-                "y": 315
-            },
-            "e301438c-0bd0-429c-ab0c-66126501069a": {
-                "x": 1764,
-                "y": 747
-            }
-        },
-        "uiConfig": {},
-        "nodes": {
-            "3b40ffa2-ad51-444f-a040-2748beab59a5": {
-                "x": 1648,
-                "y": 334.015625,
-                "connections": {
-                    "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-                    "false": "5c2c9a13-626d-4058-8447-31c78d04acee"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Call Validation Service"
-            },
-            "578be13f-34d4-412d-9dca-4a8e46b4008f": {
-                "x": 1399,
-                "y": 340.015625,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "3b40ffa2-ad51-444f-a040-2748beab59a5"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Fetch Hashed Password"
-            },
-            "73454ed9-828e-44a5-8ca2-c65085852d9f": {
-                "x": 190,
-                "y": 531.015625,
-                "connections": {
-                    "hasSession": "f27fc95c-c74f-4778-8d53-8cb2a5e142a1",
-                    "noSession": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check for Session"
-            },
-            "78936cb2-2423-4b7e-9a45-528b8b386dcd": {
-                "x": 712.828125,
-                "y": 340.015625,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "956820bb-c811-41be-b09f-64406dce2e62"
-                },
-                "nodeType": "IdentifyExistingUserNode",
-                "displayName": "Identify Existing User"
-            },
-            "956820bb-c811-41be-b09f-64406dce2e62": {
-                "x": 1101,
-                "y": 295.015625,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "578be13f-34d4-412d-9dca-4a8e46b4008f"
-                },
-                "nodeType": "PageNode",
-                "displayName": "Enter Credential"
-            },
-            "f27fc95c-c74f-4778-8d53-8cb2a5e142a1": {
-                "x": 443,
-                "y": 388.015625,
-                "connections": {
-                    "outcome": "78936cb2-2423-4b7e-9a45-528b8b386dcd"
-                },
-                "nodeType": "SessionDataNode",
-                "displayName": "Get Session Data"
-            },
-            "5c2c9a13-626d-4058-8447-31c78d04acee": {
-                "x": 1135,
-                "y": 537.015625,
-                "connections": {
-                    "Retry": "956820bb-c811-41be-b09f-64406dce2e62",
-                    "Reject": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "RetryLimitDecisionNode",
-                "displayName": "Retry Limit Decision"
-            }
-        }
+        "stage": "VALIDATE_CREDENTIAL_1"
+      }
+    },
+    {
+      "_id": "1408b24a-ed80-47ab-b388-02a7cb6814e5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "7f9c55bb-9307-45b7-9b4f-7d1bf4e8ea49"
+      }
+    },
+    {
+      "_id": "578be13f-34d4-412d-9dca-4a8e46b4008f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "137e1fd5-19f4-425d-96eb-2a8c20cabcf8"
+      }
+    },
+    {
+      "_id": "3b40ffa2-ad51-444f-a040-2748beab59a5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "65d2099f-9583-47d3-8303-8051709cb436"
+      }
+    },
+    {
+      "_id": "5c2c9a13-626d-4058-8447-31c78d04acee",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
     }
+  ],
+  "tree": {
+    "_id": "CHCredentialValidation",
+    "description": "As an authenticated user, validate a supplied cleartext credential against a hashed version",
+    "identityResource": "managed/alpha_user",
+    "entryNodeId": "73454ed9-828e-44a5-8ca2-c65085852d9f",
+    "staticNodes": {
+      "startNode": {
+        "x": 62,
+        "y": 103
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1925,
+        "y": 315
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1764,
+        "y": 747
+      }
+    },
+    "uiConfig": {},
+    "nodes": {
+      "3b40ffa2-ad51-444f-a040-2748beab59a5": {
+        "x": 1648,
+        "y": 334.015625,
+        "connections": {
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "false": "5c2c9a13-626d-4058-8447-31c78d04acee"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Call Validation Service"
+      },
+      "578be13f-34d4-412d-9dca-4a8e46b4008f": {
+        "x": 1399,
+        "y": 340.015625,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "3b40ffa2-ad51-444f-a040-2748beab59a5"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Fetch Hashed Password"
+      },
+      "73454ed9-828e-44a5-8ca2-c65085852d9f": {
+        "x": 190,
+        "y": 531.015625,
+        "connections": {
+          "hasSession": "f27fc95c-c74f-4778-8d53-8cb2a5e142a1",
+          "noSession": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check for Session"
+      },
+      "78936cb2-2423-4b7e-9a45-528b8b386dcd": {
+        "x": 712.828125,
+        "y": 340.015625,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "956820bb-c811-41be-b09f-64406dce2e62"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "956820bb-c811-41be-b09f-64406dce2e62": {
+        "x": 1101,
+        "y": 295.015625,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "578be13f-34d4-412d-9dca-4a8e46b4008f"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Enter Credential"
+      },
+      "f27fc95c-c74f-4778-8d53-8cb2a5e142a1": {
+        "x": 443,
+        "y": 388.015625,
+        "connections": {
+          "outcome": "78936cb2-2423-4b7e-9a45-528b8b386dcd"
+        },
+        "nodeType": "SessionDataNode",
+        "displayName": "Get Session Data"
+      },
+      "5c2c9a13-626d-4058-8447-31c78d04acee": {
+        "x": 1135,
+        "y": 537.015625,
+        "connections": {
+          "Retry": "956820bb-c811-41be-b09f-64406dce2e62",
+          "Reject": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      }
+    }
+  }
 }

--- a/config/auth-trees/ch-login.json
+++ b/config/auth-trees/ch-login.json
@@ -1,631 +1,769 @@
 {
-	"nodes": [
-		{
-			"_id": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-			"nodeType": "PageNode",
-			"details": {
-				"nodes": [ 
-					{
-						"_id": "a346e4e7-8490-4ec6-962f-ebb9ba51dbe6",
-						"nodeType": "ValidatedUsernameNode",
-						"displayName": "Platform Username"
-					}, 
-					{
-						"_id": "d28720a1-ad25-406b-baea-d3691f5122ea",
-						"nodeType": "ValidatedPasswordNode",
-						"displayName": "Platform Password"
-					},
-					{
-						"_id": "3b1940b6-a238-455e-8d13-ceb0f2848be4",
-						"nodeType": "ScriptedDecisionNode",
-						"displayName": "Error Handling"
-					}
-				],
-				"pageDescription": {
-					"en": "New here? <a href=\"#/service/Registration\">Create an account</a><br><a href=\"#/service/ForgottenUsername\">Forgot username?</a><a href=\"#/service/ResetPassword\"> Forgot password?</a>"
-				},
-				"pageHeader": {
-					"en": "Sign In"
-				},
-				"stage": "CH_LOGIN_1"
-			}
-		},
-		{
-			"_id": "a346e4e7-8490-4ec6-962f-ebb9ba51dbe6",
-			"nodeType": "ValidatedUsernameNode",
-			"details": {
-				"usernameAttribute": "userName",
-				"validateInput": false
-			}
-		},
-		{
-			"_id": "d28720a1-ad25-406b-baea-d3691f5122ea",
-			"nodeType": "ValidatedPasswordNode",
-			"details": {
-				"passwordAttribute": "password",
-				"validateInput": false
-			}
-		},
-		{
-			"_id": "4f019558-f468-46f2-8000-5bba1d9dac45",
-			"nodeType": "IdentifyExistingUserNode",
-			"details": {
-				"identifier": "userName",
-				"identityAttribute": "mail"
-			}
-		},
-		{
-			"_id": "758e3d0a-3211-4850-8847-86981f75888e",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "CHUpdateLegacyPassword"
-			}
-		},
-		{
-			"_id": "c32fab79-8836-4657-bef0-9f03a1e1165f",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "20a3599f-b742-4554-a8b7-27862f248dd5"
-			}
-		},
-		{
-			"_id": "0e91440f-8d40-4946-88c9-1a7e22da57bc",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "b480d9f7-5908-45cf-91d1-bc1fe56fe8de"
-			}
-		},
-		{
-			"_id": "9339d5b3-f917-46a5-918e-a8b4ce884d81",
-			"nodeType": "PageNode",
-			"details": {
-				"nodes": [{
-					"_id": "7c1389a2-2b21-483b-a2f2-2e2ad42f52b2",
-					"nodeType": "ChoiceCollectorNode",
-					"displayName": "Choice Collector"
-				}],
-				"pageDescription": {
-					"desc": "How do you want to confirm it's you?"
-				},
-				"pageHeader": {
-					"header": "How do you want to confirm it's you?"
-				},
-				"stage": "CH_LOGIN_2"
-			}
-		},
-		{
-			"_id": "7c1389a2-2b21-483b-a2f2-2e2ad42f52b2",
-			"nodeType": "ChoiceCollectorNode",
-			"details": {
-				"choices": ["email", "text"],
-				"defaultChoice": "email",
-				"prompt": "How do you want to confirm it's you?"
-			}
-		},
-		{
-			"_id": "3147767a-bb7b-47b2-9b43-6d297e7cc2fa",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "df67765e-df3a-4503-9ba5-35c992b39259"
-			}
-		},
-		{
-			"_id": "0e167098-4f1b-4a6d-a383-9a415b143dda",
-			"nodeType": "OneTimePasswordGeneratorNode",
-			"details": {
-				"length": 6
-			}
-		},
-		{
-			"_id": "860b9b8a-260a-4123-85f5-7cf50e20a291",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "b276c566-622e-11eb-ae93-0242ac130002"
-			}
-		},
-		{
-			"_id": "1031a228-600a-4325-82da-c93e6a13ab5b",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "df67765e-df3a-4503-9ba5-35c992b39259"
-			}
-		},
-		{
-			"_id": "c20b82fd-458d-4a46-8d0f-41d589f3976b",
-			"nodeType": "OneTimePasswordGeneratorNode",
-			"details": {
-				"length": 6
-			}
-		},
-		{
-			"_id": "5e76d32e-9180-4a20-b0bd-ff9b89773cbb",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true", "false"],
-				"outputs": ["*"],
-				"script": "a5778ce7-addf-4fb6-a7db-92929f1314c4"
-			}
-		},
-		{
-			"_id": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0",
-			"nodeType": "PageNode",
-			"details": {
-				"nodes": [{
-					"_id": "60732b03-b048-432e-be0f-cb13e211586e",
-					"nodeType": "ScriptedDecisionNode",
-					"displayName": "Scripted Decision"
-				}, {
-					"_id": "3633da1e-04fc-4d44-a6c8-b199cfade38a",
-					"nodeType": "OneTimePasswordCollectorDecisionNode",
-					"displayName": "OTP Collector Decision"
-				}],
-				"pageDescription": {
-					"desc": "Please enter the code you received"
-				},
-				"pageHeader": {
-					"header": "Please enter your code"
-				},
-				"stage": "CH_LOGIN_3"
-			}
-		},
-		{
-			"_id": "60732b03-b048-432e-be0f-cb13e211586e",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["True"],
-				"outputs": ["*"],
-				"script": "ace951c8-d169-4426-9357-d5b44e0aa728"
-			}
-		},
-		{
-			"_id": "3633da1e-04fc-4d44-a6c8-b199cfade38a",
-			"nodeType": "OneTimePasswordCollectorDecisionNode",
-			"details": {
-				"passwordExpiryTime": 30
-			}
-		},
-		{
-			"_id": "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc",
-			"nodeType": "RetryLimitDecisionNode",
-			"details": {
-				"retryLimit": 3
-			}
-		},
-		{
-			"_id": "739919ca-5a2b-4788-a447-36fe83a011f9",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true"],
-				"outputs": ["*"],
-				"script": "bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c"
-			}
-		},
-		{
-			"_id": "ae62ed05-3a04-456b-8642-7bc222e0dd43",
-			"nodeType": "IncrementLoginCountNode",
-			"details": {
-				"identityAttribute": "userName"
-			}
-		},
-		{
-			"_id": "bf46b661-96c6-443a-b012-3b5608b7051f",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"inputs": ["*"],
-				"outcomes": ["true"],
-				"outputs": ["*"],
-				"script": "d7da3b35-af63-499b-aa0a-bb03666508db"
-			}
-		},
-		{
-			"_id": "f8d1e6a3-14d1-4eda-9515-6e0dfacad539",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "ProgressiveProfile"
-			}
-		},
-		{
-			"_id": "3b1940b6-a238-455e-8d13-ceb0f2848be4",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "064705f3-93d3-482c-ad3f-4531a28ce0a0"
-			}
-		},
-		{
-			"_id": "c99c82c6-20f5-456d-a94e-680c4f4a6307",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true", "false"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "188d3f9d-ca04-4df7-bcd7-eed3fe27e21e"
-			}
-		},
-		{
-			"_id": "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "a1ebbcd2-39c1-47c2-a152-4bebcf8cfb5b"
-			}
-		},
-		{
-			"_id": "bd940aa3-c854-4934-b67a-1183d89be21f",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["success", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-			}
-		},
-		{
-			"_id": "fa88fc01-a7a2-429f-b7cc-546fe67a70b4",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["locked", "error", "lock_expired", "not_locked"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "7837ccb6-2e56-44bf-a5df-7cfdb0bfc38b"
-			}
-		},
-		{
-			"_id": "fc36693f-b04c-46f8-a683-1e1c1498c8bd",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["success", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "329154d4-5e55-4cc5-a17e-19d4fd3729aa"
-			}
-		},
-		{
-			"_id": "6486165d-fb00-4248-93c8-4f36ad2b2cb1",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["success", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "329154d4-5e55-4cc5-a17e-19d4fd3729aa"
-			}
-		},
-		{
-			"_id": "9d8e176e-3175-45a5-8ff3-ca0138c1b300",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["success", "error"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-			}
-		},
-		{
-			"_id": "4a8df6a5-8e56-4765-8ea0-2ff6200b6297",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "e0aec02a-ad8b-427d-a72e-cdfd8cb6c0e0"
-			}
-		},
-		{
-			"_id": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-			"nodeType": "ScriptedDecisionNode",
-			"details": {
-				"outcomes": ["true"],
-				"inputs": ["*"],
-				"outputs": ["*"],
-				"script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-			}
-		}
-	],
-    "tree": {
-		"_id": "CHLogin",
-		"description": "CH Platform Login Tree with MFA and legacy password check",
-		"identityResource": "managed/alpha_user",
-		"uiConfig": {},
-		"entryNodeId": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-		"nodes": {
-			"0e167098-4f1b-4a6d-a383-9a415b143dda": {
-				"x": 1992,
-				"y": 108.33333333333334,
-				"connections": {
-					"outcome": "860b9b8a-260a-4123-85f5-7cf50e20a291"
-				},
-				"nodeType": "OneTimePasswordGeneratorNode",
-				"displayName": "HOTP Generator"
-			},
-			"0e91440f-8d40-4946-88c9-1a7e22da57bc": {
-				"x": 1240,
-				"y": 31.5,
-				"connections": {
-					"false": "1031a228-600a-4325-82da-c93e6a13ab5b",
-					"true": "9339d5b3-f917-46a5-918e-a8b4ce884d81"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Has Phone Number"
-			},
-			"1031a228-600a-4325-82da-c93e6a13ab5b": {
-				"x": 1732,
-				"y": 248,
-				"connections": {
-					"false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"true": "c20b82fd-458d-4a46-8d0f-41d589f3976b"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Create Notify JWT - Email"
-			},
-			"3147767a-bb7b-47b2-9b43-6d297e7cc2fa": {
-				"x": 1732,
-				"y": 75,
-				"connections": {
-					"false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"true": "0e167098-4f1b-4a6d-a383-9a415b143dda"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Create Notify JWT - SMS"
-			},
-			"35194bf4-8dcc-41a2-8545-4a965b8f6ec0": {
-				"x": 2540,
-				"y": 64.015625,
-				"connections": {
-					"false": "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc",
-					"true": "ae62ed05-3a04-456b-8642-7bc222e0dd43"
-				},
-				"nodeType": "PageNode",
-				"displayName": "Enter OTP"
-			},
-			"4f019558-f468-46f2-8000-5bba1d9dac45": {
-				"x": 432,
-				"y": 80.015625,
-				"connections": {
-					"true": "bd940aa3-c854-4934-b67a-1183d89be21f",
-					"false": "4a8df6a5-8e56-4765-8ea0-2ff6200b6297"
-				},
-				"nodeType": "IdentifyExistingUserNode",
-				"displayName": "Identify Existing User"
-			},
-			"5e76d32e-9180-4a20-b0bd-ff9b89773cbb": {
-				"x": 2239,
-				"y": 260,
-				"connections": {
-					"false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Send MFA email via Notify"
-			},
-			"6486165d-fb00-4248-93c8-4f36ad2b2cb1": {
-				"x": 1239,
-				"y": 251.015625,
-				"connections": {
-					"error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"success": "c32fab79-8836-4657-bef0-9f03a1e1165f"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Reset Counter after login OK"
-			},
-			"739919ca-5a2b-4788-a447-36fe83a011f9": {
-				"x": 2967,
-				"y": 351.015625,
-				"connections": {
-					"true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Raise Error"
-			},
-			"758e3d0a-3211-4850-8847-86981f75888e": {
-				"x": 894,
-				"y": 394.015625,
-				"connections": {
-					"false": "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4",
-					"true": "9d8e176e-3175-45a5-8ff3-ca0138c1b300"
-				},
-				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Update Legacy Password"
-			},
-			"860b9b8a-260a-4123-85f5-7cf50e20a291": {
-				"x": 2246,
-				"y": 83,
-				"connections": {
-					"false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Send MFA text via Notify"
-			},
-			"9339d5b3-f917-46a5-918e-a8b4ce884d81": {
-				"x": 1469,
-				"y": 52.015625,
-				"connections": {
-					"email": "1031a228-600a-4325-82da-c93e6a13ab5b",
-					"text": "3147767a-bb7b-47b2-9b43-6d297e7cc2fa"
-				},
-				"nodeType": "PageNode",
-				"displayName": "Choose Email/SMS"
-			},
-			"94a5f48e-d6e3-4bf4-8edc-45c028a70900": {
-				"x": 218,
-				"y": 136,
-				"connections": {
-					"true": "c99c82c6-20f5-456d-a94e-680c4f4a6307"
-				},
-				"nodeType": "PageNode",
-				"displayName": "Login Form"
-			},
-			"9d8e176e-3175-45a5-8ff3-ca0138c1b300": {
-				"x": 1171,
-				"y": 422.015625,
-				"connections": {
-					"error": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"success": "6486165d-fb00-4248-93c8-4f36ad2b2cb1"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get New IDM Token"
-			},
-			"a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc": {
-				"x": 2732,
-				"y": 318.015625,
-				"connections": {
-					"Reject": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"Retry": "739919ca-5a2b-4788-a447-36fe83a011f9"
-				},
-				"nodeType": "RetryLimitDecisionNode",
-				"displayName": "Retry Limit Decision"
-			},
-			"ae62ed05-3a04-456b-8642-7bc222e0dd43": {
-				"x": 2810,
-				"y": 195.5,
-				"connections": {
-					"outcome": "bf46b661-96c6-443a-b012-3b5608b7051f"
-				},
-				"nodeType": "IncrementLoginCountNode",
-				"displayName": "Increment Login Count"
-			},
-			"bd940aa3-c854-4934-b67a-1183d89be21f": {
-				"x": 614,
-				"y": 13.015625,
-				"connections": {
-					"error": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
-					"success": "fa88fc01-a7a2-429f-b7cc-546fe67a70b4"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM Token"
-			},
-			"bf46b661-96c6-443a-b012-3b5608b7051f": {
-				"x": 3059,
-				"y": 194.5,
-				"connections": {
-					"true": "f8d1e6a3-14d1-4eda-9515-6e0dfacad539"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Update Last Login"
-			},
-			"c20b82fd-458d-4a46-8d0f-41d589f3976b": {
-				"x": 1994,
-				"y": 285.66666666666663,
-				"connections": {
-					"outcome": "5e76d32e-9180-4a20-b0bd-ff9b89773cbb"
-				},
-				"nodeType": "OneTimePasswordGeneratorNode",
-				"displayName": "HOTP Generator"
-			},
-			"c32fab79-8836-4657-bef0-9f03a1e1165f": {
-				"x": 1032,
-				"y": 39.5,
-				"connections": {
-					"false": "ae62ed05-3a04-456b-8642-7bc222e0dd43",
-					"true": "0e91440f-8d40-4946-88c9-1a7e22da57bc"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Require MFA"
-			},
-			"c99c82c6-20f5-456d-a94e-680c4f4a6307": {
-				"x": 324,
-				"y": 442.015625,
-				"connections": {
-					"true": "4f019558-f468-46f2-8000-5bba1d9dac45",
-					"false": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "check format"
-			},
-			"d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4": {
-				"x": 700,
-				"y": 552.015625,
-				"connections": {
-					"error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"true": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Soft Lock Increment Counter"
-			},
-			"f8d1e6a3-14d1-4eda-9515-6e0dfacad539": {
-				"x": 3311,
-				"y": 172.5,
-				"connections": {
-					"false": "e301438c-0bd0-429c-ab0c-66126501069a",
-					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
-				},
-				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Inner Tree Evaluator"
-			},
-			"fa88fc01-a7a2-429f-b7cc-546fe67a70b4": {
-				"x": 788,
-				"y": 120.015625,
-				"connections": {
-					"error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"lock_expired": "fc36693f-b04c-46f8-a683-1e1c1498c8bd",
-					"locked": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"not_locked": "758e3d0a-3211-4850-8847-86981f75888e"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check soft lock"
-			},
-			"fc36693f-b04c-46f8-a683-1e1c1498c8bd": {
-				"x": 691,
-				"y": 316.015625,
-				"connections": {
-					"error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
-					"success": "758e3d0a-3211-4850-8847-86981f75888e"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Reset Counter"
-			},
-			"4a8df6a5-8e56-4765-8ea0-2ff6200b6297": {
-				"x": 324,
-				"y": 597.015625,
-				"connections": {
-					"true": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Login Error message"
-			},
-			"7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a": {
-				"x": 2261,
-				"y": 700.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "General Error"
-			}
-		},
-		"staticNodes": {
-			"startNode": {
-				"x": 70,
-				"y": 190
-			},
-			"70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-				"x": 3625,
-				"y": 196.66666666666666
-			},
-			"e301438c-0bd0-429c-ab0c-66126501069a": {
-				"x": 3639,
-				"y": 797.3333333333334
-			}
-		}
-	}
+  "nodes": [
+    {
+      "_id": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "a346e4e7-8490-4ec6-962f-ebb9ba51dbe6",
+            "nodeType": "ValidatedUsernameNode",
+            "displayName": "Platform Username"
+          },
+          {
+            "_id": "d28720a1-ad25-406b-baea-d3691f5122ea",
+            "nodeType": "ValidatedPasswordNode",
+            "displayName": "Platform Password"
+          },
+          {
+            "_id": "3b1940b6-a238-455e-8d13-ceb0f2848be4",
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "Error Handling"
+          }
+        ],
+        "pageDescription": {
+          "en": "New here? <a href=\"#/service/Registration\">Create an account</a><br><a href=\"#/service/ForgottenUsername\">Forgot username?</a><a href=\"#/service/ResetPassword\"> Forgot password?</a>"
+        },
+        "pageHeader": {
+          "en": "Sign In"
+        },
+        "stage": "CH_LOGIN_1"
+      }
+    },
+    {
+      "_id": "a346e4e7-8490-4ec6-962f-ebb9ba51dbe6",
+      "nodeType": "ValidatedUsernameNode",
+      "details": {
+        "usernameAttribute": "userName",
+        "validateInput": false
+      }
+    },
+    {
+      "_id": "d28720a1-ad25-406b-baea-d3691f5122ea",
+      "nodeType": "ValidatedPasswordNode",
+      "details": {
+        "passwordAttribute": "password",
+        "validateInput": false
+      }
+    },
+    {
+      "_id": "4f019558-f468-46f2-8000-5bba1d9dac45",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identifier": "userName",
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "758e3d0a-3211-4850-8847-86981f75888e",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHUpdateLegacyPassword"
+      }
+    },
+    {
+      "_id": "c32fab79-8836-4657-bef0-9f03a1e1165f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "20a3599f-b742-4554-a8b7-27862f248dd5"
+      }
+    },
+    {
+      "_id": "0e91440f-8d40-4946-88c9-1a7e22da57bc",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "b480d9f7-5908-45cf-91d1-bc1fe56fe8de"
+      }
+    },
+    {
+      "_id": "9339d5b3-f917-46a5-918e-a8b4ce884d81",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "7c1389a2-2b21-483b-a2f2-2e2ad42f52b2",
+            "nodeType": "ChoiceCollectorNode",
+            "displayName": "Choice Collector"
+          }
+        ],
+        "pageDescription": {
+          "desc": "How do you want to confirm it's you?"
+        },
+        "pageHeader": {
+          "header": "How do you want to confirm it's you?"
+        },
+        "stage": "CH_LOGIN_2"
+      }
+    },
+    {
+      "_id": "7c1389a2-2b21-483b-a2f2-2e2ad42f52b2",
+      "nodeType": "ChoiceCollectorNode",
+      "details": {
+        "choices": [
+          "email",
+          "text"
+        ],
+        "defaultChoice": "email",
+        "prompt": "How do you want to confirm it's you?"
+      }
+    },
+    {
+      "_id": "3147767a-bb7b-47b2-9b43-6d297e7cc2fa",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259"
+      }
+    },
+    {
+      "_id": "0e167098-4f1b-4a6d-a383-9a415b143dda",
+      "nodeType": "OneTimePasswordGeneratorNode",
+      "details": {
+        "length": 6
+      }
+    },
+    {
+      "_id": "860b9b8a-260a-4123-85f5-7cf50e20a291",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "b276c566-622e-11eb-ae93-0242ac130002"
+      }
+    },
+    {
+      "_id": "1031a228-600a-4325-82da-c93e6a13ab5b",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df67765e-df3a-4503-9ba5-35c992b39259"
+      }
+    },
+    {
+      "_id": "c20b82fd-458d-4a46-8d0f-41d589f3976b",
+      "nodeType": "OneTimePasswordGeneratorNode",
+      "details": {
+        "length": 6
+      }
+    },
+    {
+      "_id": "5e76d32e-9180-4a20-b0bd-ff9b89773cbb",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "a5778ce7-addf-4fb6-a7db-92929f1314c4"
+      }
+    },
+    {
+      "_id": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0",
+      "nodeType": "PageNode",
+      "details": {
+        "nodes": [
+          {
+            "_id": "60732b03-b048-432e-be0f-cb13e211586e",
+            "nodeType": "ScriptedDecisionNode",
+            "displayName": "Scripted Decision"
+          },
+          {
+            "_id": "3633da1e-04fc-4d44-a6c8-b199cfade38a",
+            "nodeType": "OneTimePasswordCollectorDecisionNode",
+            "displayName": "OTP Collector Decision"
+          }
+        ],
+        "pageDescription": {
+          "desc": "Please enter the code you received"
+        },
+        "pageHeader": {
+          "header": "Please enter your code"
+        },
+        "stage": "CH_LOGIN_3"
+      }
+    },
+    {
+      "_id": "60732b03-b048-432e-be0f-cb13e211586e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "True"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ace951c8-d169-4426-9357-d5b44e0aa728"
+      }
+    },
+    {
+      "_id": "3633da1e-04fc-4d44-a6c8-b199cfade38a",
+      "nodeType": "OneTimePasswordCollectorDecisionNode",
+      "details": {
+        "passwordExpiryTime": 30
+      }
+    },
+    {
+      "_id": "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "739919ca-5a2b-4788-a447-36fe83a011f9",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "bf6c0ac8-8e13-4f11-8d99-d01b23e02a5c"
+      }
+    },
+    {
+      "_id": "ae62ed05-3a04-456b-8642-7bc222e0dd43",
+      "nodeType": "IncrementLoginCountNode",
+      "details": {
+        "identityAttribute": "userName"
+      }
+    },
+    {
+      "_id": "bf46b661-96c6-443a-b012-3b5608b7051f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "d7da3b35-af63-499b-aa0a-bb03666508db"
+      }
+    },
+    {
+      "_id": "f8d1e6a3-14d1-4eda-9515-6e0dfacad539",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "ProgressiveProfile"
+      }
+    },
+    {
+      "_id": "3b1940b6-a238-455e-8d13-ceb0f2848be4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "064705f3-93d3-482c-ad3f-4531a28ce0a0"
+      }
+    },
+    {
+      "_id": "c99c82c6-20f5-456d-a94e-680c4f4a6307",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "188d3f9d-ca04-4df7-bcd7-eed3fe27e21e"
+      }
+    },
+    {
+      "_id": "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "a1ebbcd2-39c1-47c2-a152-4bebcf8cfb5b"
+      }
+    },
+    {
+      "_id": "bd940aa3-c854-4934-b67a-1183d89be21f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "fa88fc01-a7a2-429f-b7cc-546fe67a70b4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "locked",
+          "error",
+          "lock_expired",
+          "not_locked"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "7837ccb6-2e56-44bf-a5df-7cfdb0bfc38b"
+      }
+    },
+    {
+      "_id": "fc36693f-b04c-46f8-a683-1e1c1498c8bd",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "329154d4-5e55-4cc5-a17e-19d4fd3729aa"
+      }
+    },
+    {
+      "_id": "6486165d-fb00-4248-93c8-4f36ad2b2cb1",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "329154d4-5e55-4cc5-a17e-19d4fd3729aa"
+      }
+    },
+    {
+      "_id": "9d8e176e-3175-45a5-8ff3-ca0138c1b300",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "4a8df6a5-8e56-4765-8ea0-2ff6200b6297",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e0aec02a-ad8b-427d-a72e-cdfd8cb6c0e0"
+      }
+    },
+    {
+      "_id": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHLogin",
+    "description": "CH Platform Login Tree with MFA and legacy password check",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+    "nodes": {
+      "0e167098-4f1b-4a6d-a383-9a415b143dda": {
+        "x": 1992,
+        "y": 108.33333333333334,
+        "connections": {
+          "outcome": "860b9b8a-260a-4123-85f5-7cf50e20a291"
+        },
+        "nodeType": "OneTimePasswordGeneratorNode",
+        "displayName": "HOTP Generator"
+      },
+      "0e91440f-8d40-4946-88c9-1a7e22da57bc": {
+        "x": 1240,
+        "y": 31.5,
+        "connections": {
+          "false": "1031a228-600a-4325-82da-c93e6a13ab5b",
+          "true": "9339d5b3-f917-46a5-918e-a8b4ce884d81"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Has Phone Number"
+      },
+      "1031a228-600a-4325-82da-c93e6a13ab5b": {
+        "x": 1732,
+        "y": 248,
+        "connections": {
+          "false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "true": "c20b82fd-458d-4a46-8d0f-41d589f3976b"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT - Email"
+      },
+      "3147767a-bb7b-47b2-9b43-6d297e7cc2fa": {
+        "x": 1732,
+        "y": 75,
+        "connections": {
+          "false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "true": "0e167098-4f1b-4a6d-a383-9a415b143dda"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Notify JWT - SMS"
+      },
+      "35194bf4-8dcc-41a2-8545-4a965b8f6ec0": {
+        "x": 2540,
+        "y": 64.015625,
+        "connections": {
+          "false": "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc",
+          "true": "ae62ed05-3a04-456b-8642-7bc222e0dd43"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Enter OTP"
+      },
+      "4f019558-f468-46f2-8000-5bba1d9dac45": {
+        "x": 432,
+        "y": 80.015625,
+        "connections": {
+          "true": "bd940aa3-c854-4934-b67a-1183d89be21f",
+          "false": "4a8df6a5-8e56-4765-8ea0-2ff6200b6297"
+        },
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "5e76d32e-9180-4a20-b0bd-ff9b89773cbb": {
+        "x": 2239,
+        "y": 260,
+        "connections": {
+          "false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Send MFA email via Notify"
+      },
+      "6486165d-fb00-4248-93c8-4f36ad2b2cb1": {
+        "x": 1239,
+        "y": 251.015625,
+        "connections": {
+          "error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "success": "c32fab79-8836-4657-bef0-9f03a1e1165f"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Reset Counter after login OK"
+      },
+      "739919ca-5a2b-4788-a447-36fe83a011f9": {
+        "x": 2967,
+        "y": 351.015625,
+        "connections": {
+          "true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Raise Error"
+      },
+      "758e3d0a-3211-4850-8847-86981f75888e": {
+        "x": 894,
+        "y": 394.015625,
+        "connections": {
+          "false": "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4",
+          "true": "9d8e176e-3175-45a5-8ff3-ca0138c1b300"
+        },
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Update Legacy Password"
+      },
+      "860b9b8a-260a-4123-85f5-7cf50e20a291": {
+        "x": 2246,
+        "y": 83,
+        "connections": {
+          "false": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "true": "35194bf4-8dcc-41a2-8545-4a965b8f6ec0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Send MFA text via Notify"
+      },
+      "9339d5b3-f917-46a5-918e-a8b4ce884d81": {
+        "x": 1469,
+        "y": 52.015625,
+        "connections": {
+          "email": "1031a228-600a-4325-82da-c93e6a13ab5b",
+          "text": "3147767a-bb7b-47b2-9b43-6d297e7cc2fa"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Choose Email/SMS"
+      },
+      "94a5f48e-d6e3-4bf4-8edc-45c028a70900": {
+        "x": 218,
+        "y": 136,
+        "connections": {
+          "true": "c99c82c6-20f5-456d-a94e-680c4f4a6307"
+        },
+        "nodeType": "PageNode",
+        "displayName": "Login Form"
+      },
+      "9d8e176e-3175-45a5-8ff3-ca0138c1b300": {
+        "x": 1171,
+        "y": 422.015625,
+        "connections": {
+          "error": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "success": "6486165d-fb00-4248-93c8-4f36ad2b2cb1"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get New IDM Token"
+      },
+      "a2adb2e2-a3f7-4214-927c-0a47d5d0e1dc": {
+        "x": 2732,
+        "y": 318.015625,
+        "connections": {
+          "Reject": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "Retry": "739919ca-5a2b-4788-a447-36fe83a011f9"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "ae62ed05-3a04-456b-8642-7bc222e0dd43": {
+        "x": 2810,
+        "y": 195.5,
+        "connections": {
+          "outcome": "bf46b661-96c6-443a-b012-3b5608b7051f"
+        },
+        "nodeType": "IncrementLoginCountNode",
+        "displayName": "Increment Login Count"
+      },
+      "bd940aa3-c854-4934-b67a-1183d89be21f": {
+        "x": 614,
+        "y": 13.015625,
+        "connections": {
+          "error": "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a",
+          "success": "fa88fc01-a7a2-429f-b7cc-546fe67a70b4"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Token"
+      },
+      "bf46b661-96c6-443a-b012-3b5608b7051f": {
+        "x": 3059,
+        "y": 194.5,
+        "connections": {
+          "true": "f8d1e6a3-14d1-4eda-9515-6e0dfacad539"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Update Last Login"
+      },
+      "c20b82fd-458d-4a46-8d0f-41d589f3976b": {
+        "x": 1994,
+        "y": 285.66666666666663,
+        "connections": {
+          "outcome": "5e76d32e-9180-4a20-b0bd-ff9b89773cbb"
+        },
+        "nodeType": "OneTimePasswordGeneratorNode",
+        "displayName": "HOTP Generator"
+      },
+      "c32fab79-8836-4657-bef0-9f03a1e1165f": {
+        "x": 1032,
+        "y": 39.5,
+        "connections": {
+          "false": "ae62ed05-3a04-456b-8642-7bc222e0dd43",
+          "true": "0e91440f-8d40-4946-88c9-1a7e22da57bc"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Require MFA"
+      },
+      "c99c82c6-20f5-456d-a94e-680c4f4a6307": {
+        "x": 324,
+        "y": 442.015625,
+        "connections": {
+          "true": "4f019558-f468-46f2-8000-5bba1d9dac45",
+          "false": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "check format"
+      },
+      "d1f2eef5-5ad7-4ad6-bc5a-e65710879ff4": {
+        "x": 700,
+        "y": 552.015625,
+        "connections": {
+          "error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "true": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Soft Lock Increment Counter"
+      },
+      "f8d1e6a3-14d1-4eda-9515-6e0dfacad539": {
+        "x": 3311,
+        "y": 172.5,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+        },
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Inner Tree Evaluator"
+      },
+      "fa88fc01-a7a2-429f-b7cc-546fe67a70b4": {
+        "x": 788,
+        "y": 120.015625,
+        "connections": {
+          "error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "lock_expired": "fc36693f-b04c-46f8-a683-1e1c1498c8bd",
+          "locked": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "not_locked": "758e3d0a-3211-4850-8847-86981f75888e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check soft lock"
+      },
+      "fc36693f-b04c-46f8-a683-1e1c1498c8bd": {
+        "x": 691,
+        "y": 316.015625,
+        "connections": {
+          "error": "94a5f48e-d6e3-4bf4-8edc-45c028a70900",
+          "success": "758e3d0a-3211-4850-8847-86981f75888e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Reset Counter"
+      },
+      "4a8df6a5-8e56-4765-8ea0-2ff6200b6297": {
+        "x": 324,
+        "y": 597.015625,
+        "connections": {
+          "true": "94a5f48e-d6e3-4bf4-8edc-45c028a70900"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Login Error message"
+      },
+      "7afb0b0e-8d8c-4e60-9cd3-8ef526129b0a": {
+        "x": 2261,
+        "y": 700.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "General Error"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 70,
+        "y": 190
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 3625,
+        "y": 196.66666666666666
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 3639,
+        "y": 797.3333333333334
+      }
+    }
+  }
 }

--- a/config/auth-trees/ch-update-legacy-password.json
+++ b/config/auth-trees/ch-update-legacy-password.json
@@ -1,358 +1,359 @@
 {
-    "nodes": [
-        {
-            "_id": "b1e2f7d4-cd1e-4433-a020-d445bbd76d28",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "valid",
-                    "update"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "2c9f9d6a-4b93-493a-bf0d-44fe53d8d1d1"
-            }
-        },
-        {
-            "_id": "704fbf38-6a45-4842-8e70-60cae68c9524",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "inputs": [
-                    "*"
-                ],
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "137e1fd5-19f4-425d-96eb-2a8c20cabcf8"
-            }
-        },
-        {
-            "_id": "39276a55-2540-4d26-9231-56bd3113a612",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "inputs": [
-                    "*"
-                ],
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "65d2099f-9583-47d3-8303-8051709cb436"
-            }
-        },
-        {
-            "_id": "4893e08c-e3f0-47a7-ab74-742fc22e74c8",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "inputs": [
-                    "*"
-                ],
-                "outcomes": [
-                    "success",
-                    "error"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }
-        },
-        {
-            "_id": "fab99cf3-086a-4f01-a12d-165dd5792c14",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false",
-                    "invalid"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "9bab9cb5-c723-4fb1-aa02-825aaaa7a266"
-            }
-        },
-        {
-            "_id": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
-            "nodeType": "DataStoreDecisionNode",
-            "details": {}
-        },
-        {
-            "_id": "a979a1c2-8474-4fdb-8c59-406bd39f5f0b",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true",
-                    "false"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "14c3cb5d-1010-459d-9747-6ff19a8de70d"
-            }
-        },
-        {
-            "_id": "8b77e445-2462-48ff-959b-a6c4cb515fb2",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "match",
-                    "mismatch"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "a5042601-6867-4566-81d1-fad4ecd61487"
-            }
-        },
-        {
-            "_id": "e2c86578-2128-429d-bb98-2fde50ce422c",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "success",
-                    "error"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }
-        },
-        {
-            "_id": "641a7ada-844c-4eec-8de4-aeab76c41465",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "pass",
-                    "fail",
-                    "error"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
-            }
-        },
-        {
-            "_id": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "success",
-                    "mismatch"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "52014433-9b16-4f21-a00c-1ab477c918f8"
-            }
-        },
-        {
-            "_id": "836b56d3-403a-4510-87d4-725b502fc0e1",
-            "nodeType": "RetryLimitDecisionNode",
-            "details": {
-                "retryLimit": 3
-            }
-        },
-        {
-            "_id": "9208332b-9c36-4064-a82b-6835de853e36",
-            "nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": [
-                    "true"
-                ],
-                "inputs": [
-                    "*"
-                ],
-                "outputs": [
-                    "*"
-                ],
-                "script": "13e9d2a5-e93a-47f2-894d-4d732918c383"
-            }
-        }
-    ],
-    "tree": {
-        "_id": "CHUpdateLegacyPassword",
-        "description": "Update user password if entered cleartext password matches hashed value",
-        "identityResource": "managed/alpha_user",
-        "uiConfig": {},
-        "entryNodeId": "b1e2f7d4-cd1e-4433-a020-d445bbd76d28",
-        "nodes": {
-            "e2c86578-2128-429d-bb98-2fde50ce422c": {
-                "x": 2231,
-                "y": 213.5,
-                "connections": {
-                    "success": "641a7ada-844c-4eec-8de4-aeab76c41465",
-                    "error": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Get IDM Access Token"
-            },
-            "fab99cf3-086a-4f01-a12d-165dd5792c14": {
-                "x": 1334,
-                "y": 190,
-                "connections": {
-                    "true": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "invalid": "a979a1c2-8474-4fdb-8c59-406bd39f5f0b"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Update User Password"
-            },
-            "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed": {
-                "x": 1567,
-                "y": 45,
-                "connections": {
-                    "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-                    "false": "9208332b-9c36-4064-a82b-6835de853e36"
-                },
-                "nodeType": "DataStoreDecisionNode",
-                "displayName": "Data Store Decision"
-            },
-            "4893e08c-e3f0-47a7-ab74-742fc22e74c8": {
-                "x": 1013,
-                "y": 172.5,
-                "connections": {
-                    "error": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "success": "fab99cf3-086a-4f01-a12d-165dd5792c14"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Get IDM Access Token"
-            },
-            "704fbf38-6a45-4842-8e70-60cae68c9524": {
-                "x": 495,
-                "y": 280.5,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "39276a55-2540-4d26-9231-56bd3113a612"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Fetch Legacy Password"
-            },
-            "39276a55-2540-4d26-9231-56bd3113a612": {
-                "x": 760,
-                "y": 172.5,
-                "connections": {
-                    "true": "4893e08c-e3f0-47a7-ab74-742fc22e74c8",
-                    "false": "9208332b-9c36-4064-a82b-6835de853e36"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Call Validation Service"
-            },
-            "57d915a9-a414-4d14-bae4-e811ba80d0ce": {
-                "x": 2254,
-                "y": 772.6666666666666,
-                "connections": {
-                    "mismatch": "836b56d3-403a-4510-87d4-725b502fc0e1",
-                    "success": "8b77e445-2462-48ff-959b-a6c4cb515fb2"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Change Password Collector"
-            },
-            "641a7ada-844c-4eec-8de4-aeab76c41465": {
-                "x": 2250,
-                "y": 410.3333333333333,
-                "connections": {
-                    "fail": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
-                    "error": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
-                    "pass": "fab99cf3-086a-4f01-a12d-165dd5792c14"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check Password Policy"
-            },
-            "a979a1c2-8474-4fdb-8c59-406bd39f5f0b": {
-                "x": 1575,
-                "y": 486,
-                "connections": {
-                    "false": "e301438c-0bd0-429c-ab0c-66126501069a",
-                    "true": "57d915a9-a414-4d14-bae4-e811ba80d0ce"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Change Password Required"
-            },
-            "b1e2f7d4-cd1e-4433-a020-d445bbd76d28": {
-                "x": 210,
-                "y": 172.5,
-                "connections": {
-                    "valid": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
-                    "update": "704fbf38-6a45-4842-8e70-60cae68c9524"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check Password Status"
-            },
-            "836b56d3-403a-4510-87d4-725b502fc0e1": {
-                "x": 2269,
-                "y": 992,
-                "connections": {
-                    "Retry": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
-                    "Reject": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "RetryLimitDecisionNode",
-                "displayName": "Retry Limit Decision"
-            },
-            "8b77e445-2462-48ff-959b-a6c4cb515fb2": {
-                "x": 1894,
-                "y": 234,
-                "connections": {
-                    "match": "e2c86578-2128-429d-bb98-2fde50ce422c",
-                    "mismatch": "57d915a9-a414-4d14-bae4-e811ba80d0ce"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Check Original Password"
-            },
-            "9208332b-9c36-4064-a82b-6835de853e36": {
-                "x": 2237,
-                "y": 126.015625,
-                "connections": {
-                    "true": "e301438c-0bd0-429c-ab0c-66126501069a"
-                },
-                "nodeType": "ScriptedDecisionNode",
-                "displayName": "Generate Error Message"
-            }
-        },
-        "staticNodes": {
-            "startNode": {
-                "x": 70,
-                "y": 190
-            },
-            "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-                "x": 1940,
-                "y": 56.833333333333314
-            },
-            "e301438c-0bd0-429c-ab0c-66126501069a": {
-                "x": 2890,
-                "y": 526.6666666666667
-            }
-        }
+  "nodes": [
+    {
+      "_id": "b1e2f7d4-cd1e-4433-a020-d445bbd76d28",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "valid",
+          "update"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "2c9f9d6a-4b93-493a-bf0d-44fe53d8d1d1"
+      }
+    },
+    {
+      "_id": "704fbf38-6a45-4842-8e70-60cae68c9524",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "137e1fd5-19f4-425d-96eb-2a8c20cabcf8"
+      }
+    },
+    {
+      "_id": "39276a55-2540-4d26-9231-56bd3113a612",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "65d2099f-9583-47d3-8303-8051709cb436"
+      }
+    },
+    {
+      "_id": "4893e08c-e3f0-47a7-ab74-742fc22e74c8",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "fab99cf3-086a-4f01-a12d-165dd5792c14",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false",
+          "invalid"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "9bab9cb5-c723-4fb1-aa02-825aaaa7a266"
+      }
+    },
+    {
+      "_id": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
+      "nodeType": "DataStoreDecisionNode",
+      "details": {}
+    },
+    {
+      "_id": "a979a1c2-8474-4fdb-8c59-406bd39f5f0b",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "14c3cb5d-1010-459d-9747-6ff19a8de70d"
+      }
+    },
+    {
+      "_id": "8b77e445-2462-48ff-959b-a6c4cb515fb2",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "match",
+          "mismatch"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "a5042601-6867-4566-81d1-fad4ecd61487"
+      }
+    },
+    {
+      "_id": "e2c86578-2128-429d-bb98-2fde50ce422c",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "641a7ada-844c-4eec-8de4-aeab76c41465",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "pass",
+          "fail",
+          "error"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
+      }
+    },
+    {
+      "_id": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "success",
+          "mismatch"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "52014433-9b16-4f21-a00c-1ab477c918f8"
+      }
+    },
+    {
+      "_id": "836b56d3-403a-4510-87d4-725b502fc0e1",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "9208332b-9c36-4064-a82b-6835de853e36",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "13e9d2a5-e93a-47f2-894d-4d732918c383"
+      }
     }
+  ],
+  "tree": {
+    "_id": "CHUpdateLegacyPassword",
+    "description": "Update user password if entered cleartext password matches hashed value",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "b1e2f7d4-cd1e-4433-a020-d445bbd76d28",
+    "nodes": {
+      "e2c86578-2128-429d-bb98-2fde50ce422c": {
+        "x": 2231,
+        "y": 213.5,
+        "connections": {
+          "success": "641a7ada-844c-4eec-8de4-aeab76c41465",
+          "error": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Access Token"
+      },
+      "fab99cf3-086a-4f01-a12d-165dd5792c14": {
+        "x": 1334,
+        "y": 190,
+        "connections": {
+          "true": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "invalid": "a979a1c2-8474-4fdb-8c59-406bd39f5f0b"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Update User Password"
+      },
+      "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed": {
+        "x": 1567,
+        "y": 45,
+        "connections": {
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "false": "9208332b-9c36-4064-a82b-6835de853e36"
+        },
+        "nodeType": "DataStoreDecisionNode",
+        "displayName": "Data Store Decision"
+      },
+      "4893e08c-e3f0-47a7-ab74-742fc22e74c8": {
+        "x": 1013,
+        "y": 172.5,
+        "connections": {
+          "error": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "success": "fab99cf3-086a-4f01-a12d-165dd5792c14"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Access Token"
+      },
+      "704fbf38-6a45-4842-8e70-60cae68c9524": {
+        "x": 495,
+        "y": 280.5,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "39276a55-2540-4d26-9231-56bd3113a612"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Fetch Legacy Password"
+      },
+      "39276a55-2540-4d26-9231-56bd3113a612": {
+        "x": 760,
+        "y": 172.5,
+        "connections": {
+          "true": "4893e08c-e3f0-47a7-ab74-742fc22e74c8",
+          "false": "9208332b-9c36-4064-a82b-6835de853e36"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Call Validation Service"
+      },
+      "57d915a9-a414-4d14-bae4-e811ba80d0ce": {
+        "x": 2254,
+        "y": 772.6666666666666,
+        "connections": {
+          "mismatch": "836b56d3-403a-4510-87d4-725b502fc0e1",
+          "success": "8b77e445-2462-48ff-959b-a6c4cb515fb2"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Change Password Collector"
+      },
+      "641a7ada-844c-4eec-8de4-aeab76c41465": {
+        "x": 2250,
+        "y": 410.3333333333333,
+        "connections": {
+          "fail": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
+          "error": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
+          "pass": "fab99cf3-086a-4f01-a12d-165dd5792c14"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Password Policy"
+      },
+      "a979a1c2-8474-4fdb-8c59-406bd39f5f0b": {
+        "x": 1575,
+        "y": 486,
+        "connections": {
+          "false": "e301438c-0bd0-429c-ab0c-66126501069a",
+          "true": "57d915a9-a414-4d14-bae4-e811ba80d0ce"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Change Password Required"
+      },
+      "b1e2f7d4-cd1e-4433-a020-d445bbd76d28": {
+        "x": 210,
+        "y": 172.5,
+        "connections": {
+          "valid": "dfff5b45-4ae5-436d-a3d3-bb8dba5b94ed",
+          "update": "704fbf38-6a45-4842-8e70-60cae68c9524"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Password Status"
+      },
+      "836b56d3-403a-4510-87d4-725b502fc0e1": {
+        "x": 2269,
+        "y": 992,
+        "connections": {
+          "Retry": "57d915a9-a414-4d14-bae4-e811ba80d0ce",
+          "Reject": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "8b77e445-2462-48ff-959b-a6c4cb515fb2": {
+        "x": 1894,
+        "y": 234,
+        "connections": {
+          "match": "e2c86578-2128-429d-bb98-2fde50ce422c",
+          "mismatch": "57d915a9-a414-4d14-bae4-e811ba80d0ce"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Original Password"
+      },
+      "9208332b-9c36-4064-a82b-6835de853e36": {
+        "x": 2237,
+        "y": 126.015625,
+        "connections": {
+          "true": "e301438c-0bd0-429c-ab0c-66126501069a"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Generate Error Message"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 70,
+        "y": 190
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1940,
+        "y": 56.833333333333314
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 2890,
+        "y": 526.6666666666667
+      }
+    }
+  }
 }

--- a/config/auth-trees/ch-update-password.json
+++ b/config/auth-trees/ch-update-password.json
@@ -1,288 +1,349 @@
 {
-	"nodes": [
-		{
-            "_id":"c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["hasSession","noSession"],
-                "outputs":["*"],
-                "script":"c4001e02-469c-4cc4-bf95-9f43d7e46568"
-            }            
+  "nodes": [
+    {
+      "_id": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "hasSession",
+          "noSession"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c4001e02-469c-4cc4-bf95-9f43d7e46568"
+      }
+    },
+    {
+      "_id": "72c2688d-910a-4fd3-b094-25803bc9626a",
+      "nodeType": "SessionDataNode",
+      "details": {
+        "sharedStateKey": "userName",
+        "sessionDataKey": "UserToken"
+      }
+    },
+    {
+      "_id": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "mismatch"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "52014433-9b16-4f21-a00c-1ab477c918f8"
+      }
+    },
+    {
+      "_id": "99568072-5a13-48ec-8d07-c06a8c82b425",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "23448f95-703e-4605-b7f5-1ff78fa8def2",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "pass",
+          "fail",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
+      }
+    },
+    {
+      "_id": "ad3af2c3-f67d-4d7a-b954-698a764c4791",
+      "nodeType": "DataStoreDecisionNode",
+      "details": {}
+    },
+    {
+      "_id": "81fec77e-909d-4a6b-bd6a-4dee5964e956",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "1495201c-23da-46b1-8537-73d508cf8358",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "84caf8b3-813a-4998-85ff-a3dd8eee4bcf"
+      }
+    },
+    {
+      "_id": "81f81b53-416f-465a-8ca3-ecbc3216162d",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "04e99c63-2875-43ca-9e5f-84832bf59a34"
+      }
+    },
+    {
+      "_id": "5dbba61f-e063-4264-bc63-1e71927419b1",
+      "nodeType": "PatchObjectNode",
+      "details": {
+        "patchAsObject": false,
+        "ignoredFields": [
+          "userName"
+        ],
+        "identityResource": "managed/alpha_user",
+        "identityAttribute": "userName"
+      }
+    },
+    {
+      "_id": "0c2e7c10-63fb-4e25-8218-68e742672fd1",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "1a7ced42-93f3-4739-a9b8-b773b489ed1d"
+      }
+    },
+    {
+      "_id": "b2e1eb3f-6276-4437-b52d-606a9c05fa59",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df"
+      }
+    },
+    {
+      "_id": "c036600d-18b5-4186-a122-227bea684ba8",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHChangePassword",
+    "description": "Update password using active session",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
+    "nodes": {
+      "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3": {
+        "x": 166,
+        "y": 254.015625,
+        "connections": {
+          "noSession": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
+          "hasSession": "72c2688d-910a-4fd3-b094-25803bc9626a"
         },
-		{
-			"_id":"72c2688d-910a-4fd3-b094-25803bc9626a",
-			"nodeType": "SessionDataNode", 
-			"details": {
-				"sharedStateKey":"userName",
-				"sessionDataKey":"UserToken"
-			}				
-		},
-		{
-            "_id":"c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["success","mismatch"],
-                "outputs":["*"],
-                "script":"52014433-9b16-4f21-a00c-1ab477c918f8"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check for Session"
+      },
+      "72c2688d-910a-4fd3-b094-25803bc9626a": {
+        "x": 373,
+        "y": 129.015625,
+        "connections": {
+          "outcome": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
         },
-		{
-            "_id":"99568072-5a13-48ec-8d07-c06a8c82b425",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["success","error"],
-                "outputs":["*"],
-                "script":"c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
+        "nodeType": "SessionDataNode",
+        "displayName": "Get Session Data"
+      },
+      "c0ddbe48-e4f5-48a9-8879-79762611c5e4": {
+        "x": 672,
+        "y": 100.015625,
+        "connections": {
+          "success": "99568072-5a13-48ec-8d07-c06a8c82b425",
+          "mismatch": "81fec77e-909d-4a6b-bd6a-4dee5964e956"
         },
-		{
-            "_id":"23448f95-703e-4605-b7f5-1ff78fa8def2",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["pass","fail","error"],
-                "outputs":["*"],
-                "script":"c089f1fe-fa0f-4f61-a3d1-a1fce6e953cf"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Change Password Collector"
+      },
+      "99568072-5a13-48ec-8d07-c06a8c82b425": {
+        "x": 965,
+        "y": 231.015625,
+        "connections": {
+          "error": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
+          "success": "23448f95-703e-4605-b7f5-1ff78fa8def2"
         },
-		{
-			"_id":"ad3af2c3-f67d-4d7a-b954-698a764c4791",
-			"nodeType": "DataStoreDecisionNode", 
-			"details":{}
-		},
-		{
-            "_id":"81fec77e-909d-4a6b-bd6a-4dee5964e956",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit": 3
-            }
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Access Token"
+      },
+      "81fec77e-909d-4a6b-bd6a-4dee5964e956": {
+        "x": 748,
+        "y": 296.015625,
+        "connections": {
+          "Retry": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+          "Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59"
         },
-		{
-            "_id":"1495201c-23da-46b1-8537-73d508cf8358",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"84caf8b3-813a-4998-85ff-a3dd8eee4bcf"
-            }            
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "23448f95-703e-4605-b7f5-1ff78fa8def2": {
+        "x": 1210,
+        "y": 45,
+        "connections": {
+          "fail": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+          "error": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+          "pass": "ad3af2c3-f67d-4d7a-b954-698a764c4791"
         },
-		{
-            "_id":"81f81b53-416f-465a-8ca3-ecbc3216162d",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"04e99c63-2875-43ca-9e5f-84832bf59a34"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Pwd Policy"
+      },
+      "ad3af2c3-f67d-4d7a-b954-698a764c4791": {
+        "x": 1339,
+        "y": 218.015625,
+        "connections": {
+          "true": "1495201c-23da-46b1-8537-73d508cf8358",
+          "false": "c036600d-18b5-4186-a122-227bea684ba8"
         },
-		{
-			"_id":"5dbba61f-e063-4264-bc63-1e71927419b1",
-			"nodeType": "PatchObjectNode", 
-			"details": {
-				"patchAsObject":false,
-				"ignoredFields":[
-			   		"userName"
-				],
-				"identityResource":"managed/alpha_user",
-				"identityAttribute":"userName"
-			}
-		},
-		{
-            "_id":"0c2e7c10-63fb-4e25-8218-68e742672fd1",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"1a7ced42-93f3-4739-a9b8-b773b489ed1d"
-            }            
+        "nodeType": "DataStoreDecisionNode",
+        "displayName": "Data Store Decision"
+      },
+      "81f81b53-416f-465a-8ca3-ecbc3216162d": {
+        "x": 1653,
+        "y": 369.015625,
+        "connections": {
+          "true": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
         },
-		{
-            "_id":"b2e1eb3f-6276-4437-b52d-606a9c05fa59",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes":["true"],
-                "outputs":["*"],
-                "script":"fdac4efb-d8b8-478b-8300-e11a4c3503df"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Pwd Error Message"
+      },
+      "1495201c-23da-46b1-8537-73d508cf8358": {
+        "x": 1451,
+        "y": 88.015625,
+        "connections": {
+          "true": "5dbba61f-e063-4264-bc63-1e71927419b1"
         },
-		{
-            "_id":"c036600d-18b5-4186-a122-227bea684ba8",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit": 3
-            }
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Load New Pwd for Patch"
+      },
+      "5dbba61f-e063-4264-bc63-1e71927419b1": {
+        "x": 1558,
+        "y": 203.015625,
+        "connections": {
+          "PATCHED": "0c2e7c10-63fb-4e25-8218-68e742672fd1",
+          "FAILURE": "a1293502-4cf4-435e-888c-47a5dd5ed62f"
         },
-		{
-            "_id": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-                "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-            }            
-        }
-  	],
-	"tree": {
-		"_id": "CHChangePassword",
-		"description": "Update password using active session",
-		"identityResource": "managed/alpha_user",
-		"uiConfig": {},
-		"entryNodeId": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
-		"nodes": {
-			"c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3": {
-				"x": 166,
-				"y": 254.015625,
-				"connections": {
-					"noSession": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
-					"hasSession": "72c2688d-910a-4fd3-b094-25803bc9626a"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check for Session"
-			},
-			"72c2688d-910a-4fd3-b094-25803bc9626a": {
-				"x": 373,
-				"y": 129.015625,
-				"connections": {
-					"outcome": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
-				},
-				"nodeType": "SessionDataNode",
-				"displayName": "Get Session Data"
-			},
-			"c0ddbe48-e4f5-48a9-8879-79762611c5e4": {
-				"x": 672,
-				"y": 100.015625,
-				"connections": {
-					"success": "99568072-5a13-48ec-8d07-c06a8c82b425",
-					"mismatch": "81fec77e-909d-4a6b-bd6a-4dee5964e956"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Change Password Collector"
-			},
-			"99568072-5a13-48ec-8d07-c06a8c82b425": {
-				"x": 965,
-				"y": 231.015625,
-				"connections": {
-					"error": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
-					"success": "23448f95-703e-4605-b7f5-1ff78fa8def2"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM Access Token"
-			},
-			"81fec77e-909d-4a6b-bd6a-4dee5964e956": {
-				"x": 748,
-				"y": 296.015625,
-				"connections": {
-					"Retry": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-					"Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59"
-				},
-				"nodeType": "RetryLimitDecisionNode",
-				"displayName": "Retry Limit Decision"
-			},
-			"23448f95-703e-4605-b7f5-1ff78fa8def2": {
-				"x": 1210,
-				"y": 45,
-				"connections": {
-					"fail": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-					"error": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-					"pass": "ad3af2c3-f67d-4d7a-b954-698a764c4791"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check Pwd Policy"
-			},
-			"ad3af2c3-f67d-4d7a-b954-698a764c4791": {
-				"x": 1339,
-				"y": 218.015625,
-				"connections": {
-					"true": "1495201c-23da-46b1-8537-73d508cf8358",
-					"false": "c036600d-18b5-4186-a122-227bea684ba8"
-				},
-				"nodeType": "DataStoreDecisionNode",
-				"displayName": "Data Store Decision"
-			},
-			"81f81b53-416f-465a-8ca3-ecbc3216162d": {
-				"x": 1653,
-				"y": 369.015625,
-				"connections": {
-					"true": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Pwd Error Message"
-			},
-			"1495201c-23da-46b1-8537-73d508cf8358": {
-				"x": 1451,
-				"y": 88.015625,
-				"connections": {
-					"true": "5dbba61f-e063-4264-bc63-1e71927419b1"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Load New Pwd for Patch"
-			},
-			"5dbba61f-e063-4264-bc63-1e71927419b1": {
-				"x": 1558,
-				"y": 203.015625,
-				"connections": {
-					"PATCHED": "0c2e7c10-63fb-4e25-8218-68e742672fd1",
-					"FAILURE": "a1293502-4cf4-435e-888c-47a5dd5ed62f"
-				},
-				"nodeType": "PatchObjectNode",
-				"displayName": "Patch Object"
-			},
-			"0c2e7c10-63fb-4e25-8218-68e742672fd1": {
-				"x": 1749,
-				"y": 81.015625,
-				"connections": {
-					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Confirmation"
-			},
-			"c036600d-18b5-4186-a122-227bea684ba8": {
-				"x": 1399,
-				"y": 384.015625,
-				"connections": {
-					"Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59",
-					"Retry": "81f81b53-416f-465a-8ca3-ecbc3216162d"
-				},
-				"nodeType": "RetryLimitDecisionNode",
-				"displayName": "Retry Limit Decision"
-			},
-			"b2e1eb3f-6276-4437-b52d-606a9c05fa59": {
-				"x": 1618,
-				"y": 566.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "max attempts message"
-			},
-			"a1293502-4cf4-435e-888c-47a5dd5ed62f": {
-				"x": 1542,
-				"y": 787.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "General Error"
-			}
-		},
-		"staticNodes": {
-			"startNode": {
-				"x": 62,
-				"y": 103
-			},
-			"70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-				"x": 1867,
-				"y": 257
-			},
-			"e301438c-0bd0-429c-ab0c-66126501069a": {
-				"x": 1816,
-				"y": 755
-			}
-		}
-	}
+        "nodeType": "PatchObjectNode",
+        "displayName": "Patch Object"
+      },
+      "0c2e7c10-63fb-4e25-8218-68e742672fd1": {
+        "x": 1749,
+        "y": 81.015625,
+        "connections": {
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Confirmation"
+      },
+      "c036600d-18b5-4186-a122-227bea684ba8": {
+        "x": 1399,
+        "y": 384.015625,
+        "connections": {
+          "Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59",
+          "Retry": "81f81b53-416f-465a-8ca3-ecbc3216162d"
+        },
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "b2e1eb3f-6276-4437-b52d-606a9c05fa59": {
+        "x": 1618,
+        "y": 566.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "max attempts message"
+      },
+      "a1293502-4cf4-435e-888c-47a5dd5ed62f": {
+        "x": 1542,
+        "y": 787.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "General Error"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 62,
+        "y": 103
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1867,
+        "y": 257
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1816,
+        "y": 755
+      }
+    }
+  }
 }
 

--- a/config/auth-trees/ch-webfiling.json
+++ b/config/auth-trees/ch-webfiling.json
@@ -1,419 +1,532 @@
 {
-	"nodes": [
-		{
-            "_id":"35f0b7c1-ac55-406d-aebe-12e33ab6125a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["noSession", "hasSession"],
-                "outputs":["*"],
-                "script": "ddce54ff-70fe-4ef7-bdfe-3c83488ef266"
-            }            
+  "nodes": [
+    {
+      "_id": "35f0b7c1-ac55-406d-aebe-12e33ab6125a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "noSession",
+          "hasSession"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ddce54ff-70fe-4ef7-bdfe-3c83488ef266"
+      }
+    },
+    {
+      "_id": "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHWebFiling-Login"
+      }
+    },
+    {
+      "_id": "ffad651d-d017-43dc-bc3e-ec4768de5cc5",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "19a9ba97-3eaf-46ed-9b59-ea9315d81407"
+      }
+    },
+    {
+      "_id": "61877889-8233-4048-b76c-39f882081e40",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ca6cbc1b-d83b-4946-b327-be15402894fa"
+      }
+    },
+    {
+      "_id": "9e1930dd-6045-417c-9286-d2083f454f01",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "0dc8c791-4b84-4f63-af32-5f10a58c54c1",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false",
+          "error",
+          "other"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "55801756-11bf-493d-b49c-195488cf939a"
+      }
+    },
+    {
+      "_id": "fc86f06d-b17e-4cda-b10c-fb9fae255d59",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "ad7a63a6-fae2-46c0-be70-bec1f059f064"
+      }
+    },
+    {
+      "_id": "4b27ff9e-407a-4880-8c81-92be95c0e46f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "917f36a9-f21e-43e4-bed5-9b2171228387"
+      }
+    },
+    {
+      "_id": "3b9435a8-96c5-4b54-8877-1a494e9ab6e7",
+      "nodeType": "RetryLimitDecisionNode",
+      "details": {
+        "incrementUserAttributeOnFailure": false,
+        "retryLimit": 3
+      }
+    },
+    {
+      "_id": "9f02e20d-5cee-4608-af7c-3732d3838d88",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "460f8d31-5f90-440a-9f47-f5951778ea4f"
+      }
+    },
+    {
+      "_id": "eba4be16-8b25-4ffd-ac41-97d7354a860d",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "78da2828-68cc-4f63-b003-b8a250b1753d"
+      }
+    },
+    {
+      "_id": "304e305a-a2f4-4380-a5db-3bca9b5da30e",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "09352d71-046f-4fbf-b831-aefb8954705a",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "true",
+          "error",
+          "already_associated",
+          "auth_code_inactive"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "16975ea5-4f0a-4ac6-861f-00dbf39ca441"
+      }
+    },
+    {
+      "_id": "c549d83a-f796-4a27-b6da-91cb626a0bd1",
+      "nodeType": "SessionDataNode",
+      "details": {
+        "sharedStateKey": "userName",
+        "sessionDataKey": "UserToken"
+      }
+    },
+    {
+      "_id": "b13495ba-6ac2-4877-8535-4f63dffb813f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "success",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
+      }
+    },
+    {
+      "_id": "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "inputs": [
+          "*"
+        ],
+        "outcomes": [
+          "user_associated",
+          "user_not_associated",
+          "error"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "d8d0c71c-ddfb-47f6-a577-33aa0b7c2bcd"
+      }
+    },
+    {
+      "_id": "fbf0037d-0557-4111-bd01-edeb685c836f",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true",
+          "false"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "df75d4ae-8f25-48f4-af14-bb87206e029d"
+      }
+    },
+    {
+      "_id": "bfcdaf66-5730-40b7-a847-00f62cd539ca",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df"
+      }
+    },
+    {
+      "_id": "cd37f8c8-249f-4d7c-be85-4c2bd262225b",
+      "nodeType": "IdentifyExistingUserNode",
+      "details": {
+        "identifier": "userName",
+        "identityAttribute": "mail"
+      }
+    },
+    {
+      "_id": "22ba2520-ea77-4eb7-b9fb-6767cb98e54e",
+      "nodeType": "InnerTreeEvaluatorNode",
+      "details": {
+        "tree": "CHManageEmailConsent"
+      }
+    },
+    {
+      "_id": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "outcomes": [
+          "true"
+        ],
+        "inputs": [
+          "*"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
+      }
+    }
+  ],
+  "tree": {
+    "_id": "CHWebFiling",
+    "description": "Journey for WebFiling users",
+    "identityResource": "managed/alpha_user",
+    "uiConfig": {},
+    "entryNodeId": "35f0b7c1-ac55-406d-aebe-12e33ab6125a",
+    "nodes": {
+      "09352d71-046f-4fbf-b831-aefb8954705a": {
+        "x": 1546,
+        "y": 425.015625,
+        "connections": {
+          "already_associated": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "auth_code_inactive": "61877889-8233-4048-b76c-39f882081e40",
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
         },
-		{
-			"_id": "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "CHWebFiling-Login"
-			}
-		},
-		{
-            "_id": "ffad651d-d017-43dc-bc3e-ec4768de5cc5",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-                "script": "19a9ba97-3eaf-46ed-9b59-ea9315d81407"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Create Association"
+      },
+      "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01": {
+        "x": 417,
+        "y": 164.015625,
+        "connections": {
+          "false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "ffad651d-d017-43dc-bc3e-ec4768de5cc5"
         },
-		{
-            "_id": "61877889-8233-4048-b76c-39f882081e40",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false"],
-                "outputs":["*"],
-                "script": "ca6cbc1b-d83b-4946-b327-be15402894fa"
-            }            
+        "nodeType": "InnerTreeEvaluatorNode",
+        "displayName": "Login"
+      },
+      "0dc8c791-4b84-4f63-af32-5f10a58c54c1": {
+        "x": 840,
+        "y": 391.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "false": "61877889-8233-4048-b76c-39f882081e40",
+          "other": "61877889-8233-4048-b76c-39f882081e40",
+          "true": "b13495ba-6ac2-4877-8535-4f63dffb813f"
         },
-		{
-            "_id": "9e1930dd-6045-417c-9286-d2083f454f01",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-                "script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get Company Data"
+      },
+      "304e305a-a2f4-4380-a5db-3bca9b5da30e": {
+        "x": 1552,
+        "y": 304.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "success": "09352d71-046f-4fbf-b831-aefb8954705a"
         },
-		{
-            "_id": "0dc8c791-4b84-4f63-af32-5f10a58c54c1",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false", "error", "other"],
-                "outputs":["*"],
-                "script": "55801756-11bf-493d-b49c-195488cf939a"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM token again"
+      },
+      "35f0b7c1-ac55-406d-aebe-12e33ab6125a": {
+        "x": 195,
+        "y": 60.015625,
+        "connections": {
+          "hasSession": "c549d83a-f796-4a27-b6da-91cb626a0bd1",
+          "noSession": "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01"
         },
-		{
-			"_id": "fc86f06d-b17e-4cda-b10c-fb9fae255d59",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false"],
-                "outputs":["*"],
-                "script": "ad7a63a6-fae2-46c0-be70-bec1f059f064"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Session"
+      },
+      "3b9435a8-96c5-4b54-8877-1a494e9ab6e7": {
+        "x": 1337,
+        "y": 497.015625,
+        "connections": {
+          "Reject": "bfcdaf66-5730-40b7-a847-00f62cd539ca",
+          "Retry": "fc86f06d-b17e-4cda-b10c-fb9fae255d59"
         },
-		{
-			"_id": "4b27ff9e-407a-4880-8c81-92be95c0e46f",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-				"script": "917f36a9-f21e-43e4-bed5-9b2171228387"
-            }            
+        "nodeType": "RetryLimitDecisionNode",
+        "displayName": "Retry Limit Decision"
+      },
+      "4b27ff9e-407a-4880-8c81-92be95c0e46f": {
+        "x": 1333,
+        "y": 422.015625,
+        "connections": {
+          "true": "3b9435a8-96c5-4b54-8877-1a494e9ab6e7"
         },
-		{
-            "_id": "3b9435a8-96c5-4b54-8877-1a494e9ab6e7",
-            "nodeType": "RetryLimitDecisionNode", 
-            "details": {
-                "retryLimit":3
-            }
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Auth code error msg"
+      },
+      "61877889-8233-4048-b76c-39f882081e40": {
+        "x": 810,
+        "y": 147.015625,
+        "connections": {
+          "false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "9e1930dd-6045-417c-9286-d2083f454f01"
         },
-		{
-			"_id": "9f02e20d-5cee-4608-af7c-3732d3838d88",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true"],
-                "outputs":["*"],
-				"script": "460f8d31-5f90-440a-9f47-f5951778ea4f"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Prompt for Company No"
+      },
+      "9e1930dd-6045-417c-9286-d2083f454f01": {
+        "x": 831,
+        "y": 264.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "success": "0dc8c791-4b84-4f63-af32-5f10a58c54c1"
         },
-		{
-			"_id": "eba4be16-8b25-4ffd-ac41-97d7354a860d",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "false"],
-                "outputs":["*"],
-				"script": "78da2828-68cc-4f63-b003-b8a250b1753d"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Token"
+      },
+      "9f02e20d-5cee-4608-af7c-3732d3838d88": {
+        "x": 1549,
+        "y": 108.015625,
+        "connections": {
+          "true": "eba4be16-8b25-4ffd-ac41-97d7354a860d"
         },
-		{
-			"_id": "304e305a-a2f4-4380-a5db-3bca9b5da30e",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-				"script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Add Auth code to session"
+      },
+      "b13495ba-6ac2-4877-8535-4f63dffb813f": {
+        "x": 1053,
+        "y": 86.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "success": "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c"
         },
-		{
-			"_id": "09352d71-046f-4fbf-b831-aefb8954705a",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["true", "error", "already_associated", "auth_code_inactive"],
-                "outputs":["*"],
-				"script": "16975ea5-4f0a-4ac6-861f-00dbf39ca441"
-            }            
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Get IDM Token for company check"
+      },
+      "bfcdaf66-5730-40b7-a847-00f62cd539ca": {
+        "x": 1343,
+        "y": 620.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "max attempts error"
+      },
+      "c549d83a-f796-4a27-b6da-91cb626a0bd1": {
+        "x": 380,
+        "y": 34.015625,
+        "connections": {
+          "outcome": "cd37f8c8-249f-4d7c-be85-4c2bd262225b"
         },
-		{
-			"_id": "c549d83a-f796-4a27-b6da-91cb626a0bd1",
-			"nodeType": "SessionDataNode", 
-			"details": {
-				"sharedStateKey":"userName",
-				"sessionDataKey":"UserToken"
-			}				
-		},
-		{
-			"_id": "b13495ba-6ac2-4877-8535-4f63dffb813f",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["success", "error"],
-                "outputs":["*"],
-				"script": "c0ab8c9c-b9b2-4bb7-b427-f10ddf9db149"
-            }            
+        "nodeType": "SessionDataNode",
+        "displayName": "Get Session Data"
+      },
+      "cd37f8c8-249f-4d7c-be85-4c2bd262225b": {
+        "x": 616.640625,
+        "y": 60.015625,
+        "connections": {
+          "false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "61877889-8233-4048-b76c-39f882081e40"
         },
-		{
-			"_id": "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c",
-            "nodeType": "ScriptedDecisionNode", 
-            "details": {
-                "inputs":["*"],
-                "outcomes": ["user_associated", "user_not_associated", "error"],
-                "outputs":["*"],
-				"script": "d8d0c71c-ddfb-47f6-a577-33aa0b7c2bcd"
-            }            
+        "nodeType": "IdentifyExistingUserNode",
+        "displayName": "Identify Existing User"
+      },
+      "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c": {
+        "x": 1071,
+        "y": 211.015625,
+        "connections": {
+          "error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "user_associated": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "user_not_associated": "fc86f06d-b17e-4cda-b10c-fb9fae255d59"
         },
-		{
-			"_id": "fbf0037d-0557-4111-bd01-edeb685c836f",
-			"nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true", "false"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "df75d4ae-8f25-48f4-af14-bb87206e029d"
-			}
-		},
-		{
-			"_id": "bfcdaf66-5730-40b7-a847-00f62cd539ca",
-			"nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "fdac4efb-d8b8-478b-8300-e11a4c3503df"
-			}
-		},
-		{
-			"_id": "cd37f8c8-249f-4d7c-be85-4c2bd262225b",
-			"nodeType": "IdentifyExistingUserNode",
-			"details": {
-				"identifier": "userName",
-				"identityAttribute": "mail"
-			}
-		},
-		{
-			"_id": "22ba2520-ea77-4eb7-b9fb-6767cb98e54e",
-			"nodeType": "InnerTreeEvaluatorNode",
-			"details": {
-				"tree": "CHManageEmailConsent"
-			}
-		},
-		{
-			"_id": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-			"nodeType": "ScriptedDecisionNode",
-            "details": {
-                "outcomes": ["true"],
-                "inputs": ["*"],
-                "outputs": ["*"],
-                "script": "e69b137b-1bae-4804-af6b-6a93371733ca"
-			}
-		}
-    ],
-    "tree": {
-		"_id": "CHWebFiling",
-		"description": "Journey for WebFiling users",
-		"identityResource": "managed/alpha_user",
-		"uiConfig": {},
-		"entryNodeId": "35f0b7c1-ac55-406d-aebe-12e33ab6125a",
-		"nodes": {
-			"09352d71-046f-4fbf-b831-aefb8954705a": {
-				"x": 1546,
-				"y": 425.015625,
-				"connections": {
-					"already_associated": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-					"auth_code_inactive": "61877889-8233-4048-b76c-39f882081e40",
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Create Association"
-			},
-			"0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01": {
-				"x": 417,
-				"y": 164.015625,
-				"connections": {
-					"false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "ffad651d-d017-43dc-bc3e-ec4768de5cc5"
-				},
-				"nodeType": "InnerTreeEvaluatorNode",
-				"displayName": "Login"
-			},
-			"0dc8c791-4b84-4f63-af32-5f10a58c54c1": {
-				"x": 840,
-				"y": 391.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"false": "61877889-8233-4048-b76c-39f882081e40",
-					"other": "61877889-8233-4048-b76c-39f882081e40",
-					"true": "b13495ba-6ac2-4877-8535-4f63dffb813f"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get Company Data"
-			},
-			"304e305a-a2f4-4380-a5db-3bca9b5da30e": {
-				"x": 1552,
-				"y": 304.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"success": "09352d71-046f-4fbf-b831-aefb8954705a"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM token again"
-			},
-			"35f0b7c1-ac55-406d-aebe-12e33ab6125a": {
-				"x": 195,
-				"y": 60.015625,
-				"connections": {
-					"hasSession": "c549d83a-f796-4a27-b6da-91cb626a0bd1",
-					"noSession": "0a9b70bc-8fc7-4c54-9bfa-3db936cb9d01"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check Session"
-			},
-			"3b9435a8-96c5-4b54-8877-1a494e9ab6e7": {
-				"x": 1337,
-				"y": 497.015625,
-				"connections": {
-					"Reject": "bfcdaf66-5730-40b7-a847-00f62cd539ca",
-					"Retry": "fc86f06d-b17e-4cda-b10c-fb9fae255d59"
-				},
-				"nodeType": "RetryLimitDecisionNode",
-				"displayName": "Retry Limit Decision"
-			},
-			"4b27ff9e-407a-4880-8c81-92be95c0e46f": {
-				"x": 1333,
-				"y": 422.015625,
-				"connections": {
-					"true": "3b9435a8-96c5-4b54-8877-1a494e9ab6e7"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Auth code error msg"
-			},
-			"61877889-8233-4048-b76c-39f882081e40": {
-				"x": 810,
-				"y": 147.015625,
-				"connections": {
-					"false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "9e1930dd-6045-417c-9286-d2083f454f01"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Prompt for Company No"
-			},
-			"9e1930dd-6045-417c-9286-d2083f454f01": {
-				"x": 831,
-				"y": 264.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"success": "0dc8c791-4b84-4f63-af32-5f10a58c54c1"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM Token"
-			},
-			"9f02e20d-5cee-4608-af7c-3732d3838d88": {
-				"x": 1549,
-				"y": 108.015625,
-				"connections": {
-					"true": "eba4be16-8b25-4ffd-ac41-97d7354a860d"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Add Auth code to session"
-			},
-			"b13495ba-6ac2-4877-8535-4f63dffb813f": {
-				"x": 1053,
-				"y": 86.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"success": "dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Get IDM Token for company check"
-			},
-			"bfcdaf66-5730-40b7-a847-00f62cd539ca": {
-				"x": 1343,
-				"y": 620.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "max attempts error"
-			},
-			"c549d83a-f796-4a27-b6da-91cb626a0bd1": {
-				"x": 380,
-				"y": 34.015625,
-				"connections": {
-					"outcome": "cd37f8c8-249f-4d7c-be85-4c2bd262225b"
-				},
-				"nodeType": "SessionDataNode",
-				"displayName": "Get Session Data"
-			},
-			"cd37f8c8-249f-4d7c-be85-4c2bd262225b": {
-				"x": 616.640625,
-				"y": 60.015625,
-				"connections": {
-					"false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "61877889-8233-4048-b76c-39f882081e40"
-				},
-				"nodeType": "IdentifyExistingUserNode",
-				"displayName": "Identify Existing User"
-			},
-			"dfb2d5fd-8a2f-4b59-9f7b-347046b69e5c": {
-				"x": 1071,
-				"y": 211.015625,
-				"connections": {
-					"error": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"user_associated": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-					"user_not_associated": "fc86f06d-b17e-4cda-b10c-fb9fae255d59"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Check Company Association"
-			},
-			"eba4be16-8b25-4ffd-ac41-97d7354a860d": {
-				"x": 1552,
-				"y": 180.015625,
-				"connections": {
-					"false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
-					"true": "304e305a-a2f4-4380-a5db-3bca9b5da30e"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Confirm association"
-			},
-			"fbf0037d-0557-4111-bd01-edeb685c836f": {
-				"x": 1308,
-				"y": 302.015625,
-				"connections": {
-					"false": "4b27ff9e-407a-4880-8c81-92be95c0e46f",
-					"true": "9f02e20d-5cee-4608-af7c-3732d3838d88"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Validate Cleartext Auth Code"
-			},
-			"fc86f06d-b17e-4cda-b10c-fb9fae255d59": {
-				"x": 1335,
-				"y": 178.015625,
-				"connections": {
-					"false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
-					"true": "fbf0037d-0557-4111-bd01-edeb685c836f"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Enter Auth Code"
-			},
-			"ffad651d-d017-43dc-bc3e-ec4768de5cc5": {
-				"x": 418,
-				"y": 290.015625,
-				"connections": {
-					"true": "61877889-8233-4048-b76c-39f882081e40"
-				},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "Add to Session"
-			},
-			"074551cb-6074-4ded-b08e-03c638bfd1a1": {
-				"x": 1106,
-				"y": 780.015625,
-				"connections": {},
-				"nodeType": "ScriptedDecisionNode",
-				"displayName": "General Error"
-			}
-		},
-		"staticNodes": {
-			"startNode": {
-				"x": 70,
-				"y": 80
-			},
-			"70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-				"x": 1819,
-				"y": 487
-			},
-			"e301438c-0bd0-429c-ab0c-66126501069a": {
-				"x": 1323,
-				"y": 769
-			}
-		}
-	}
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Check Company Association"
+      },
+      "eba4be16-8b25-4ffd-ac41-97d7354a860d": {
+        "x": 1552,
+        "y": 180.015625,
+        "connections": {
+          "false": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0",
+          "true": "304e305a-a2f4-4380-a5db-3bca9b5da30e"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Confirm association"
+      },
+      "fbf0037d-0557-4111-bd01-edeb685c836f": {
+        "x": 1308,
+        "y": 302.015625,
+        "connections": {
+          "false": "4b27ff9e-407a-4880-8c81-92be95c0e46f",
+          "true": "9f02e20d-5cee-4608-af7c-3732d3838d88"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Validate Cleartext Auth Code"
+      },
+      "fc86f06d-b17e-4cda-b10c-fb9fae255d59": {
+        "x": 1335,
+        "y": 178.015625,
+        "connections": {
+          "false": "074551cb-6074-4ded-b08e-03c638bfd1a1",
+          "true": "fbf0037d-0557-4111-bd01-edeb685c836f"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Enter Auth Code"
+      },
+      "ffad651d-d017-43dc-bc3e-ec4768de5cc5": {
+        "x": 418,
+        "y": 290.015625,
+        "connections": {
+          "true": "61877889-8233-4048-b76c-39f882081e40"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Add to Session"
+      },
+      "074551cb-6074-4ded-b08e-03c638bfd1a1": {
+        "x": 1106,
+        "y": 780.015625,
+        "connections": {},
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "General Error"
+      }
+    },
+    "staticNodes": {
+      "startNode": {
+        "x": 70,
+        "y": 80
+      },
+      "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
+        "x": 1819,
+        "y": 487
+      },
+      "e301438c-0bd0-429c-ab0c-66126501069a": {
+        "x": 1323,
+        "y": 769
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Description

* modify retry limit decision nodes to not save to user state

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [ ] scripts (AM)
- [x] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
