### PR TITLE
feat: add secret for mongodb connection string

### DIFF
--- a/config/variables-secrets/secrets.json
+++ b/config/variables-secrets/secrets.json
@@ -117,5 +117,12 @@
     "encoding": "generic",
     "useInPlaceholders": true,
     "valueBase64": "%ESV_SERVICE_ACCOUNT_PRIVATEKEY%"
+  },
+  {
+    "_id": "esv-mongodb-forgerock-connection-uri",
+    "description": "mongodb connection string for export",
+    "encoding": "generic",
+    "useInPlaceholders": true,
+    "valueBase64": "%ESV_MONGODB_FORGEROCK_CONNECTION_URI%"
   }
 ]


### PR DESCRIPTION
# Description

Creates a new secret for the MongoDB connection string to be used for exporting user data from ForgeRock

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [x] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
