### PR TITLE
Idam 1114/increase complexity change gov uk

### DIFF
--- a/config/am-scripts/scripts-content/ch-scrs-validate-params.js
+++ b/config/am-scripts/scripts-content/ch-scrs-validate-params.js
@@ -72,7 +72,7 @@ function getHeaderParams (requestHeaders) {
   if (requestHeaders.get(headerNotificationEmail)) {
     email = requestHeaders.get(headerNotificationEmail).get(0);
   }
-  
+
   if (requestHeaders.get(headerNewUser)) {
     newUser = (String(requestHeaders.get(headerNewUser).get(0)) === 'true');
   }
@@ -99,7 +99,7 @@ function getHeaderParams (requestHeaders) {
 
   _log('Got individual headers');
 
-  if ((!username || !username.equals('tree-service-user@companieshouse.com')) ||
+  if ((!username || !username.equals('tree-service-user@companieshouse.gov.uk')) ||
     !pwd ||
     !link ||
     !email ||

--- a/config/connectors/mappings/cleanup_FIDC_users.json
+++ b/config/connectors/mappings/cleanup_FIDC_users.json
@@ -80,10 +80,10 @@
       "situation": "ABSENT"
     }
   ],
-  "validTarget" : {
-    "type" : "text/javascript",
-    "globals" : { },
-    "source" : "target.userName !== 'tree-service-user@companieshouse.com' && 'tree-service-user@companieshouse.co.uk' && target.userName !== 'ConcourseUser@companieshouse.gov.uk' && target.userName !== 'AdminClientTest@example.com' && target.userName !== 'pxtdbugadc1@gmail.com' && target.userName !== 'pxtdbugadc2@gmail.com' && target.userName !== 'pxtdbugadc3@gmail.com' && target.userName !== 'pxtdbugadc4@gmail.com' && target.userName !== 'testautomationfr36@test.companieshouse.gov.uk' && target.userName !== 'testautomationfr37@test.companieshouse.gov.uk' && target.userName !== 'fcalvino@companieshouse.gov.uk' && target.userName !== 'francesco.calvino@amido.com'"
+  "validTarget": {
+    "type": "text/javascript",
+    "globals": {},
+    "source": "target.userName !== 'tree-service-user@companieshouse.gov.uk' && 'tree-service-user@companieshouse.co.uk' && target.userName !== 'ConcourseUser@companieshouse.gov.uk' && target.userName !== 'AdminClientTest@example.com' && target.userName !== 'pxtdbugadc1@gmail.com' && target.userName !== 'pxtdbugadc2@gmail.com' && target.userName !== 'pxtdbugadc3@gmail.com' && target.userName !== 'pxtdbugadc4@gmail.com' && target.userName !== 'testautomationfr36@test.companieshouse.gov.uk' && target.userName !== 'testautomationfr37@test.companieshouse.gov.uk' && target.userName !== 'fcalvino@companieshouse.gov.uk' && target.userName !== 'francesco.calvino@amido.com'"
   },
   "clusteredSourceReconEnabled": true,
   "reconSourceQueryPageSize": 100000,

--- a/config/managed-users/tree-service-user.json.tpl
+++ b/config/managed-users/tree-service-user.json.tpl
@@ -1,7 +1,7 @@
 {
   "_id": "9dbbf03c-6c71-45a9-9afb-cbde39b53ead",
 
-  "userName": "tree-service-user@companieshouse.com",
+  "userName": "tree-service-user@companieshouse.gov.uk",
   "password": "{AUTH_TREE_PASSWORD}",
   "authzRoles": [
     {
@@ -21,9 +21,9 @@
   "city": null,
   "givenName": "Tree Service",
   "profileImage": null,
-  "sn": "tree-service-user@companieshouse.com",
+  "sn": "tree-service-user@companieshouse.gov.uk",
   "telephoneNumber": null,
-  "mail": "tree-service-user@companieshouse.com",
+  "mail": "tree-service-user@companieshouse.gov.uk",
   "isMemberOf": null,
   "frIndexedString1": "11111111111111111111111111111112",
   "frIndexedString3": "migrated",

--- a/config/managed-users/tree-service-user.json.tpl
+++ b/config/managed-users/tree-service-user.json.tpl
@@ -1,5 +1,5 @@
 {
-  "_id": "9dbbf03c-6c71-45a9-9afb-cbde39b53ead",
+  "_id": "69a569d7-3c64-4619-8eb9-2fd232355bc0",
 
   "userName": "tree-service-user@companieshouse.gov.uk",
   "password": "{AUTH_TREE_PASSWORD}",

--- a/config/password-policy/password-policy.json
+++ b/config/password-policy/password-policy.json
@@ -17,6 +17,15 @@
       "maxConsecutiveLength": 2
     },
     {
+      "_id": "alpha_userPasswordPolicy-dictionary-password-validator",
+      "type": "dictionary",
+      "enabled": true,
+      "dictionaryFile": "config/wordlist.txt",
+      "caseSensitiveValidation": false,
+      "checkSubstrings": false,
+      "testReversedPassword": true
+    },
+    {
       "_id": "alpha_userPasswordPolicy-attribute-value-password-validator",
       "type": "attribute-value",
       "enabled": true,

--- a/tests/scripts/update-managed-users.test.js
+++ b/tests/scripts/update-managed-users.test.js
@@ -1,26 +1,26 @@
 describe('update-managed-users', () => {
-  jest.mock('fs');
-  const fs = require('fs');
-  const path = require('path');
-  jest.mock('../../helpers/get-access-token');
-  const getAccessToken = require('../../helpers/get-access-token');
-  jest.mock('../../helpers/fidc-request');
-  const fidcRequest = require('../../helpers/fidc-request');
-  jest.spyOn(console, 'log').mockImplementation(() => {});
-  jest.spyOn(console, 'error').mockImplementation(() => {});
-  jest.spyOn(process, 'exit').mockImplementation(() => {});
+  jest.mock('fs')
+  const fs = require('fs')
+  const path = require('path')
+  jest.mock('../../helpers/get-access-token')
+  const getAccessToken = require('../../helpers/get-access-token')
+  jest.mock('../../helpers/fidc-request')
+  const fidcRequest = require('../../helpers/fidc-request')
+  jest.spyOn(console, 'log').mockImplementation(() => {})
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  jest.spyOn(process, 'exit').mockImplementation(() => {})
 
-  const updateManagedUsers = require('../../scripts/update-managed-users');
+  const updateManagedUsers = require('../../scripts/update-managed-users')
 
   const mockValues = {
     fidcUrl: 'https://fidc-test.forgerock.com',
     accessToken: 'forgerock-token'
-  };
+  }
 
   const mockConfigFile = path.resolve(
     __dirname,
     '../../config/managed-users/tree-service-user.json'
-  );
+  )
 
   const mockConfig = {
     _id: '99999999-6c71-45a9-9afb-cbde39b53ead',
@@ -93,63 +93,63 @@ describe('update-managed-users', () => {
     preferences: null,
     aliasList: [],
     memberOfOrgIDs: []
-  };
+  }
 
   beforeEach(() => {
-    fidcRequest.mockImplementation(() => Promise.resolve());
+    fidcRequest.mockImplementation(() => Promise.resolve())
     getAccessToken.mockImplementation(() =>
       Promise.resolve(mockValues.accessToken)
-    );
-    process.env.FIDC_URL = mockValues.fidcUrl;
-    fs.readdirSync.mockReturnValue(['tree-service-user.json']);
-    jest.mock(mockConfigFile, () => mockConfig, { virtual: true });
-  });
+    )
+    process.env.FIDC_URL = mockValues.fidcUrl
+    fs.readdirSync.mockReturnValue(['tree-service-user.json'])
+    jest.mock(mockConfigFile, () => mockConfig, { virtual: true })
+  })
 
   afterEach(() => {
-    jest.resetAllMocks();
-    console.log.mockClear();
-    console.error.mockClear();
-    process.exit.mockClear();
-  });
+    jest.resetAllMocks()
+    console.log.mockClear()
+    console.error.mockClear()
+    process.exit.mockClear()
+  })
 
   afterAll(() => {
-    console.log.mockRestore();
-    console.error.mockRestore();
-    process.exit.mockRestore();
-  });
+    console.log.mockRestore()
+    console.error.mockRestore()
+    process.exit.mockRestore()
+  })
 
   it('should error if getAccessToken functions fails', async () => {
-    expect.assertions(2);
-    const errorMessage = 'Invalid user';
+    expect.assertions(2)
+    const errorMessage = 'Invalid user'
     getAccessToken.mockImplementation(() =>
       Promise.reject(new Error(errorMessage))
-    );
-    await updateManagedUsers(mockValues);
-    expect(console.error).toHaveBeenCalledWith(errorMessage);
-    expect(process.exit).toHaveBeenCalledWith(1);
-  });
+    )
+    await updateManagedUsers(mockValues)
+    expect(console.error).toHaveBeenCalledWith(errorMessage)
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
 
   it('should call API using config file', async () => {
-    expect.assertions(2);
-    const expectedUrl = `${mockValues.fidcUrl}/openidm/managed/alpha_user/${mockConfig._id}`;
-    await updateManagedUsers(mockValues);
-    expect(fidcRequest.mock.calls.length).toEqual(1);
+    expect.assertions(2)
+    const expectedUrl = `${mockValues.fidcUrl}/openidm/managed/alpha_user/${mockConfig._id}`
+    await updateManagedUsers(mockValues)
+    expect(fidcRequest.mock.calls.length).toEqual(1)
     expect(fidcRequest).toHaveBeenCalledWith(
       expectedUrl,
       mockConfig,
       mockValues.accessToken,
       false
-    );
-  });
+    )
+  })
 
   it('should error if API request fails', async () => {
-    expect.assertions(2);
-    const errorMessage = 'Something went wrong';
+    expect.assertions(2)
+    const errorMessage = 'Something went wrong'
     fidcRequest.mockImplementation(() =>
       Promise.reject(new Error(errorMessage))
-    );
-    await updateManagedUsers(mockValues);
-    expect(console.error).toHaveBeenCalledWith(errorMessage);
-    expect(process.exit).toHaveBeenCalledWith(1);
-  });
-});
+    )
+    await updateManagedUsers(mockValues)
+    expect(console.error).toHaveBeenCalledWith(errorMessage)
+    expect(process.exit).toHaveBeenCalledWith(1)
+  })
+})

--- a/tests/scripts/update-managed-users.test.js
+++ b/tests/scripts/update-managed-users.test.js
@@ -1,31 +1,31 @@
 describe('update-managed-users', () => {
-  jest.mock('fs')
-  const fs = require('fs')
-  const path = require('path')
-  jest.mock('../../helpers/get-access-token')
-  const getAccessToken = require('../../helpers/get-access-token')
-  jest.mock('../../helpers/fidc-request')
-  const fidcRequest = require('../../helpers/fidc-request')
-  jest.spyOn(console, 'log').mockImplementation(() => {})
-  jest.spyOn(console, 'error').mockImplementation(() => {})
-  jest.spyOn(process, 'exit').mockImplementation(() => {})
+  jest.mock('fs');
+  const fs = require('fs');
+  const path = require('path');
+  jest.mock('../../helpers/get-access-token');
+  const getAccessToken = require('../../helpers/get-access-token');
+  jest.mock('../../helpers/fidc-request');
+  const fidcRequest = require('../../helpers/fidc-request');
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(process, 'exit').mockImplementation(() => {});
 
-  const updateManagedUsers = require('../../scripts/update-managed-users')
+  const updateManagedUsers = require('../../scripts/update-managed-users');
 
   const mockValues = {
     fidcUrl: 'https://fidc-test.forgerock.com',
     accessToken: 'forgerock-token'
-  }
+  };
 
   const mockConfigFile = path.resolve(
     __dirname,
     '../../config/managed-users/tree-service-user.json'
-  )
+  );
 
   const mockConfig = {
     _id: '99999999-6c71-45a9-9afb-cbde39b53ead',
 
-    userName: 'test-tree-service-user@companieshouse.com',
+    userName: 'test-tree-service-user@companieshouse.gov.uk',
     password: 'LetMeIn1234!',
     authzRoles: [
       {
@@ -45,9 +45,9 @@ describe('update-managed-users', () => {
     city: null,
     givenName: null,
     profileImage: null,
-    sn: 'test-tree-service-user@companieshouse.com',
+    sn: 'test-tree-service-user@companieshouse.gov.uk',
     telephoneNumber: null,
-    mail: 'test-tree-service-user@companieshouse.com',
+    mail: 'test-tree-service-user@companieshouse.gov.uk',
     isMemberOf: null,
     frIndexedString1: '11111111111111111111111111111112',
     frIndexedString3: 'migrated',
@@ -93,63 +93,63 @@ describe('update-managed-users', () => {
     preferences: null,
     aliasList: [],
     memberOfOrgIDs: []
-  }
+  };
 
   beforeEach(() => {
-    fidcRequest.mockImplementation(() => Promise.resolve())
+    fidcRequest.mockImplementation(() => Promise.resolve());
     getAccessToken.mockImplementation(() =>
       Promise.resolve(mockValues.accessToken)
-    )
-    process.env.FIDC_URL = mockValues.fidcUrl
-    fs.readdirSync.mockReturnValue(['tree-service-user.json'])
-    jest.mock(mockConfigFile, () => mockConfig, { virtual: true })
-  })
+    );
+    process.env.FIDC_URL = mockValues.fidcUrl;
+    fs.readdirSync.mockReturnValue(['tree-service-user.json']);
+    jest.mock(mockConfigFile, () => mockConfig, { virtual: true });
+  });
 
   afterEach(() => {
-    jest.resetAllMocks()
-    console.log.mockClear()
-    console.error.mockClear()
-    process.exit.mockClear()
-  })
+    jest.resetAllMocks();
+    console.log.mockClear();
+    console.error.mockClear();
+    process.exit.mockClear();
+  });
 
   afterAll(() => {
-    console.log.mockRestore()
-    console.error.mockRestore()
-    process.exit.mockRestore()
-  })
+    console.log.mockRestore();
+    console.error.mockRestore();
+    process.exit.mockRestore();
+  });
 
   it('should error if getAccessToken functions fails', async () => {
-    expect.assertions(2)
-    const errorMessage = 'Invalid user'
+    expect.assertions(2);
+    const errorMessage = 'Invalid user';
     getAccessToken.mockImplementation(() =>
       Promise.reject(new Error(errorMessage))
-    )
-    await updateManagedUsers(mockValues)
-    expect(console.error).toHaveBeenCalledWith(errorMessage)
-    expect(process.exit).toHaveBeenCalledWith(1)
-  })
+    );
+    await updateManagedUsers(mockValues);
+    expect(console.error).toHaveBeenCalledWith(errorMessage);
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
 
   it('should call API using config file', async () => {
-    expect.assertions(2)
-    const expectedUrl = `${mockValues.fidcUrl}/openidm/managed/alpha_user/${mockConfig._id}`
-    await updateManagedUsers(mockValues)
-    expect(fidcRequest.mock.calls.length).toEqual(1)
+    expect.assertions(2);
+    const expectedUrl = `${mockValues.fidcUrl}/openidm/managed/alpha_user/${mockConfig._id}`;
+    await updateManagedUsers(mockValues);
+    expect(fidcRequest.mock.calls.length).toEqual(1);
     expect(fidcRequest).toHaveBeenCalledWith(
       expectedUrl,
       mockConfig,
       mockValues.accessToken,
       false
-    )
-  })
+    );
+  });
 
   it('should error if API request fails', async () => {
-    expect.assertions(2)
-    const errorMessage = 'Something went wrong'
+    expect.assertions(2);
+    const errorMessage = 'Something went wrong';
     fidcRequest.mockImplementation(() =>
       Promise.reject(new Error(errorMessage))
-    )
-    await updateManagedUsers(mockValues)
-    expect(console.error).toHaveBeenCalledWith(errorMessage)
-    expect(process.exit).toHaveBeenCalledWith(1)
-  })
-})
+    );
+    await updateManagedUsers(mockValues);
+    expect(console.error).toHaveBeenCalledWith(errorMessage);
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
# Description

* Change `.com` users to be `.gov.uk`
* Change simple passwords to be more complex
* Modify tree-service-user password
* Modify ESVs to match

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [x] applications (AM)
- [ ] agents (AM)
- [x] scripts (AM)
- [ ] auth trees (AM)
- [x] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] access config (IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] managed-objects (IDM)
- [x] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] services (AM)
- [ ] internal-roles (IDM)
