### PR TITLE
IDAM 1596: Reconcilation for inactivating users

### DIFF
--- a/config/connectors/definitions/inactive-user.json
+++ b/config/connectors/definitions/inactive-user.json
@@ -38,7 +38,7 @@
   },
   "configurationProperties": {
     "spaceReplacementString": "_",
-    "csvFile": "/opt/app/testing",
+    "csvFile": "/opt/app/data/inactive.csv",
     "newlineString": "\n",
     "headerUid": "email",
     "quoteCharacter": "\"",

--- a/config/connectors/definitions/inactive-user.json
+++ b/config/connectors/definitions/inactive-user.json
@@ -1,0 +1,66 @@
+{
+  "_id": "provisioner.openicf/InactiveUser",
+  "connectorRef": {
+    "connectorHostRef": "chs-group",
+    "displayName": "CSV File Connector",
+    "bundleVersion": "1.5.20.9",
+    "systemType": "provisioner.openicf",
+    "bundleName": "org.forgerock.openicf.connectors.csvfile-connector",
+    "connectorName": "org.forgerock.openicf.csvfile.CSVFileConnector"
+  },
+  "poolConfigOption": {
+    "maxObjects": 10,
+    "maxIdle": 10,
+    "maxWait": 150000,
+    "minEvictableIdleTimeMillis": 120000,
+    "minIdle": 1
+  },
+  "resultsHandlerConfig": {
+    "enableNormalizingResultsHandler": false,
+    "enableFilteredResultsHandler": false,
+    "enableCaseInsensitiveFilter": false,
+    "enableAttributesToGetSearchResultsHandler": true
+  },
+  "operationTimeout": {
+    "CREATE": -1,
+    "UPDATE": -1,
+    "DELETE": -1,
+    "TEST": -1,
+    "SCRIPT_ON_CONNECTOR": -1,
+    "SCRIPT_ON_RESOURCE": -1,
+    "GET": -1,
+    "RESOLVEUSERNAME": -1,
+    "AUTHENTICATE": -1,
+    "SEARCH": -1,
+    "VALIDATE": -1,
+    "SYNC": -1,
+    "SCHEMA": -1
+  },
+  "configurationProperties": {
+    "spaceReplacementString": "_",
+    "csvFile": "/opt/app/testing",
+    "newlineString": "\n",
+    "headerUid": "email",
+    "quoteCharacter": "\"",
+    "escapeCharacter": "\\",
+    "fieldDelimiter": ",",
+    "syncFileRetentionCount": "3"
+  },
+  "enabled": true,
+  "objectTypes": {
+    "__ACCOUNT__": {
+      "$schema": "http://json-schema.org/draft-03/schema",
+      "type": "object",
+      "id": "email",
+      "nativeType": "__ACCOUNT__",
+      "properties": {
+        "email": {
+          "type": "string",
+          "nativeName": "email",
+          "nativeType": "string",
+          "required": false
+        }
+      }
+    }
+  }
+}

--- a/config/connectors/mappings/inactiveUser_alphaUser.json
+++ b/config/connectors/mappings/inactiveUser_alphaUser.json
@@ -1,0 +1,80 @@
+   {
+      "target": "managed/alpha_user",
+      "source": "system/InactiveUser/__ACCOUNT__",
+      "name": "inactiveUser_alphaUser",
+      "consentRequired": false,
+      "icon": null,
+      "displayName": "inactiveUser_alphaUser",
+      "properties": [
+        {
+          "target": "accountStatus",
+          "default": "inactive"
+        },
+        {
+          "target": "userName",
+          "source": "email"
+        }
+      ],
+      "policies": [
+        {
+          "action": "IGNORE",
+          "situation": "AMBIGUOUS"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "SOURCE_MISSING"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "MISSING"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "FOUND_ALREADY_LINKED"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "UNQUALIFIED"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "UNASSIGNED"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "LINK_ONLY"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "TARGET_IGNORED"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "SOURCE_IGNORED"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "ALL_GONE"
+        },
+        {
+          "action": "UPDATE",
+          "situation": "CONFIRMED"
+        },
+        {
+          "action": "UPDATE",
+          "situation": "FOUND"
+        },
+        {
+          "action": "IGNORE",
+          "situation": "ABSENT"
+        }
+      ],
+      "correlationQuery": [
+        {
+          "linkQualifier": "default",
+          "type": "text/javascript",
+          "globals": {},
+          "source": "var qry = { \"_queryFilter\" : \"userName eq \\\"\" + source.email + \"\\\"\" };\n\nqry"
+        }
+      ]
+   }


### PR DESCRIPTION
# Description

Added connector to read CSV of users that need to have their accountStatus set to inactive.

Added mapping which uses the connector mentioned above to run a recon process to deactivate the users.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [x] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
