### PR TITLE
added suggested maxMessageSize config

### DIFF
--- a/config/connectors/remote-servers.json
+++ b/config/connectors/remote-servers.json
@@ -1,6 +1,9 @@
 {
   "_id": "provisioner.openicf.connectorinfoprovider",
   "connectorsLocation": "connectors",
+  "ICFServlet": {
+    "maxMessageSize": 102400
+  },
   "remoteConnectorClients": [
     {
       "name": "chs-primary",


### PR DESCRIPTION
# Description

Due to issues seen recently with nightly syncs and Forgerock RCS connections to the users and companies databases, a ticket was raised with Forgerock for advise on the errors we were seeing in the RCS and IDM logs. 

In response, Forgerock have advised us to add this additional config for maxMessageSize to our FIDC config. 

>We can try the following to see if there is any difference, within the openicf connector there is max message size - so how much data it can transfer across, you would need to just set this value to    "maxMessageSize" : 102400

I am adding in this additional config in order to see if this resolves the issues we have been seeing with the RCS connections. 

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [x] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
