### PR TITLE
idam-1132/Fix error shown if invalid OTP

### DIFF
--- a/config/am-scripts/scripts-content/ch-callback-to-capture-otp-response.js
+++ b/config/am-scripts/scripts-content/ch-callback-to-capture-otp-response.js
@@ -103,6 +103,22 @@ if (callbacks.isEmpty()) {
 
   if (otpError) {
     pageProps.incorrect = otpError;
+
+    if (mfaRoute === 'sms') {
+      pageProps.errors = [{
+        label: 'Enter the security code exactly as it is shown in the text message',
+        token: 'OTP_NOT_VALID_SMS',
+        fieldName: 'IDToken4',
+        anchor: 'IDToken4'
+      }];
+    } else if (mfaRoute === 'email') {
+      pageProps.errors = [{
+        label: 'Enter the security code exactly as it is shown in the email',
+        token: 'OTP_NOT_VALID_EMAIL',
+        fieldName: 'IDToken4',
+        anchor: 'IDToken4'
+      }];
+    }
   }
 
   if (otpResend) {


### PR DESCRIPTION
# Description

* Add error to PageProps if OTP code is invalid

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] applications (AM)
- [ ] agents (AM)
- [x] scripts (AM)
- [ ] auth trees (AM)
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
