### PR TITLE
Setting sync failure retries for alphaUser to EWF users sync

### DIFF
--- a/config/connectors/mappings/alphaUser_webfilingUser.json
+++ b/config/connectors/mappings/alphaUser_webfilingUser.json
@@ -14,6 +14,10 @@
     "type": "text/javascript",
     "source": "// change via external file"
   },
+  "syncFailureHandler": {
+    "maxRetries": 5,
+    "postRetryAction": "logged-ignore"
+  },
   "properties": [
     {
       "target": "PARENT_USERNAME",


### PR DESCRIPTION
Setting number of sync failure retries to reduce the chance of the unique constraint violation which can occur if multiple syncs are in progress/perpetually failing.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
