### PR TITLE
Adding timeouts for MongoDB operations

### DIFF
--- a/config/connectors/definitions/mongodb-companies.json
+++ b/config/connectors/definitions/mongodb-companies.json
@@ -23,17 +23,17 @@
 	},
 	"operationTimeout": {
 		"CREATE": -1,
-		"UPDATE": -1,
+		"UPDATE": 15000,
 		"DELETE": -1,
 		"TEST": -1,
 		"SCRIPT_ON_CONNECTOR": -1,
 		"SCRIPT_ON_RESOURCE": -1,
-		"GET": -1,
+		"GET": 15000,
 		"RESOLVEUSERNAME": -1,
 		"AUTHENTICATE": -1,
-		"SEARCH": -1,
+		"SEARCH": 15000,
 		"VALIDATE": -1,
-		"SYNC": -1,
+		"SYNC": 15000,
 		"SCHEMA": -1
 	},
 	"configurationProperties": {


### PR DESCRIPTION
# Description

Adding 15 second timeouts to MongoDB connector operations instead of unlimited timeouts

**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [✅] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
