### PR TITLE
fix: persistent session vulnerability

### DIFF
--- a/config/am-scripts/scripts-content/ch-invalidate-user-sessions.js
+++ b/config/am-scripts/scripts-content/ch-invalidate-user-sessions.js
@@ -1,0 +1,260 @@
+var _scriptName = 'CH INVALIDATE USER SESSIONS';
+_log('EDMS-INVALIDATE: Starting');
+
+var fr = JavaImporter(
+  org.forgerock.openam.auth.node.api.Action,
+  org.forgerock.json.jose.builders.JwtBuilderFactory,
+  org.forgerock.json.jose.jwt.JwtClaimsSet,
+  org.forgerock.json.jose.jws.JwsAlgorithm,
+  org.forgerock.json.jose.jws.SignedJwt,
+  org.forgerock.json.jose.jws.handlers.SecretRSASigningHandler,
+  org.forgerock.json.jose.jwk.RsaJWK,
+  javax.crypto.spec.SecretKeySpec,
+  org.forgerock.secrets.SecretBuilder,
+  org.forgerock.secrets.keys.SigningKey,
+  java.time.temporal.ChronoUnit,
+  java.time.Clock,
+  java.util.UUID
+);
+
+var NodeOutcome = {
+  SUCCESS: 'true'
+};
+
+var nodeConfig = {
+    nodeName: _scriptName,
+    tenantFqdnEsv: "esv.tenant.env.fqdn",
+    accountIdEsv: "esv.service.account.id",
+    privateKeyEsv: "esv.service.account.privatekey",
+    accessTokenStateField: "amAccessToken",
+    maxAttempts: 3,
+    scope: "fr:am:*",
+    serviceAccountClientId: "service-account",
+    jwtValiditySeconds: 10,
+  };
+  
+  
+var nodeLogger = {
+  debug: function (message) {
+    logger.message("***" + nodeConfig.nodeName + " " + message);
+  },
+  warning: function (message) {
+    logger.warning("***" + nodeConfig.nodeName + " " + message);
+  },
+  error: function (message) {
+    logger.error("***" + nodeConfig.nodeName + " " + message);
+  },
+};
+
+
+function getKeyFromJwk(issuer, jwk) {
+  var privateKey = fr.RsaJWK.parse(jwk).toRSAPrivateKey();
+
+  var secretBuilder = new fr.SecretBuilder();
+
+  secretBuilder
+    .secretKey(privateKey)
+    .stableId(issuer)
+    .expiresIn(
+    5,
+    fr.ChronoUnit.MINUTES,
+    fr.Clock.systemUTC()
+  );
+  return new fr.SigningKey(secretBuilder);
+}
+
+function getAssertionJwt(accountId, privateKey, audience, validity) {
+  var signingHandler = new fr.SecretRSASigningHandler(
+    getKeyFromJwk(accountId, privateKey)
+  );
+
+  var iat = new Date().getTime();
+  var exp = new Date(iat + validity * 1000);
+
+  var jwtClaims = new fr.JwtClaimsSet();
+
+  jwtClaims.setIssuer(accountId);
+  jwtClaims.setSubject(accountId);
+  jwtClaims.addAudience(audience);
+  jwtClaims.setExpirationTime(exp);
+  jwtClaims.setJwtId(fr.UUID.randomUUID());
+
+  var jwt = new fr.JwtBuilderFactory()
+  .jws(signingHandler)
+  .headers()
+  .alg(fr.JwsAlgorithm.RS256)
+  .done()
+  .claims(jwtClaims)
+  .build();
+
+  return jwt;
+}
+
+function getAccessToken(accountId, privateKey, tenantFqdn, maxAttempts) {
+  var response = null;
+  var accessToken = null;
+  var tokenEndpoint = "https://"
+  .concat(tenantFqdn)
+  .concat("/am/oauth2/access_token");
+
+  nodeLogger.debug("Getting Access Token from endpoint " + tokenEndpoint);
+
+  var assertionJwt = getAssertionJwt(
+    accountId,
+    privateKey,
+    tokenEndpoint,
+    nodeConfig.jwtValiditySeconds
+  );
+
+  if (!assertionJwt) {
+    nodeLogger.error("Error getting assertion JWT");
+    return null;
+  }
+
+  nodeLogger.debug("Got assertion JWT " + assertionJwt);
+
+  for (var attempt = 0; attempt < maxAttempts; attempt++) {
+    nodeLogger.debug("Attempt " + (attempt + 1) + " of " + maxAttempts);
+    try {
+      var request = new org.forgerock.http.protocol.Request();
+      request.setUri(tokenEndpoint);
+      request.setMethod("POST");
+      request
+        .getHeaders()
+        .add("Content-Type", "application/x-www-form-urlencoded");
+
+      var params = "grant_type="
+      .concat(
+        encodeURIComponent("urn:ietf:params:oauth:grant-type:jwt-bearer")
+      )
+      .concat("&client_id=")
+      .concat(encodeURIComponent(nodeConfig.serviceAccountClientId))
+      .concat("&assertion=")
+      .concat(encodeURIComponent(assertionJwt))
+      .concat("&scope=")
+      .concat(encodeURIComponent(nodeConfig.scope));
+
+      request.setEntity(params);
+      response = httpClient.send(request).get();
+      if (response) {
+        break;
+      }
+    } catch (e) {
+      nodeLogger.error(
+        "Failure calling access token endpoint: " +
+        tokenEndpoint +
+        " exception:" +
+        e
+      );
+    }
+  }
+
+  if (!response) {
+    nodeLogger.error("Bad response");
+    return null;
+  }
+
+  if (response.getStatus().getCode() !== 200) {
+    nodeLogger.error(
+      "Unable to acquire Access Token. HTTP Result: " + response.getStatus()
+    );
+    return null;
+  }
+
+  try {
+    var responseJson = response.getEntity().getString();
+    nodeLogger.debug("Response content " + responseJson);
+    var oauth2response = JSON.parse(responseJson);
+    accessToken = oauth2response.access_token;
+    nodeLogger.debug("Access Token acquired: " + accessToken);
+    return accessToken;
+  } catch (e) {
+    nodeLogger.error("Error getting access token from response: " + e);
+  }
+
+  return null;
+}
+
+(function () {
+  try {
+    nodeLogger.debug("Node starting");
+
+    var accessToken = transientState.get(nodeConfig.accessTokenStateField);
+
+    if (accessToken) {
+      nodeLogger.debug("Access token already present: continuing");
+      return;
+    }
+
+    var tenantFqdn = systemEnv.getProperty(nodeConfig.tenantFqdnEsv);
+    if (!tenantFqdn) {
+      nodeLogger.error("Couldn't get FQDN from esv " + nodeConfig.tenantFqdnEsv);
+      return;
+    }
+
+    var accountId = systemEnv.getProperty(nodeConfig.accountIdEsv);
+    if (!accountId) {
+      nodeLogger.error(
+        "Couldn't get service account id from esv " + nodeConfig.accountIdEsv
+      );
+      return;
+    }
+
+    var privateKey = systemEnv.getProperty(nodeConfig.privateKeyEsv);
+    if (!privateKey) {
+      nodeLogger.error(
+        "Couldn't get private key from esv " + nodeConfig.privateKey
+      );
+      return;
+    }
+
+    accessToken = getAccessToken(
+      accountId,
+      privateKey,
+      tenantFqdn,
+      nodeConfig.maxAttempts
+    );
+
+    if (!accessToken) {
+      nodeLogger.error("Failed to get access token");
+      return;
+    }
+
+    nodeLogger.debug("Success - adding token to transient state");
+    transientState.put(nodeConfig.accessTokenStateField, accessToken);
+  } catch (e) {
+    nodeLogger.error("Exception encountered " + e);
+    return;
+  }
+})();
+  
+  
+  // STARTING INVALIDATE SESSIONS REQUEST
+ var userName = sharedState.get("userName")
+ _log(`EDMS-USERNAME: Get userName - ${userName}`)
+ var testFqdn = systemEnv.getProperty(nodeConfig.tenantFqdnEsv)
+ var at = transientState.get(nodeConfig.accessTokenStateField)
+ _log(`EDMS-TESTING: ${userName}`)
+ _log(`EDMS-TESTING-TOKEN: ${at}`)
+_log(`EDMS-TESTING-FQDN: ${testFqdn}`)
+
+_log(`EDMS-REQUEST: Starting API request`)
+ var request = new org.forgerock.http.protocol.Request();
+_log(`EDMS-REQUEST: Setting request method`)
+ request.setMethod('POST')
+_log(`Setting request URL with ${testFqdn}`)
+ request.setUri(`https://${testFqdn}/am/json/realms/root/realms/alpha/sessions/?_action=logoutByUser`);
+ request.getHeaders().add('Authorization', 'Bearer ' + at);
+ request.getHeaders().add('Content-Type', 'application/json');
+ request.getHeaders().add('Accept-API-Version', 'resource=5.1, protocol=1.0');
+ request.setEntity(JSON.stringify({"username": userName}));
+
+_log(`EDMS-REQUEST: Making HTTP Request`)
+ var response = httpClient.send(request).get();
+_log(`EDMS-SESSION-RESPONSE: ${response.getStatus().getCode()}`)
+
+action = fr.Action.goTo(NodeOutcome.SUCCESS).build();
+
+
+// LIBRARY START
+// LIBRARY END

--- a/config/auth-trees/ch-update-password.json
+++ b/config/auth-trees/ch-update-password.json
@@ -205,151 +205,151 @@
     "uiConfig": {},
     "entryNodeId": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
     "nodes": {
-      "0c2e7c10-63fb-4e25-8218-68e742672fd1": {
-        "x": 2077,
-        "y": 223.015625,
-        "connections": {
-          "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Confirmation"
+      "0f48ac34-1750-4289-9d60-0a1381bfb9a2": {
+          "connections": {
+              "true": "70e691a5-1e33-4ac3-a356-e7b6d60d92e0"
+          },
+          "displayName": "Invalidate user's sessions",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 2034,
+          "y": 223.015625
       },
       "1495201c-23da-46b1-8537-73d508cf8358": {
-        "x": 1451,
-        "y": 88.015625,
-        "connections": {
-          "true": "5dbba61f-e063-4264-bc63-1e71927419b1"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Load New Pwd for Patch"
-      },
-      "23448f95-703e-4605-b7f5-1ff78fa8def2": {
-        "x": 1210,
-        "y": 45,
-        "connections": {
-          "error": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-          "fail": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
-          "pass": "ad3af2c3-f67d-4d7a-b954-698a764c4791"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Check Pwd Policy"
-      },
-      "5dbba61f-e063-4264-bc63-1e71927419b1": {
-        "x": 1558,
-        "y": 203.015625,
-        "connections": {
-          "FAILURE": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
-          "PATCHED": "1de5bf0d-8d1b-4136-a137-e8e791076283"
-        },
-        "nodeType": "PatchObjectNode",
-        "displayName": "Patch Object"
-      },
-      "72c2688d-910a-4fd3-b094-25803bc9626a": {
-        "x": 406,
-        "y": 148.015625,
-        "connections": {
-          "outcome": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
-        },
-        "nodeType": "SessionDataNode",
-        "displayName": "Get Session Data"
-      },
-      "81f81b53-416f-465a-8ca3-ecbc3216162d": {
-        "x": 1653,
-        "y": 369.015625,
-        "connections": {
-          "true": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Pwd Error Message"
-      },
-      "99568072-5a13-48ec-8d07-c06a8c82b425": {
-        "x": 965,
-        "y": 231.015625,
-        "connections": {
-          "error": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
-          "success": "23448f95-703e-4605-b7f5-1ff78fa8def2"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Get IDM Access Token"
-      },
-      "a1293502-4cf4-435e-888c-47a5dd5ed62f": {
-        "x": 1542,
-        "y": 787.015625,
-        "connections": {},
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "General Error"
-      },
-      "ad3af2c3-f67d-4d7a-b954-698a764c4791": {
-        "x": 1339,
-        "y": 218.015625,
-        "connections": {
-          "false": "c036600d-18b5-4186-a122-227bea684ba8",
-          "true": "1495201c-23da-46b1-8537-73d508cf8358"
-        },
-        "nodeType": "DataStoreDecisionNode",
-        "displayName": "Data Store Decision"
-      },
-      "b2e1eb3f-6276-4437-b52d-606a9c05fa59": {
-        "x": 1618,
-        "y": 566.015625,
-        "connections": {},
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "max attempts message"
-      },
-      "c036600d-18b5-4186-a122-227bea684ba8": {
-        "x": 1399,
-        "y": 384.015625,
-        "connections": {
-          "Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59",
-          "Retry": "81f81b53-416f-465a-8ca3-ecbc3216162d"
-        },
-        "nodeType": "RetryLimitDecisionNode",
-        "displayName": "Retry Limit Decision"
-      },
-      "c0ddbe48-e4f5-48a9-8879-79762611c5e4": {
-        "x": 673,
-        "y": 129.015625,
-        "connections": {
-          "mismatch": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
-          "success": "99568072-5a13-48ec-8d07-c06a8c82b425"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Change Password Collector"
-      },
-      "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3": {
-        "x": 166,
-        "y": 254.015625,
-        "connections": {
-          "hasSession": "72c2688d-910a-4fd3-b094-25803bc9626a",
-          "noSession": "a1293502-4cf4-435e-888c-47a5dd5ed62f"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Check for Session"
+          "connections": {
+              "true": "5dbba61f-e063-4264-bc63-1e71927419b1"
+          },
+          "displayName": "Load New Pwd for Patch",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 1451,
+          "y": 88.015625
       },
       "1de5bf0d-8d1b-4136-a137-e8e791076283": {
-        "x": 1812,
-        "y": 223.015625,
-        "connections": {
-          "true": "0c2e7c10-63fb-4e25-8218-68e742672fd1"
-        },
-        "nodeType": "ScriptedDecisionNode",
-        "displayName": "Store pwd in session"
-      }
-    },
-    "staticNodes": {
-      "startNode": {
-        "x": 62,
-        "y": 103
+          "connections": {
+              "true": "0f48ac34-1750-4289-9d60-0a1381bfb9a2"
+          },
+          "displayName": "Store pwd in session",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 1812,
+          "y": 223.015625
       },
+      "23448f95-703e-4605-b7f5-1ff78fa8def2": {
+          "connections": {
+              "error": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+              "fail": "c0ddbe48-e4f5-48a9-8879-79762611c5e4",
+              "pass": "ad3af2c3-f67d-4d7a-b954-698a764c4791"
+          },
+          "displayName": "Check Pwd Policy",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 1210,
+          "y": 45
+      },
+      "5dbba61f-e063-4264-bc63-1e71927419b1": {
+          "connections": {
+              "FAILURE": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
+              "PATCHED": "1de5bf0d-8d1b-4136-a137-e8e791076283"
+          },
+          "displayName": "Patch Object",
+          "nodeType": "PatchObjectNode",
+          "x": 1558,
+          "y": 203.015625
+      },
+      "72c2688d-910a-4fd3-b094-25803bc9626a": {
+          "connections": {
+              "outcome": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
+          },
+          "displayName": "Get Session Data",
+          "nodeType": "SessionDataNode",
+          "x": 406,
+          "y": 148.015625
+      },
+      "81f81b53-416f-465a-8ca3-ecbc3216162d": {
+          "connections": {
+              "true": "c0ddbe48-e4f5-48a9-8879-79762611c5e4"
+          },
+          "displayName": "Pwd Error Message",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 1653,
+          "y": 369.015625
+      },
+      "99568072-5a13-48ec-8d07-c06a8c82b425": {
+          "connections": {
+              "error": "a1293502-4cf4-435e-888c-47a5dd5ed62f",
+              "success": "23448f95-703e-4605-b7f5-1ff78fa8def2"
+          },
+          "displayName": "Get IDM Access Token",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 965,
+          "y": 231.015625
+      },
+      "a1293502-4cf4-435e-888c-47a5dd5ed62f": {
+          "connections": {},
+          "displayName": "General Error",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 1542,
+          "y": 787.015625
+      },
+      "ad3af2c3-f67d-4d7a-b954-698a764c4791": {
+          "connections": {
+              "false": "c036600d-18b5-4186-a122-227bea684ba8",
+              "true": "1495201c-23da-46b1-8537-73d508cf8358"
+          },
+          "displayName": "Data Store Decision",
+          "nodeType": "DataStoreDecisionNode",
+          "x": 1339,
+          "y": 218.015625
+      },
+      "b2e1eb3f-6276-4437-b52d-606a9c05fa59": {
+          "connections": {},
+          "displayName": "max attempts message",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 1618,
+          "y": 566.015625
+      },
+      "c036600d-18b5-4186-a122-227bea684ba8": {
+          "connections": {
+              "Reject": "b2e1eb3f-6276-4437-b52d-606a9c05fa59",
+              "Retry": "81f81b53-416f-465a-8ca3-ecbc3216162d"
+          },
+          "displayName": "Retry Limit Decision",
+          "nodeType": "RetryLimitDecisionNode",
+          "x": 1399,
+          "y": 384.015625
+      },
+      "c0ddbe48-e4f5-48a9-8879-79762611c5e4": {
+          "connections": {
+              "mismatch": "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3",
+              "success": "99568072-5a13-48ec-8d07-c06a8c82b425"
+          },
+          "displayName": "Change Password Collector",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 673,
+          "y": 129.015625
+      },
+      "c7f4ff0d-b3ed-445a-8735-ef3f93eab7e3": {
+          "connections": {
+              "hasSession": "72c2688d-910a-4fd3-b094-25803bc9626a",
+              "noSession": "a1293502-4cf4-435e-888c-47a5dd5ed62f"
+          },
+          "displayName": "Check for Session",
+          "nodeType": "ScriptedDecisionNode",
+          "x": 166,
+          "y": 254.015625
+      }
+  },
+  "description": "Update password using active session",
+  "staticNodes": {
       "70e691a5-1e33-4ac3-a356-e7b6d60d92e0": {
-        "x": 2292,
-        "y": 216
+          "x": 2292,
+          "y": 216
       },
       "e301438c-0bd0-429c-ab0c-66126501069a": {
-        "x": 1816,
-        "y": 755
+          "x": 1816,
+          "y": 755
+      },
+      "startNode": {
+          "x": 62,
+          "y": 103
       }
-    },
-    "description": "Update password using active session"
+  },
   }
 }

--- a/config/variables-secrets/secrets.json
+++ b/config/variables-secrets/secrets.json
@@ -103,5 +103,19 @@
     "encoding": "generic",
     "useInPlaceholders": true,
     "valueBase64": "%ESV_CBD3EB4482_GENERATEHASHAPIKEY%"
+  },
+  {
+    "_id": "esv-service-account-id",
+    "description": "am-access service account id",
+    "encoding": "generic",
+    "useInPlaceholders": true,
+    "valueBase64": "%ESV_SERVICE_ACCOUNT_ID%"
+  },
+  {
+    "_id": "esv-service-account-privatekey",
+    "description": "am-access service account private key",
+    "encoding": "generic",
+    "useInPlaceholders": true,
+    "valueBase64": "%ESV_SERVICE_ACCOUNT_PRIVATEKEY%"
   }
 ]

--- a/config/variables-secrets/variables.json
+++ b/config/variables-secrets/variables.json
@@ -263,5 +263,10 @@
     "_id": "esv-scrs-script-repeatinterval",
     "description": "Frequency of execution of SCRS script",
     "valueBase64": "%ESV_SCRS_SCRIPT_REPEATINTERVAL%"
+  },
+  {
+    "_id": "esv-tenant-env-fqdn",
+    "description": "This is the dev environment fqdn",
+    "valueBase64": "%ESV_TENANT_ENV_FQDN%"
   }
 ]


### PR DESCRIPTION
# Description

Script added to invalidate user sessions. ESVs added for script to use service account. Auth-tree modified to incorporate the new node that uses the script and create the necessary connections to the surrounding nodes. A node was removed. 

**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [x] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [x] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [x] variables
