### PR TITLE
Token mappings

### DIFF
--- a/config/am-scripts/scripts-content/oauth2-token-mod.groovy
+++ b/config/am-scripts/scripts-content/oauth2-token-mod.groovy
@@ -166,32 +166,9 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
         def map = [:]
         map['user_profile'] = 'read'
         return map
-    } else if (scope.equals('https://account.companieshouse.gov.uk/user.write-full') ||
-        scope.equals('https://identity.company-information.service.gov.uk/user.write-full')) {
-        if (isInternalApp) {
-            def map = [:]
-            map['user_applications'] = 'create,read,update,delete'
-            map['user_profile'] = 'delete,read,update'
-            map['user_following'] = 'read,update'
-            map['user_transactions'] = 'read'
-            map['user_request_auth_code'] = 'create'
-            map['user_orders'] = 'create,read,update,delete'
-            map['user_secure_applications'] = 'create,read,update,delete'
-            map['user_third_party_apps'] = 'read,delete'
-            return map
-        } else {
-            def map = [:]
-            map['error'] = 'Permission denied. External app requested forbidden scope: /user.write-full'
-            return map
-        }
-    } else if (scope.equals('https://api.companieshouse.gov.uk/company/registered-office-address.update') ||
-        scope.equals('https://api.company-information.service.gov.uk/company/registered-office-address.update')) {
-        def map = [:]
-        map['company_number'] = companyNumber
-        map['company_roa'] = 'update'
-        return map
     } else if (scope.equals('https://api.companieshouse.gov.uk/company') ||
-        scope.equals('http://api.companieshouse.gov.uk/company')) {
+            scope.equals('http://api.companieshouse.gov.uk/company') ||
+            scope.equals('http://api.companieshouse.gov.uk/company/' + companyNumber)) {
         if (legacyScopesAllowed) {
             // Grant permission here for legacy scopes - no new domain option for this one!
             if (isInternalApp) {
@@ -215,7 +192,7 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             return map
         }
     } else if (scope.equals('https://api.companieshouse.gov.uk/company/admin.write-full') ||
-        scope.equals('https://api.company-information.service.gov.uk/company/admin.write-full')) {
+            scope.equals('https://api.company-information.service.gov.uk/company/admin.write-full')) {
         if (isInternalApp) {
             def map = [:]
             map['company_accounts'] = 'update'
@@ -231,6 +208,471 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             map['error'] = 'Permission denied. External app requested scope: admin.write-full for company number: ' + companyNumber
             return map
         }
+    } else if (scope.equals('https://account.companieshouse.gov.uk/user.write-full') ||
+            scope.equals('https://identity.company-information.service.gov.uk/user.write-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_applications'] = 'create,read,update,delete'
+            map['user_profile'] = 'delete,read,update'
+            map['user_following'] = 'read,update'
+            map['user_transactions'] = 'read'
+            map['user_request_auth_code'] = 'create'
+            map['user_orders'] = 'create,read,update,delete'
+            map['user_secure_applications'] = 'create,read,update,delete'
+            map['user_third_party_apps'] = 'read,delete'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /user.write-full'
+            return map
+        }
+    } else if (scope.equals('http://identity.company-information.service.gov.uk/user/profile.update')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_profile'] = 'read,update'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /profile.update'
+            return map
+        }
+    } else if (scope.equals('http://identity.company-information.service.gov.uk/user/profile.delete')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_profile'] = 'read,delete'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /profile.delete'
+            return map
+        }
+    } else if (scope.equals('http://identity.company-information.service.gov.uk/user/profile.write-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_profile'] = 'read,update,delete'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /profile.write-full'
+            return map
+        }
+    } else if (scope.equals('https://find-and-update.company-information.service.gov.uk/following.read')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_following'] = 'read'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /following.read'
+            return map
+        }
+    } else if (scope.equals('https://find-and-update.company-information.service.gov.uk/following.update')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_following'] = 'read,update'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /following.update'
+            return map
+        }
+    } else if (scope.equals('https://find-and-update.company-information.service.gov.uk/transactions.read')) {
+        def map = [:]
+        map['user_transactions'] = 'read'
+        return map
+    } else if (scope.equals('https://find-and-update.company-information.service.gov.uk/orders.read')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_orders'] = 'create,read,update,delete'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /orders.read'
+            return map
+        }
+    } else if (scope.equals('https://identity.company-information.service.gov.uk/applications.create')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_applications'] = 'create'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /applications.create'
+            return map
+        }
+    } else if (scope.equals('https://identity.company-information.service.gov.uk/applications.read')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_applications'] = 'read'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /applications.read'
+            return map
+        }
+    } else if (scope.equals('https://identity.company-information.service.gov.uk/applications.update')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_applications'] = 'update'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /applications.update'
+            return map
+        }
+    } else if (scope.equals('https://identity.company-information.service.gov.uk/applications.delete')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_applications'] = 'delete'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /applications.delete'
+            return map
+        }
+    } else if (scope.equals('https://identity.company-information.service.gov.uk/applications.write-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_applications'] = 'create,read,update,delete'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /applications.write-full'
+            return map
+        }
+    } else if (scope.equals('https://identity.company-information.service.gov.uk/authentication-code.create')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_request_auth_code'] = 'create'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /authentication-code.create'
+            return map
+        }
+    } else if (scope.equals('https://account.companieshouse.gov.uk/user.write-full') ||
+            scope.equals('https://identity.company-information.service.gov.uk/user.write-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['user_applications'] = 'create,read,update,delete'
+            map['user_profile'] = 'create,read,update,delete'
+            map['user_following'] = 'create,read,update,delete'
+            map['user_transactions'] = 'read'
+            map['user_request_auth_code'] = 'create'
+            map['user_orders'] = 'create,read,update,delete'
+            map['user_secure_applications'] = 'create,read,update,delete'
+            map['user_third_party_apps'] = 'create,read,update,delete'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /user.write-full'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company.create')) {
+        def map = [:]
+        map['company_incorporation'] = 'create'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyType + '.create')) {
+        def map = [:]
+        map['company_incorporation'] = companyType + ':create'
+        return map
+    } else if (scope.equals('https://account.companieshouse.gov.uk/company/' + companyNumber + '/authentication-code.update')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_auth_code'] = 'update'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /authentication-code.update'
+            return map
+        }
+    } else if (scope.equals('https://account.companieshouse.gov.uk/company/' + companyNumber + '/authentication-code.delete')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_auth_code'] = 'delete'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /authentication-code.delete'
+            return map
+        }
+    } else if (scope.equals('https://account.companieshouse.gov.uk/company/' + companyNumber + '/authentication-code.write-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_auth_code'] = 'update,delete'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /authentication-code.write-full'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/transactions')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_transactions'] = 'read'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /transactions'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/registered-office-address.update')) {
+        def map = [:]
+        map['company_roa'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/charges.create')) {
+        def map = [:]
+        map['company_charges'] = 'create'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/charges.update')) {
+        def map = [:]
+        map['company_charges'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/charges.write-full')) {
+        def map = [:]
+        map['company_charges'] = 'create,update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/charges/' + chargeId + '.update')) {
+        def map = [:]
+        map['company_charges'] = chargeId + ':update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/*/charges.create')) {
+        def map = [:]
+        map['charges'] = 'create'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/*/charges.update')) {
+        def map = [:]
+        map['charges'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/*/charges.write-full')) {
+        def map = [:]
+        map['charges'] = 'create,update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/filing-history.update')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_filing_history'] = 'update'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /filing-history.update'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers.create')) {
+        def map = [:]
+        map['company_officers'] = 'create'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers.update')) {
+        def map = [:]
+        map['company_officers'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers.write-full')) {
+        def map = [:]
+        map['company_officers'] = 'create,update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers.read-protected')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_officers'] = 'read-protected'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /officers.read-protected'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers.read-secure')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_officers'] = 'read-secure'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /officers.read-secure'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers.read-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_officers'] = 'read-protected,read-secure'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /officers.read-full'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.update')) {
+        def map = [:]
+        map['company_officers'] = officerId + ':update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.read-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_officers'] = officerId + ':read-full'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /' + officerId + '.read-full'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/registers.update')) {
+        def map = [:]
+        map['company_registers'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/registers/' + registerType + '.update')) {
+        def map = [:]
+        map['company_registers'] = registerType + ':update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/foreign-company-details.update')) {
+        def map = [:]
+        map['company_foreign_company_details'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/branch-company-details.update')) {
+        def map = [:]
+        map['company_branch_company_details'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/company-name.update')) {
+        def map = [:]
+        map['company_name'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/company-type.update')) {
+        def map = [:]
+        map['company_type'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/share-capital.update')) {
+        def map = [:]
+        map['company_share_capital'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/confirmation-statement.update')) {
+        def map = [:]
+        map['company_confirmation_statement'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/accounts.update')) {
+        def map = [:]
+        map['company_accounts'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/constitution.update')) {
+        def map = [:]
+        map['company_constitution'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/secretarial.write-full')) {
+        def map = [:]
+        map['company_roa'] = 'update'
+        map['company_officers'] = 'create,update'
+        map['company_pscs'] = 'create,update'
+        map['company_psc_statements'] = 'create,update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/admin.write-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_number'] = companyNumber
+            map['company_transactions'] = 'read'
+            map['company_roa'] = 'update'
+            map['company_charges'] = 'create,update' //TODO
+            map['company_status'] = 'update'
+            map['company_auth_code'] = 'update' //TODO
+            map['company_filing_history'] = 'update'
+            map['company_officers'] = 'create' //TODO
+            map['company_registers'] = 'update' //TODO
+            map['company_foreign_company_details'] = 'update'
+            map['company_branch_company_details'] = 'update'
+            map['company_name'] = 'update'
+            map['company_type'] = 'update'
+            map['company_share_capital'] = 'update'
+            map['company_confirmation_statement'] = 'update'
+            map['company_accounts'] = 'update'
+            map['company_constitution'] = 'update'
+            map['company_pscs'] = 'create' //TODO
+            map['company_psc_statements'] = 'create' //TODO
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /admin.write-full'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control.create')) {
+        def map = [:]
+        map['company_pscs'] = 'create'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control.update')) {
+        def map = [:]
+        map['company_pscs'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control.write-full')) {
+        def map = [:]
+        map['company_pscs'] = 'create,update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control.read-protected')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_pscs'] = 'read-protected'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /persons-with-significant-control.read-protected'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control.read-secure')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_pscs'] = 'read-secure'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /persons-with-significant-control.read-secure'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control.read-super-secure')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_pscs'] = 'read-super-secure'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /persons-with-significant-control.read-super-secure'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control.read-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_pscs'] = 'read-protected,read-secure,read-super-secure'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /persons-with-significant-control.read-full'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.update')) {
+        def map = [:]
+        map['company_pscs'] = pscId + ':update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.read-full')) {
+        if (isInternalApp) {
+            def map = [:]
+            map['company_pscs'] = pscId + ':read-full'
+            return map
+        } else {
+            def map = [:]
+            map['error'] = 'Permission denied. External app requested forbidden scope: /' + pscId + '.read-full'
+            return map
+        }
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control-statements.create')) {
+        def map = [:]
+        map['company_psc_statements'] = 'create'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control-statements.update')) {
+        def map = [:]
+        map['company_psc_statements'] = 'update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control-statements.write-full')) {
+        def map = [:]
+        map['company_psc_statements'] = 'create,update'
+        return map
+    } else if (scope.equals('https://api.companieshouse.gov.uk/company/registered-office-address.update') ||
+        scope.equals('https://api.company-information.service.gov.uk/company/registered-office-address.update')) {
+        def map = [:]
+        map['company_number'] = companyNumber
+        map['company_roa'] = 'update'
+        return map
     } else {
         def map = [:]
         map['error'] = 'No permissions found matching the scope: ' + scope + '. Please add a new scope to the token modification script'

--- a/config/am-scripts/scripts-content/oauth2-token-mod.groovy
+++ b/config/am-scripts/scripts-content/oauth2-token-mod.groovy
@@ -635,35 +635,31 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
         return map
     } else {
 
-        //do regex cases
-        var companyTypeRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\w+).create/
-        var officerIdRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/officers\/(\w+)\/(\d+).(\w+)/
-        var registerTypeRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/registers\/(\w+).update/
-        var pscIdRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/persons-with-significant-control\/(\w+)\/(\d+).(\w+)/
-        var chargeIdRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/charges\/(\d+).update/
+        //do dynamic value cases (having to use string manipulation and FR won't currently allow use of regex classes)
 
-        var matcher = scope =~ companyTypeRegex
-        if (matcher.size() > 0) {
-            var companyType = matcher[0][0]
-            logger.message('[CHSLOG] CompanyType = ' + companyType)
-            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyType + '.create')) {
-                def map = [:]
-                map['company_incorporation'] = companyType + ':create'
-                return map
-            }
+        // Scope = 'https://api.companieshouse.gov.uk/company/' + companyType + '.create'
+        if (scope.startsWith('https://api.companieshouse.gov.uk/company/') && scope.endsWith('.create')) {
+            var companySplitScope = scope.split('https://api.companieshouse.gov.uk/company/')
+            var companyType = companySplitScope[1].split('.create')
+            def map = [:]
+            logger.message('[CHSLOG] CompanyType = ' + companyType[0])
+            map['company_incorporation'] = companyType[0] + ':create'
+            return map
         }
 
-        matcher = scope =~ officerIdRegex
-        if (matcher.size() > 0) {
-            var officerType = matcher[1][0]
-            var officerId = matcher[2][0]
-
-            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.update')) {
+        if (scope.contains("/officers/")) {
+            var officersSplit = scope.split('/officers/')
+            if (officersSplit[1].endsWith('.update')) { // 'https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.update'
+                var officerIdSplit = officersSplit[1].split('/')
+                var officerId = officerIdSplit[1].split('.update')[0]
                 def map = [:]
                 map['company_officers'] = officerId + ':update'
                 return map
-            } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.read-full')) {
+            }
+            else if (officersSplit[1].endsWith('.read-full')) { // 'https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.read-full'
                 if (isInternalApp) {
+                    var officerIdSplit = officersSplit[1].split('/')
+                    var officerId = officerIdSplit[1].split('.read-full')[0]
                     def map = [:]
                     map['company_officers'] = officerId + ':read-full'
                     return map
@@ -675,28 +671,30 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             }
         }
 
-        matcher = scope =~ registerTypeRegex
-        if (matcher.size() > 0) {
-            var registerType = matcher[1][0]
+        if (scope.contains("/registers/") && scope.contains(".update")) { // 'https://api.companieshouse.gov.uk/company/' + companyNumber + '/registers/' + registerType + '.update'
+            var registersSplit = scope.split("/registers/")
+            var registerTypeSplit = registersSplit[1].split('.update')
+            var registerType = registerTypeSplit[0]
 
-            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/registers/' + registerType + '.update')) {
-                def map = [:]
-                map['company_registers'] = registerType + ':update'
-                return map
-            }
+            def map = [:]
+            map['company_registers'] = registerType + ':update'
+            return map
         }
 
-        matcher = scope =~ pscIdRegex
-        if (matcher.size() > 0) {
-            var pscType = matcher[1][0]
-            var pscId = matcher[2][0]
-
-            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.update')) {
+        if (scope.contains("/persons-with-significant-control/")) {
+            if (scope.contains(".update")) { // 'https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.update'
+                var significantControlSplit = scope.split("/persons-with-significant-control/")
+                var pscSlashSplit = significantControlSplit[1].split('/')
+                var pscId = pscSlashSplit[1].split('.update')[0]
                 def map = [:]
                 map['company_pscs'] = pscId + ':update'
                 return map
-            } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.read-full')) {
+            }
+            else if (scope.contains(".read-full")) { // 'https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.read-full'
                 if (isInternalApp) {
+                    var significantControlSplit = scope.split("/persons-with-significant-control/")
+                    var pscSlashSplit = significantControlSplit[1].split('/')
+                    var pscId = pscSlashSplit[1].split('.read-full')[0]
                     def map = [:]
                     map['company_pscs'] = pscId + ':read-full'
                     return map
@@ -708,15 +706,14 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             }
         }
 
-        matcher = scope =~ chargeIdRegex
-        if (matcher.size() > 0) {
-            var chargeId = matcher[1][0]
+        if (scope.contains("/charges/") && scope.contains(".update")) { // 'https://api.companieshouse.gov.uk/company/' + companyNumber + '/charges/' + chargeId + '.update'
+            var chargesSplit = scope.split("/charges/")
+            var chargeIdSplit = chargesSplit[1].split('.update')
+            var chargeId = chargeIdSplit[0]
 
-            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/charges/' + chargeId + '.update')) {
-                def map = [:]
-                map['company_charges'] = chargeId + ':update'
-                return map
-            }
+            def map = [:]
+            map['company_charges'] = chargeId + ':update'
+            return map
         }
 
         def map = [:]

--- a/config/am-scripts/scripts-content/oauth2-token-mod.groovy
+++ b/config/am-scripts/scripts-content/oauth2-token-mod.groovy
@@ -372,10 +372,6 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
         def map = [:]
         map['company_incorporation'] = 'create'
         return map
-    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyType + '.create')) {
-        def map = [:]
-        map['company_incorporation'] = companyType + ':create'
-        return map
     } else if (scope.equals('https://account.companieshouse.gov.uk/company/' + companyNumber + '/authentication-code.update')) {
         if (isInternalApp) {
             def map = [:]
@@ -500,27 +496,9 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             map['error'] = 'Permission denied. External app requested forbidden scope: /officers.read-full'
             return map
         }
-    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.update')) {
-        def map = [:]
-        map['company_officers'] = officerId + ':update'
-        return map
-    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.read-full')) {
-        if (isInternalApp) {
-            def map = [:]
-            map['company_officers'] = officerId + ':read-full'
-            return map
-        } else {
-            def map = [:]
-            map['error'] = 'Permission denied. External app requested forbidden scope: /' + officerId + '.read-full'
-            return map
-        }
     } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/registers.update')) {
         def map = [:]
         map['company_registers'] = 'update'
-        return map
-    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/registers/' + registerType + '.update')) {
-        def map = [:]
-        map['company_registers'] = registerType + ':update'
         return map
     } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/foreign-company-details.update')) {
         def map = [:]
@@ -641,20 +619,6 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             map['error'] = 'Permission denied. External app requested forbidden scope: /persons-with-significant-control.read-full'
             return map
         }
-    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.update')) {
-        def map = [:]
-        map['company_pscs'] = pscId + ':update'
-        return map
-    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.read-full')) {
-        if (isInternalApp) {
-            def map = [:]
-            map['company_pscs'] = pscId + ':read-full'
-            return map
-        } else {
-            def map = [:]
-            map['error'] = 'Permission denied. External app requested forbidden scope: /' + pscId + '.read-full'
-            return map
-        }
     } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control-statements.create')) {
         def map = [:]
         map['company_psc_statements'] = 'create'
@@ -674,6 +638,79 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
         map['company_roa'] = 'update'
         return map
     } else {
+
+        //do regex cases
+        var companyTypeRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\w+).create/
+        var officerIdRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/officers\/(\w+)\/(\d+).(\w+)/
+        var registerTypeRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/registers\/(\w+).update/
+        var pscIdRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/persons-with-significant-control\/(\w+)\/(\d+).(\w+)/
+
+        var matcher = scope =~ companyTypeRegex
+        if (matcher.size() > 0) {
+            var companyType = matcher[0][0]
+            logger.message('[CHSLOG] CompanyType = ' + companyType)
+            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyType + '.create')) {
+                def map = [:]
+                map['company_incorporation'] = companyType + ':create'
+                return map
+            }
+        }
+
+        matcher = scope =~ officerIdRegex
+        if (matcher.size() > 0) {
+            var officerType = matcher[1][0]
+            var officerId = matcher[2][0]
+
+            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.update')) {
+                def map = [:]
+                map['company_officers'] = officerId + ':update'
+                return map
+            } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/officers/' + officerType + '/' + officerId + '.read-full')) {
+                if (isInternalApp) {
+                    def map = [:]
+                    map['company_officers'] = officerId + ':read-full'
+                    return map
+                } else {
+                    def map = [:]
+                    map['error'] = 'Permission denied. External app requested forbidden scope: /' + officerId + '.read-full'
+                    return map
+                }
+            }
+        }
+
+        matcher = scope =~ registerTypeRegex
+        if (matcher.size() > 0) {
+            var registerType = matcher[1][0]
+
+            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/registers/' + registerType + '.update')) {
+                def map = [:]
+                map['company_registers'] = registerType + ':update'
+                return map
+            }
+        }
+
+        matcher = scope =~ pscIdRegex
+        if (matcher.size() > 0) {
+            var pscType = matcher[1][0]
+            var pscId = matcher[2][0]
+
+            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.update')) {
+                def map = [:]
+                map['company_pscs'] = pscId + ':update'
+                return map
+            } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/persons-with-significant-control/' + pscType + '/' + pscId + '.read-full')) {
+                if (isInternalApp) {
+                    def map = [:]
+                    map['company_pscs'] = pscId + ':read-full'
+                    return map
+                } else {
+                    def map = [:]
+                    map['error'] = 'Permission denied. External app requested forbidden scope: /' + pscId + '.read-full'
+                    return map
+                }
+            }
+        }
+
         def map = [:]
         map['error'] = 'No permissions found matching the scope: ' + scope + '. Please add a new scope to the token modification script'
         return map

--- a/config/am-scripts/scripts-content/oauth2-token-mod.groovy
+++ b/config/am-scripts/scripts-content/oauth2-token-mod.groovy
@@ -41,14 +41,14 @@ if (claims == null) {
     def claimsObject = new JsonSlurper().parseText(claims)
     if (claimsObject == null) {
         logger.error('[CHSLOG] Could not decode claims to object')
-  } else if (claimsObject.userInfo == null) {
+    } else if (claimsObject.userinfo == null) {
         logger.error('[CHSLOG] No userInfo in claims')
-  } else if (claimsObject.userInfo.company == null) {
+    } else if (claimsObject.userinfo.company == null) {
         logger.error('[CHSLOG] No company in claims')
-  } else if (claimsObject.userInfo.company.value == null) {
+    } else if (claimsObject.userinfo.company.value == null) {
         logger.error('[CHSLOG] No company value in claims')
-  } else {
-        def company = claimsObject.userInfo.company.value
+    } else {
+        def company = claimsObject.userinfo.company.value
         logger.error('[CHSLOG] Got company ' + company)
         accessToken.setField('company', company)
 
@@ -71,8 +71,8 @@ if (claims == null) {
         // TODO Pass values in request
 
         // var scopes = ""
-        var scopes = "https://account.companieshouse.gov.uk/user/profile.read"
-        // var scopes = "https://identity.company-information.service.gov.uk/user/profile.read"
+        //var scopes = "https://account.companieshouse.gov.uk/user/profile.read"
+        var scopes = "https://identity.company-information.service.gov.uk/user/profile.read"
         // var scopes = "https://account.companieshouse.gov.uk/user.write-full"
         // var scopes = "https://identity.company-information.service.gov.uk/user.write-full"
         // var scopes = "https://api.companieshouse.gov.uk/company/registered-office-address.update"

--- a/config/am-scripts/scripts-content/oauth2-token-mod.groovy
+++ b/config/am-scripts/scripts-content/oauth2-token-mod.groovy
@@ -217,7 +217,7 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             map['user_following'] = 'read,update'
             map['user_transactions'] = 'read'
             map['user_request_auth_code'] = 'create'
-            map['user_orders'] = 'create,read,update,delete'
+            map['user_orders'] = 'read'
             map['user_secure_applications'] = 'create,read,update,delete'
             map['user_third_party_apps'] = 'read,delete'
             return map
@@ -283,7 +283,7 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
     } else if (scope.equals('https://find-and-update.company-information.service.gov.uk/orders.read')) {
         if (isInternalApp) {
             def map = [:]
-            map['user_orders'] = 'create,read,update,delete'
+            map['user_orders'] = 'read'
             return map
         } else {
             def map = [:]
@@ -356,10 +356,10 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             def map = [:]
             map['user_applications'] = 'create,read,update,delete'
             map['user_profile'] = 'create,read,update,delete'
-            map['user_following'] = 'create,read,update,delete'
+            map['user_following'] = 'read,update'
             map['user_transactions'] = 'read'
             map['user_request_auth_code'] = 'create'
-            map['user_orders'] = 'create,read,update,delete'
+            map['user_orders'] = 'read'
             map['user_secure_applications'] = 'create,read,update,delete'
             map['user_third_party_apps'] = 'create,read,update,delete'
             return map
@@ -541,12 +541,12 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             map['company_number'] = companyNumber
             map['company_transactions'] = 'read'
             map['company_roa'] = 'update'
-            map['company_charges'] = 'create,update' //TODO
+            map['company_charges'] = 'create,update'
             map['company_status'] = 'update'
-            map['company_auth_code'] = 'update' //TODO
+            map['company_auth_code'] = 'update,delete'
             map['company_filing_history'] = 'update'
-            map['company_officers'] = 'create' //TODO
-            map['company_registers'] = 'update' //TODO
+            map['company_officers'] = 'create,update,read-protected,read-secure'
+            map['company_registers'] = 'update'
             map['company_foreign_company_details'] = 'update'
             map['company_branch_company_details'] = 'update'
             map['company_name'] = 'update'
@@ -555,8 +555,8 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
             map['company_confirmation_statement'] = 'update'
             map['company_accounts'] = 'update'
             map['company_constitution'] = 'update'
-            map['company_pscs'] = 'create' //TODO
-            map['company_psc_statements'] = 'create' //TODO
+            map['company_pscs'] = 'create,update,read-protected,read-secure,read-super-secure'
+            map['company_psc_statements'] = 'create,update'
             return map
         } else {
             def map = [:]

--- a/config/am-scripts/scripts-content/oauth2-token-mod.groovy
+++ b/config/am-scripts/scripts-content/oauth2-token-mod.groovy
@@ -428,10 +428,6 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
         def map = [:]
         map['company_charges'] = 'create,update'
         return map
-    } else if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/charges/' + chargeId + '.update')) {
-        def map = [:]
-        map['company_charges'] = chargeId + ':update'
-        return map
     } else if (scope.equals('https://api.companieshouse.gov.uk/company/*/charges.create')) {
         def map = [:]
         map['charges'] = 'create'
@@ -644,6 +640,7 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
         var officerIdRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/officers\/(\w+)\/(\d+).(\w+)/
         var registerTypeRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/registers\/(\w+).update/
         var pscIdRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/persons-with-significant-control\/(\w+)\/(\d+).(\w+)/
+        var chargeIdRegex = /^https:\/\/api.companieshouse.gov.uk\/company\/(\d+)\/charges\/(\d+).update/
 
         var matcher = scope =~ companyTypeRegex
         if (matcher.size() > 0) {
@@ -708,6 +705,17 @@ def scopeToPermissions(scope, permissionRecord, companyNumber, isInternalApp, le
                     map['error'] = 'Permission denied. External app requested forbidden scope: /' + pscId + '.read-full'
                     return map
                 }
+            }
+        }
+
+        matcher = scope =~ chargeIdRegex
+        if (matcher.size() > 0) {
+            var chargeId = matcher[1][0]
+
+            if (scope.equals('https://api.companieshouse.gov.uk/company/' + companyNumber + '/charges/' + chargeId + '.update')) {
+                def map = [:]
+                map['company_charges'] = chargeId + ':update'
+                return map
             }
         }
 


### PR DESCRIPTION
# Description

Added the mappings for all the scopes mentioned in [here](https://companieshouse.atlassian.net/wiki/spaces/Arch/pages/1334771713/API+Filing+Service+Designs+3rd+Parties+and+CH)
There were a few dynamic values that require a regex to be used in order to get the value out the scope and returned in the permissions.
It can probably be improved but as it's a PoC this can do for now without obfuscating some of the mapping logic.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
