### PR TITLE
idam-1316/Set password in session after changing it

### DIFF
--- a/config/am-scripts/scripts-content/ch-update-pwd-load-new-pwd-for-patch.js
+++ b/config/am-scripts/scripts-content/ch-update-pwd-load-new-pwd-for-patch.js
@@ -13,7 +13,10 @@ var password = transientState.get('newPassword');
 try {
   var objectAttributes = sharedState.get('objectAttributes');
   objectAttributes.put('password', password);
+
   sharedState.put('objectAttributes', objectAttributes);
+  sharedState.put('password', password);
+  
   _log('updated sharedstate: ' + sharedState.get('objectAttributes'));
 
   _log('new password: ' + password);

--- a/config/auth-trees/ch-registration-verify.json
+++ b/config/auth-trees/ch-registration-verify.json
@@ -198,6 +198,22 @@
         "identityAttribute": "mail",
         "identifier": "userName"
       }
+    },
+    {
+      "_id": "e774775d-5bda-4cea-b6f9-91365b89775d",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "19a9ba97-3eaf-46ed-9b59-ea9315d81407",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
     }
   ],
   "tree": {
@@ -207,8 +223,8 @@
     "entryNodeId": "c23cf0f2-e3fa-4838-a45b-2f7f11cb4eb6",
     "nodes": {
       "02d95fe8-1c39-4144-b411-13fcd4226c6a": {
-        "x": 2309,
-        "y": 189,
+        "x": 2629,
+        "y": 191,
         "connections": {
           "CREATED": "bb74cb44-5e3f-4634-9e5f-f18e121ca93f",
           "FAILURE": "4f6d3517-2bbe-4f86-b80f-27443a04fa61"
@@ -221,7 +237,7 @@
         "y": 182,
         "connections": {
           "false": "4f6d3517-2bbe-4f86-b80f-27443a04fa61",
-          "true": "ac4e4e6e-0b76-44d6-af80-a97fb83b70e4"
+          "true": "e774775d-5bda-4cea-b6f9-91365b89775d"
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Load Password for patch"
@@ -273,8 +289,8 @@
         "displayName": "Callback Existing User"
       },
       "ac4e4e6e-0b76-44d6-af80-a97fb83b70e4": {
-        "x": 1815,
-        "y": 185.015625,
+        "x": 2135,
+        "y": 187.015625,
         "connections": {
           "outcome": "fd31a8fa-31c2-45b9-bddb-648f5d997686"
         },
@@ -282,8 +298,8 @@
         "displayName": "Consent"
       },
       "bb74cb44-5e3f-4634-9e5f-f18e121ca93f": {
-        "x": 2546,
-        "y": 190,
+        "x": 2866,
+        "y": 192,
         "connections": {
           "false": "4f6d3517-2bbe-4f86-b80f-27443a04fa61",
           "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
@@ -323,14 +339,23 @@
         "displayName": "Pwd Collector"
       },
       "fd31a8fa-31c2-45b9-bddb-648f5d997686": {
-        "x": 2051.828125,
-        "y": 186.015625,
+        "x": 2371.828125,
+        "y": 188.015625,
         "connections": {
           "false": "02d95fe8-1c39-4144-b411-13fcd4226c6a",
           "true": "9d7a87df-d656-4539-b1e4-7199950aa0e8"
         },
         "nodeType": "IdentifyExistingUserNode",
         "displayName": "Identify Existing User"
+      },
+      "e774775d-5bda-4cea-b6f9-91365b89775d": {
+        "x": 1859,
+        "y": 216.015625,
+        "connections": {
+          "true": "ac4e4e6e-0b76-44d6-af80-a97fb83b70e4"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Store pwd in session"
       }
     },
     "staticNodes": {
@@ -339,8 +364,8 @@
         "y": 180
       },
       "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 2836,
-        "y": 222
+        "x": 3156,
+        "y": 224
       },
       "e301438c-0bd0-429c-ab0c-66126501069a": {
         "x": 2510,

--- a/config/auth-trees/ch-update-password.json
+++ b/config/auth-trees/ch-update-password.json
@@ -181,6 +181,22 @@
           "*"
         ]
       }
+    },
+    {
+      "_id": "1de5bf0d-8d1b-4136-a137-e8e791076283",
+      "nodeType": "ScriptedDecisionNode",
+      "details": {
+        "script": "19a9ba97-3eaf-46ed-9b59-ea9315d81407",
+        "outcomes": [
+          "true"
+        ],
+        "outputs": [
+          "*"
+        ],
+        "inputs": [
+          "*"
+        ]
+      }
     }
   ],
   "tree": {
@@ -190,8 +206,8 @@
     "entryNodeId": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
     "nodes": {
       "0c2e7c10-63fb-4e25-8218-68e742672fd1": {
-        "x": 1749,
-        "y": 81.015625,
+        "x": 2077,
+        "y": 223.015625,
         "connections": {
           "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
         },
@@ -223,7 +239,7 @@
         "y": 203.015625,
         "connections": {
           "FAILURE": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
-          "PATCHED": "0c2e7c10-63fb-4e25-8218-68e742672fd1"
+          "PATCHED": "1de5bf0d-8d1b-4136-a137-e8e791076283"
         },
         "nodeType": "PatchObjectNode",
         "displayName": "Patch Object"
@@ -309,6 +325,15 @@
         },
         "nodeType": "ScriptedDecisionNode",
         "displayName": "Check for Session"
+      },
+      "1de5bf0d-8d1b-4136-a137-e8e791076283": {
+        "x": 1812,
+        "y": 223.015625,
+        "connections": {
+          "true": "0c2e7c10-63fb-4e25-8218-68e742672fd1"
+        },
+        "nodeType": "ScriptedDecisionNode",
+        "displayName": "Store pwd in session"
       }
     },
     "staticNodes": {
@@ -317,8 +342,8 @@
         "y": 103
       },
       "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 1867,
-        "y": 257
+        "x": 2292,
+        "y": 216
       },
       "e301438c-0bd0-429c-ab0c-66126501069a": {
         "x": 1816,


### PR DESCRIPTION
# Description

* Set password in session after changing it to ensure that the session has the most up to date value

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [x] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [x] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
