### PR TITLE
chore: remove global cors config

### DIFF
--- a/scripts/update-cors.js
+++ b/scripts/update-cors.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const path = require('path')
-const getSessionToken = require('../helpers/get-session-token')
 const getAccessToken = require('../helpers/get-access-token')
 const fidcRequest = require('../helpers/fidc-request')
 
@@ -8,7 +7,6 @@ const updateCors = async (argv) => {
   const { FIDC_URL } = process.env
 
   try {
-    const sessionToken = await getSessionToken(argv)
     const accessToken = await getAccessToken(argv)
 
     // Read auth tree JSON files
@@ -22,22 +20,7 @@ const updateCors = async (argv) => {
     // Update AM CORS settings
     await Promise.all(
       corsFileContent.map(async (corsConfigFile) => {
-        const serviceUrl = `${FIDC_URL}/am/json/global-config/services/CorsService`
-        const serviceConfigUrl = `${serviceUrl}/configuration/${corsConfigFile.corsServiceConfig._id}`
         const idmUrl = `${FIDC_URL}/openidm/config/servletfilter/cors`
-        await fidcRequest(
-          serviceUrl,
-          corsConfigFile.corsServiceGlobal,
-          sessionToken,
-          true
-        )
-        await fidcRequest(
-          serviceConfigUrl,
-          corsConfigFile.corsServiceConfig,
-          sessionToken,
-          true
-        )
-        console.log('CORS configuration updated in AM')
         await fidcRequest(
           idmUrl,
           corsConfigFile.idmCorsConfig,

--- a/tests/scripts/update-cors.test.js
+++ b/tests/scripts/update-cors.test.js
@@ -5,7 +5,6 @@ describe('update-cors', () => {
   jest.mock('../../helpers/get-access-token')
   jest.mock('../../helpers/get-session-token')
   jest.mock('../../helpers/fidc-request')
-  const getSessionToken = require('../../helpers/get-session-token')
   const getAccessToken = require('../../helpers/get-access-token')
   const fidcRequest = require('../../helpers/fidc-request')
   const updateCors = require('../../scripts/update-cors')
@@ -88,9 +87,6 @@ describe('update-cors', () => {
 
   beforeEach(() => {
     fidcRequest.mockImplementation(() => Promise.resolve())
-    getSessionToken.mockImplementation(() =>
-      Promise.resolve(mockValues.sessionToken)
-    )
     getAccessToken.mockImplementation(() =>
       Promise.resolve(mockValues.accessToken)
     )
@@ -112,17 +108,6 @@ describe('update-cors', () => {
     process.exit.mockRestore()
   })
 
-  it('should error if getSessionToken functions fails', async () => {
-    expect.assertions(2)
-    const errorMessage = 'Invalid user'
-    getSessionToken.mockImplementation(() =>
-      Promise.reject(new Error(errorMessage))
-    )
-    await updateCors(mockValues)
-    expect(console.error).toHaveBeenCalledWith(errorMessage)
-    expect(process.exit).toHaveBeenCalledWith(1)
-  })
-
   it('should error if getAccessToken functions fails', async () => {
     expect.assertions(2)
     const errorMessage = 'Invalid user'
@@ -135,25 +120,11 @@ describe('update-cors', () => {
   })
 
   it('should call AM API using config file', async () => {
-    expect.assertions(4)
-    const expectedServiceUrl = `${mockValues.fidcUrl}/am/json/global-config/services/CorsService`
-    const expectedServiceConfigUrl = `${expectedServiceUrl}/configuration/${mockConfig.corsServiceConfig._id}`
+    expect.assertions(2)
     const expectedIdmUrl = `${mockValues.fidcUrl}/openidm/config/servletfilter/cors`
     await updateCors(mockValues)
-    expect(fidcRequest.mock.calls.length).toEqual(3)
+    expect(fidcRequest.mock.calls.length).toEqual(1)
     expect(fidcRequest.mock.calls[0]).toEqual([
-      expectedServiceUrl,
-      mockConfig.corsServiceGlobal,
-      mockValues.sessionToken,
-      true
-    ])
-    expect(fidcRequest.mock.calls[1]).toEqual([
-      expectedServiceConfigUrl,
-      mockConfig.corsServiceConfig,
-      mockValues.sessionToken,
-      true
-    ])
-    expect(fidcRequest.mock.calls[2]).toEqual([
       expectedIdmUrl,
       mockConfig.idmCorsConfig,
       mockValues.accessToken,


### PR DESCRIPTION
# Description

Updates to the global CORS configuration is no longer working with the changes introduced to session tokens (https://github.com/companieshouse/forgerock-cloud-config/pull/537). This PR removes the global CORS from the update command as these are unlikely change.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [x] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
