### PR TITLE
fix: replace lt operator for lte

### DIFF
--- a/config/idm-endpoints/scripts-config.json
+++ b/config/idm-endpoints/scripts-config.json
@@ -23,7 +23,7 @@
       "repeatInterval": {
         "$int": "&{esv.removeexpiredonboardedusers.repeatinterval|1800000}"
       },
-      "queryFilter": "((/frIndexedDate2 lt \"${Time.now - 7d}Z\"))",
+      "queryFilter": "((/frIndexedDate2 lte \"${Time.now - 8d}Z\"))",
       "scriptFileName": "removeExpiredOnboardedUsers.js"
     },
     {
@@ -31,7 +31,7 @@
       "repeatInterval": {
         "$int": "&{esv.removeexpiredinvitations.repeatinterval|1800000}"
       },
-      "queryFilter": "((/frIndexedMultivalued1 lt \"${Time.now - 7d}Z\"))",
+      "queryFilter": "((/frIndexedMultivalued1 lte \"${Time.now - 8d}Z\"))",
       "scriptFileName": "removeExpiredInvitations.js"
     }
   ],


### PR DESCRIPTION
# Description

As advised by ForgeRock, changes made to _scripts-config.json_ file to replace the `lt` ... `7d` statements for `lte` ... `8d`

This has been done to facilitate ForgeRock's update of FIDC from the 2023 version to a newer 2024 version. ForgeRock have advised that the `lt` operator was the reason for the updates to fail.

**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [x] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
