### PR TITLE
fix: remove service acc private key secret

### DIFF
--- a/config/variables-secrets/secrets.json
+++ b/config/variables-secrets/secrets.json
@@ -110,12 +110,5 @@
     "encoding": "generic",
     "useInPlaceholders": true,
     "valueBase64": "%ESV_SERVICE_ACCOUNT_ID%"
-  },
-  {
-    "_id": "esv-service-account-privatekey",
-    "description": "am-access service account private key",
-    "encoding": "generic",
-    "useInPlaceholders": true,
-    "valueBase64": "%ESV_SERVICE_ACCOUNT_PRIVATEKEY%"
   }
 ]


### PR DESCRIPTION
# Description
Large secrets, as the ones required by FIDC service account private keys, are not updating successfully on FIDC when they are released via the pipeline.

Here, I have

For this reason, and until ForgeRock solve this problem, we will need to update the esv-service-account-privatekey manually.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [x] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
