### PR TITLE
fix to map Welsh companies to the 'EW' jurisdiction in FIDC

### DIFF
--- a/config/connectors/mappings/chsMongoCompanyProfile_alphaOrg.json
+++ b/config/connectors/mappings/chsMongoCompanyProfile_alphaOrg.json
@@ -103,7 +103,7 @@
 			"transform": {
 				"type": "text/javascript",
 				"globals": {},
-				"source": "if (source.jurisdiction == \"england-wales\") {\n  \"EW\"\n} else if (source.jurisdiction == \"scotland\") {\n  \"SC\"\n} else if (source.jurisdiction == \"northern-ireland\") {\n  \"NI\"\n} else {\n  source.jurisdiction\n}"
+				"source": "if (source.jurisdiction == \"england-wales\" || source.jurisdiction == \"wales\" || source.jurisdiction == \"england\") {\n  \"EW\"\n} else if (source.jurisdiction == \"scotland\") {\n  \"SC\"\n} else if (source.jurisdiction == \"northern-ireland\") {\n  \"NI\"\n} else {\n  source.jurisdiction\n}"
 			}
 		}
 	],

--- a/config/connectors/schedules/ds-backup.json
+++ b/config/connectors/schedules/ds-backup.json
@@ -1,6 +1,6 @@
 {
     "isCron": true,
-    "enabled": true,
+    "enabled": false,
     "persisted": true,
     "type": "cron",
     "misfirePolicy": "fireAndProceed",


### PR DESCRIPTION
- added condition to map 'england' and 'wales' companies to EW jurisdiction
- temporarily disabled the DSbackup scheduled recon

**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [ ] scripts (AM)
- [ ] auth trees (AM)
- [x] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [x] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
