### PR TITLE
fix: bug fix for FIDC upgrade

### DIFF
--- a/config/idm-endpoints/scripts-config.json
+++ b/config/idm-endpoints/scripts-config.json
@@ -23,7 +23,7 @@
       "repeatInterval": {
         "$int": "&{esv.removeexpiredonboardedusers.repeatinterval|1800000}"
       },
-      "queryFilter": "((/frIndexedDate2 lt \"${Time.now - 7d}Z\"))",
+      "queryFilter": "((/frIndexedDate2 lte \"${Time.now - 8d}Z\"))",
       "scriptFileName": "removeExpiredOnboardedUsers.js"
     },
     {
@@ -31,7 +31,7 @@
       "repeatInterval": {
         "$int": "&{esv.removeexpiredinvitations.repeatinterval|1800000}"
       },
-      "queryFilter": "((/frIndexedMultivalued1 lt \"${Time.now - 7d}Z\"))",
+      "queryFilter": "((/frIndexedMultivalued1 lte \"${Time.now - 8d}Z\"))",
       "scriptFileName": "removeExpiredInvitations.js"
     }
   ],


### PR DESCRIPTION
# Description

Remember to run 'standard' if 'helpers, scripts, tests or index.js' has changed.

Please include a summary of the change.
This is a bug fix suggested to resolve an issue with the FIDC scripts preventing an upgrade on the Forgerock backend.  This involved amended the lt operator to the lte one and amending the days to accomodate this change.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [X] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
