### PR TITLE
Set initialSize & maxActive to esv values

### DIFF
--- a/config/connectors/definitions/webfiling-users.json
+++ b/config/connectors/definitions/webfiling-users.json
@@ -10,10 +10,10 @@
 	},
 	"poolConfigOption": {
 		"maxObjects": 2,
-		"maxIdle": 100,
+		"maxIdle": 2,
 		"maxWait": 150000,
 		"minEvictableIdleTimeMillis": 120000,
-		"minIdle": 10 
+		"minIdle": 2
 	},
 	"resultsHandlerConfig": {
 		"enableNormalizingResultsHandler": false,

--- a/config/connectors/definitions/webfiling-users.json
+++ b/config/connectors/definitions/webfiling-users.json
@@ -69,7 +69,7 @@
 		"defaultAutoCommit": null,
 		"testOnConnect": false,
 		"jdbcInterceptors": null,
-		"initialSize": "10",
+		"initialSize": "&{esv.2099bcaeaf.configurationpropertiesinitialsize}",
 		"defaultTransactionIsolation": -1,
 		"numTestsPerEvictionRun": 0,
 		"url": "jdbc:oracle:thin:@//ewfdb.development.heritage.aws.internal:1521/EWF",
@@ -81,7 +81,7 @@
 		"timeBetweenEvictionRunsMillis": "5000",
 		"testOnReturn": false,
 		"useLock": false,
-		"maxActive": "100",
+		"maxActive": "&{esv.2099bcaeaf.configurationpropertiesmaxactive}",
 		"username": "KERMITEWF",
 		"password": {
 			"$crypto": {


### PR DESCRIPTION
# Description

Updated `maxActive` and `initialSize` parameters to use ESV values
Reverted Pool config options previously updated

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
