### PR TITLE
idam-1299/Old OTP details used for resending after not received the f…

### DIFF
--- a/config/am-scripts/scripts-content/ch-check-otp-resend-address.js
+++ b/config/am-scripts/scripts-content/ch-check-otp-resend-address.js
@@ -35,7 +35,10 @@ try {
   var mfaRouteText = 'MFA Route not supported : ' + mfaRoute + ' for userId : ' + userId;
 
   if (mfaRoute === 'sms') {
-    if (idRepository.getAttribute(userId, 'telephoneNumber').iterator().hasNext()) {
+    var isUpdatePhoneNumber = sharedState.get('updatePhoneNumber');
+    if (isUpdatePhoneNumber) {
+      phoneNumber = sharedState.get('newPhoneNumber');
+    } else if (idRepository.getAttribute(userId, 'telephoneNumber').iterator().hasNext()) {
       phoneNumber = idRepository.getAttribute(userId, 'telephoneNumber').iterator().next();
     } else {
       _log('Failed to get phoneNumber for userId : ' + userId);
@@ -49,7 +52,10 @@ try {
 
     mfaRouteText = 'Do you want to resend the SMS to '.concat(phoneNumber).concat('?');
   } else if (mfaRoute === 'email') {
-    if (idRepository.getAttribute(userId, 'mail').iterator().hasNext()) {
+    var isChangeEmail = sharedState.get('isChangeEmail');
+    if (isChangeEmail) {
+      email = sharedState.get('newEmail');
+    } else if (idRepository.getAttribute(userId, 'mail').iterator().hasNext()) {
       email = idRepository.getAttribute(userId, 'mail').iterator().next();
     } else {
       _log('Failed to get email for userId : ' + userId);


### PR DESCRIPTION
# Description

* Old OTP details used for resending after not received the first OTP

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [x] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
