### PR TITLE
idam-1040/add client admin test user for automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ config/applications/api-filing-web-client.json
 config/applications/chs-internal-client.json
 config/agents/ig-agent.json
 config/managed-users/tree-service-user.json
+config/managed-users/admin-client-test.json

--- a/config/managed-users/admin-client-test.json.tpl
+++ b/config/managed-users/admin-client-test.json.tpl
@@ -1,8 +1,8 @@
 {
-  "_id": "9dbbf03c-6c71-45a9-9afb-cbde39b53ead",
+  "_id": "513024f7-110c-4ee6-b31a-bf6026b15678",
 
-  "userName": "tree-service-user@companieshouse.com",
-  "password": "{AUTH_TREE_PASSWORD}",
+  "userName": "AdminClientTest@example.com",
+  "password": "{ADMIN_CLIENT_TEST_PASSWORD}",
   "authzRoles": [
     {
       "_ref": "internal/role/openidm-admin"
@@ -16,16 +16,16 @@
   "stateProvince": null,
   "postalAddress": null,
   "displayName": null,
-  "description": "Tree Service User",
+  "description": null,
   "country": null,
   "city": null,
-  "givenName": "Tree Service",
+  "givenName": null,
   "profileImage": null,
-  "sn": "tree-service-user@companieshouse.com",
+  "sn": "AdminClientTest@example.com",
   "telephoneNumber": null,
-  "mail": "tree-service-user@companieshouse.com",
+  "mail": "AdminClientTest@example.com",
   "isMemberOf": null,
-  "frIndexedString1": "11111111111111111111111111111112",
+  "frIndexedString1": null,
   "frIndexedString3": "migrated",
   "frIndexedString4": null,
   "frIndexedString5": "webfiling",

--- a/scripts/update-managed-users.js
+++ b/scripts/update-managed-users.js
@@ -5,7 +5,7 @@ const fidcRequest = require('../helpers/fidc-request')
 const replaceSensitiveValues = require('../helpers/replace-sensitive-values')
 
 const updateManagedUsers = async (argv) => {
-  const { FIDC_URL, AUTH_TREE_PASSWORD } = process.env
+  const { FIDC_URL, AUTH_TREE_PASSWORD, ADMIN_CLIENT_TEST_PASSWORD } = process.env
 
   try {
     const accessToken = await getAccessToken(argv)
@@ -17,8 +17,14 @@ const updateManagedUsers = async (argv) => {
 
     await replaceSensitiveValues(
       dir,
-      [/{AUTH_TREE_PASSWORD}/g],
-      [tsup]
+      [
+        /{AUTH_TREE_PASSWORD}/g,
+        /{ADMIN_CLIENT_TEST_PASSWORD}/g
+      ],
+      [
+        tsup,
+        ADMIN_CLIENT_TEST_PASSWORD
+      ]
     )
 
     const managedUsersFileContent = fs


### PR DESCRIPTION
# Description

* Add AdminClientTest user as a managed user for automated tests

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [ ] scripts (AM)
- [ ] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [x] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
