### PR TITLE
fix: update dynamic config to use service account auth

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,3 +4,5 @@ UI_URL=https://idam-ui.amido.aws.chdev.org
 EWF_URL=https://ewf-kermit.companieshouse.gov.uk
 OAUTH2_HASH_SALT=n0FLWZh88zPTlWf2c3OEBlBd5r4=
 IG_OIDC_PASSWORD=3mEf1V@1AY
+SERVICE_ACCOUNT_ID=7593db53-1118-43af-aac5-dd7aef0bb5c1 # Replace with Service account ID
+SERVICE_ACCOUNT_KEY='{"d": "","dp": "",...}' # Replace with Service account JSON string

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains scripts and configuration for the Companies House ForgeRock Identity Cloud tenant. All scripts are used as part of the CI/CD pipeline but can also be ran locally.
 
-Not all steps can be run against Staging and Production tenants; all changes to static configuration must be applied via the configuration promotion process. Changes to dynamic configuration can be aplied to all types of tenants. For more information refer to the Identity Cloud docs: https://backstage.forgerock.com/docs/idcloud/latest/tenants/promote-configuration.html  
+Not all steps can be run against Staging and Production tenants; all changes to static configuration must be applied via the configuration promotion process. Changes to dynamic configuration can be aplied to all types of tenants. For more information refer to the Identity Cloud docs: https://backstage.forgerock.com/docs/idcloud/latest/tenants/promote-configuration.html
 
 ## Running Locally
 
@@ -16,14 +16,18 @@ The following need to be installed/configured for local use:
 
 ### Environment Variables
 
-A `.env` file can be used for setting environment variables when running locally. Copy the `.env.sample` file to a new file called `.env` and update the values for the environment. 
+A `.env` file can be used for setting environment variables when running locally. Copy the `.env.sample` file to a new file called `.env` and update the values for the environment.
 
-| Name             | Description                           | Default Value | Required           |
-| ---------------- | ------------------------------------- | ------------- | ------------------ |
-| FIDC_URL         | ForgeRock Identity Cloud URL          | N/A           | :white_check_mark: |
-| FIDC_COOKIE_NAME | ForgeRock Identity Cloud cookie name  | N/A           | :white_check_mark: |
-| UI_URL           | CH Account UI URL                     | N/A           | :white_check_mark: |
-| OAUTH2_HASH_SALT | Hash salt to be use by OAuth2 service | N/A           | :white_check_mark: |
+| Name                       | Description                                           | Default Value | Required                                                                           |
+| -------------------------- | ----------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------- |
+| FIDC_URL                   | ForgeRock Identity Cloud URL                          | N/A           | :white_check_mark:                                                                 |
+| FIDC_COOKIE_NAME           | ForgeRock Identity Cloud cookie name                  | N/A           | :white_check_mark:                                                                 |
+| SERVICE_ACCOUNT_ID         | ForgeRock Service Account ID                          | N/A           | :white_check_mark:                                                                 |
+| SERVICE_ACCOUNT_KEY        | ForgeRock Service Account JSON key                    | N/A           | _If **SERVICE_ACCOUNT_KEY_PART_1** and **SERVICE_ACCOUNT_KEY_PART_2** are not set_ |
+| SERVICE_ACCOUNT_KEY_PART_1 | First half of the ForgeRock Service Account JSON key  | N/A           | _If **SERVICE_ACCOUNT_KEY** is not set_                                            |
+| SERVICE_ACCOUNT_KEY_PART_2 | Second half of the ForgeRock Service Account JSON key | N/A           | _If **SERVICE_ACCOUNT_KEY** is not set_                                            |
+| UI_URL                     | CH Account UI URL                                     | N/A           | :white_check_mark:                                                                 |
+| OAUTH2_HASH_SALT           | Hash salt to be use by OAuth2 service                 | N/A           | :white_check_mark:                                                                 |
 
 ### Install Dependencies
 

--- a/helpers/fidc-get.js
+++ b/helpers/fidc-get.js
@@ -23,6 +23,15 @@ const fidcGet = async (requestUrl, token, sessionToken) => {
     headers['Accept-API-Version'] = 'protocol=1.0,resource=1.0'
   }
 
+  // Adding header for OAuth2Client endpoint
+  const amEndpoint =
+    requestUrl.indexOf('/am/json/global-config') > -1 ||
+    requestUrl.indexOf('/am/json/realms') > -1
+
+  if (amEndpoint) {
+    headers['Accept-API-Version'] = 'protocol=2.0,resource=1.0'
+  }
+
   const requestOptions = {
     method: 'get',
     body: null,

--- a/helpers/fidc-post.js
+++ b/helpers/fidc-post.js
@@ -22,6 +22,15 @@ const fidcPost = async (requestUrl, body, token, sessionToken) => {
     headers['Accept-API-Version'] = 'protocol=1.0,resource=1.0'
   }
 
+  // Adding header for OAuth2Client endpoint
+  const amEndpoint =
+    requestUrl.indexOf('/am/json/global-config') > -1 ||
+    requestUrl.indexOf('/am/json/realms') > -1
+
+  if (amEndpoint) {
+    headers['Accept-API-Version'] = 'protocol=2.0,resource=1.0'
+  }
+
   const requestOptions = {
     method: 'post',
     body: JSON.stringify(body),

--- a/helpers/fidc-request.js
+++ b/helpers/fidc-request.js
@@ -22,6 +22,15 @@ const fidcRequest = async (requestUrl, body, token, sessionToken) => {
     headers['Accept-API-Version'] = 'protocol=1.0,resource=1.0'
   }
 
+  // Adding header for OAuth2Client endpoint
+  const amEndpoint =
+    requestUrl.indexOf('/am/json/global-config') > -1 ||
+    requestUrl.indexOf('/am/json/realms') > -1
+
+  if (amEndpoint) {
+    headers['Accept-API-Version'] = 'protocol=2.0,resource=1.0'
+  }
+
   const requestOptions = {
     method: 'put',
     body: JSON.stringify(body),

--- a/helpers/get-service-account-token.js
+++ b/helpers/get-service-account-token.js
@@ -1,0 +1,35 @@
+const fetch = require('node-fetch')
+
+const getServiceAccountToken = async () => {
+  const getSignedJWT = require('./get-signed-jwt')
+
+  const { FIDC_URL, SERVICE_ACCOUNT_ID, SERVICE_ACCOUNT_KEY } = process.env
+
+  const requestUrl = `${FIDC_URL}:443/am/oauth2/access_token`
+  const signedJWT = await getSignedJWT(SERVICE_ACCOUNT_ID, SERVICE_ACCOUNT_KEY, requestUrl)
+
+  // Get access token
+  const body = new URLSearchParams()
+  body.append('client_id', 'service-account')
+  body.append('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer')
+  body.append('assertion', signedJWT)
+  body.append('scope', 'fr:am:* fr:idm:* fr:idc:esv:*')
+  const requestOptions = {
+    method: 'post',
+    body
+  }
+
+  try {
+    const response = await fetch(requestUrl, requestOptions)
+    if (response.status !== 200) {
+      console.log('Error while getting Service Account Token')
+      throw new Error(`${response.status}: ${response.statusText}`)
+    }
+    const responseJson = await response.json()
+
+    return Promise.resolve(responseJson.access_token)
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}
+module.exports = getServiceAccountToken

--- a/helpers/get-signed-jwt.js
+++ b/helpers/get-signed-jwt.js
@@ -1,0 +1,23 @@
+const crypto = require('node:crypto')
+const { importJWK, SignJWT } = require('jose')
+
+const getSignedJWT = async (serviceAccountId, serviceAccountKey, requestUrl) => {
+  const jwkObject = JSON.parse(serviceAccountKey.replaceAll('\\', ''))
+  const algorithm = 'RS256'
+
+  const jti = crypto.randomBytes(16).toString('base64')
+  const privateKey = await importJWK(jwkObject, algorithm)
+
+  const signedJWT = await new SignJWT({})
+    .setProtectedHeader({ alg: algorithm })
+    .setIssuedAt()
+    .setIssuer(serviceAccountId)
+    .setSubject(serviceAccountId)
+    .setAudience(requestUrl)
+    .setExpirationTime('5m')
+    .setJti(jti)
+    .sign(privateKey)
+
+  return signedJWT
+}
+module.exports = getSignedJWT

--- a/index.js
+++ b/index.js
@@ -42,6 +42,18 @@ if (!process.env.FIDC_COOKIE_NAME) {
   process.exit(1)
 }
 
+if (!process.env.SERVICE_ACCOUNT_ID) {
+  console.error('Missing required environment variable: SERVICE_ACCOUNT_ID')
+  process.exit(1)
+}
+
+if (!process.env.SERVICE_ACCOUNT_KEY && (!process.env.SERVICE_ACCOUNT_KEY_PART_1 || !process.env.SERVICE_ACCOUNT_KEY_PART_2)) {
+  console.error('Missing required environment variable: SERVICE_ACCOUNT_KEY or SERVICE_ACCOUNT_KEY_PART_1 and SERVICE_ACCOUNT_KEY_PART_2')
+  process.exit(1)
+}
+
+process.env.SERVICE_ACCOUNT_KEY = process.env.SERVICE_ACCOUNT_KEY || JSON.stringify({ ...JSON.parse(process.env.SERVICE_ACCOUNT_KEY_PART_1), ...JSON.parse(process.env.SERVICE_ACCOUNT_KEY_PART_2) })
+
 // Script arguments
 yargs
   .usage('Usage: $0 [arguments]')
@@ -51,15 +63,13 @@ yargs
   .command({
     command: 'agents',
     desc: 'Update ForgeRock Agents (./config/agents)',
-    builder: cliOptions(['username', 'password', 'realm', 'igAgentPassword']),
+    builder: cliOptions(['realm', 'igAgentPassword']),
     handler: (argv) => updateAgents(argv)
   })
   .command({
     command: 'applications',
     desc: 'Update ForgeRock Applications (./config/applications)',
     builder: cliOptions([
-      'username',
-      'password',
       'realm',
       'authTreePassword',
       'igOidcPassword'
@@ -118,12 +128,6 @@ yargs
     command: 'cors',
     desc: 'Update ForgeRock CORS (./config/cors)',
     builder: cliOptions([
-      'username',
-      'password',
-      'idmUsername',
-      'idmPassword',
-      'adminClientId',
-      'adminClientSecret',
       'realm'
     ]),
     handler: (argv) => updateCors(argv)
@@ -132,10 +136,6 @@ yargs
     command: 'internal-roles',
     desc: 'Update IDM Internal Roles (./config/internal-roles)',
     builder: cliOptions([
-      'idmUsername',
-      'idmPassword',
-      'adminClientId',
-      'adminClientSecret',
       'realm'
     ]),
     handler: (argv) => updateInternalRoles(argv)
@@ -217,10 +217,6 @@ yargs
     command: 'user-roles',
     desc: 'Update IDM User Roles (./config/user-roles)',
     builder: cliOptions([
-      'idmUsername',
-      'idmPassword',
-      'adminClientId',
-      'adminClientSecret',
       'realm'
     ]),
     handler: (argv) => updateUserRoles(argv)
@@ -259,25 +255,25 @@ yargs
   .command({
     command: 'update-managed-users',
     desc: 'Update Managed Users (./config/managed-users)',
-    builder: cliOptions(['username', 'password', 'realm', 'treeServiceUserPassword']),
+    builder: cliOptions(['realm', 'treeServiceUserPassword']),
     handler: (argv) => updateManagedUsers(argv)
   })
   .command({
     command: 'variables',
     desc: 'Update Variables (.env)',
-    builder: cliOptions(['username', 'password', 'realm']),
+    builder: cliOptions(['realm']),
     handler: (argv) => updateVariables(argv)
   })
   .command({
     command: 'secrets',
     desc: 'Update Secrets (.env)',
-    builder: cliOptions(['username', 'password', 'realm']),
+    builder: cliOptions(['realm']),
     handler: (argv) => updateSecrets(argv)
   })
   .command({
     command: 'restart-fidc',
     desc: 'Restart FIDC services',
-    builder: cliOptions(['username', 'password', 'realm']),
+    builder: cliOptions(['realm']),
     handler: (argv) => restartFidc(argv)
   })
   .command({
@@ -289,7 +285,7 @@ yargs
   .command({
     command: 'update-esv-and-optional-restart',
     desc: 'Update Variables and Secrets and Optinal Restart',
-    builder: cliOptions(['username', 'password', 'realm']),
+    builder: cliOptions(['realm']),
     handler: (argv) => updateEsvAndRestart(argv)
   })
   .demandCommand()

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^8.2.0",
         "fs-extra": "^9.1.0",
+        "jose": "^5.6.3",
         "node-fetch": "^2.6.1",
         "replace-in-file": "^6.2.0",
         "uglify-js": "^3.14.3",
@@ -8428,6 +8429,15 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
+      "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-sha512": {
@@ -22637,6 +22647,11 @@
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "jose": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
+      "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g=="
     },
     "js-sha512": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "dotenv": "^8.2.0",
     "fs-extra": "^9.1.0",
+    "jose": "^5.6.3",
     "node-fetch": "^2.6.1",
     "replace-in-file": "^6.2.0",
     "uglify-js": "^3.14.3",

--- a/scripts/restart-fidc.js
+++ b/scripts/restart-fidc.js
@@ -1,11 +1,11 @@
-const getAccessToken = require('../helpers/get-access-token')
+const getServiceAccountToken = require('../helpers/get-service-account-token')
 const fidcPost = require('../helpers/fidc-post')
 
-const restartFidc = async (argv) => {
+const restartFidc = async () => {
   const { FIDC_URL } = process.env
 
   try {
-    const accessToken = await getAccessToken(argv)
+    const accessToken = await getServiceAccountToken()
 
     const requestUrl = `${FIDC_URL}/environment/startup?_action=restart`
 

--- a/scripts/update-agents.js
+++ b/scripts/update-agents.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const getSessionToken = require('../helpers/get-session-token')
+const getServiceAccountToken = require('../helpers/get-service-account-token')
 const fidcRequest = require('../helpers/fidc-request')
 const replaceSensitiveValues = require('../helpers/replace-sensitive-values')
 
@@ -9,7 +9,7 @@ const updateAgents = async (argv) => {
   const { FIDC_URL } = process.env
 
   try {
-    const sessionToken = await getSessionToken(argv)
+    const accessToken = await getServiceAccountToken()
 
     // Read agent JSON files
     const dir = path.resolve(__dirname, '../config/agents')
@@ -32,7 +32,7 @@ const updateAgents = async (argv) => {
       agentFileContent.map(async (agentFile) => {
         const requestUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/agents/${agentFile._type._id}/${agentFile._id}`
         delete agentFile._type
-        await fidcRequest(requestUrl, agentFile, sessionToken, true)
+        await fidcRequest(requestUrl, agentFile, accessToken, false)
         console.log(`${agentFile._id} updated`)
         return Promise.resolve()
       })

--- a/scripts/update-applications.js
+++ b/scripts/update-applications.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const getSessionToken = require('../helpers/get-session-token')
+const getServiceAccountToken = require('../helpers/get-service-account-token')
 const fidcRequest = require('../helpers/fidc-request')
 const replaceSensitiveValues = require('../helpers/replace-sensitive-values')
 
@@ -13,7 +13,7 @@ const updateApplications = async (argv) => {
       throw new Error('Missing required environment variable(s)')
     }
 
-    const sessionToken = await getSessionToken(argv)
+    const accessToken = await getServiceAccountToken()
 
     // Read application JSON files
     const dir = path.resolve(__dirname, '../config/applications')
@@ -38,7 +38,7 @@ const updateApplications = async (argv) => {
     await Promise.all(
       applicationFileContent.map(async (applicationFile) => {
         const requestUrl = `${FIDC_URL}/am/json/realms/root/realms/${realm}/realm-config/agents/OAuth2Client/${applicationFile._id}`
-        await fidcRequest(requestUrl, applicationFile, sessionToken, true)
+        await fidcRequest(requestUrl, applicationFile, accessToken, false)
         console.log(`${applicationFile._id} updated`)
         return Promise.resolve()
       })

--- a/scripts/update-cors.js
+++ b/scripts/update-cors.js
@@ -1,13 +1,13 @@
 const fs = require('fs')
 const path = require('path')
-const getAccessToken = require('../helpers/get-access-token')
+const getServiceAccountToken = require('../helpers/get-service-account-token')
 const fidcRequest = require('../helpers/fidc-request')
 
-const updateCors = async (argv) => {
+const updateCors = async () => {
   const { FIDC_URL } = process.env
 
   try {
-    const accessToken = await getAccessToken(argv)
+    const accessToken = await getServiceAccountToken()
 
     // Read auth tree JSON files
     const dir = path.resolve(__dirname, '../config/cors')
@@ -20,7 +20,22 @@ const updateCors = async (argv) => {
     // Update AM CORS settings
     await Promise.all(
       corsFileContent.map(async (corsConfigFile) => {
+        const serviceUrl = `${FIDC_URL}/am/json/global-config/services/CorsService`
+        const serviceConfigUrl = `${serviceUrl}/configuration/${corsConfigFile.corsServiceConfig._id}`
         const idmUrl = `${FIDC_URL}/openidm/config/servletfilter/cors`
+        await fidcRequest(
+          serviceUrl,
+          corsConfigFile.corsServiceGlobal,
+          accessToken,
+          false
+        )
+        await fidcRequest(
+          serviceConfigUrl,
+          corsConfigFile.corsServiceConfig,
+          accessToken,
+          false
+        )
+        console.log('CORS configuration updated in AM')
         await fidcRequest(
           idmUrl,
           corsConfigFile.idmCorsConfig,

--- a/scripts/update-esv-and-restart.js
+++ b/scripts/update-esv-and-restart.js
@@ -3,20 +3,20 @@ const updateSecrets = require('./update-secrets')
 const restartFidc = require('./restart-fidc')
 const fs = require('fs')
 
-const updateEsvAndRestart = async (argv) => {
+const updateEsvAndRestart = async () => {
   const restartRequiredFilename = 'FIDC_RESTART_REQUIRED.txt'
 
   if (fs.existsSync(restartRequiredFilename)) {
     fs.unlinkSync(restartRequiredFilename)
   }
 
-  await updateVariables(argv)
-  await updateSecrets(argv)
+  await updateVariables()
+  await updateSecrets()
 
   if (fs.existsSync(restartRequiredFilename)) {
     console.log('Restart required ...')
 
-    await restartFidc(argv)
+    await restartFidc()
 
     fs.unlinkSync(restartRequiredFilename)
   }

--- a/scripts/update-internal-roles.js
+++ b/scripts/update-internal-roles.js
@@ -1,13 +1,13 @@
 const fs = require('fs')
 const path = require('path')
-const getAccessToken = require('../helpers/get-access-token')
+const getServiceAccountToken = require('../helpers/get-service-account-token')
 const fidcRequest = require('../helpers/fidc-request')
 
-const updateInternalRoles = async (argv) => {
+const updateInternalRoles = async () => {
   const { FIDC_URL } = process.env
 
   try {
-    const accessToken = await getAccessToken(argv)
+    const accessToken = await getServiceAccountToken()
 
     // Combine internal roles JSON files
     const dir = path.resolve(__dirname, '../config/internal-roles')

--- a/scripts/update-managed-users.js
+++ b/scripts/update-managed-users.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const getAccessToken = require('../helpers/get-access-token')
+const getServiceAccountToken = require('../helpers/get-service-account-token')
 const fidcRequest = require('../helpers/fidc-request')
 const replaceSensitiveValues = require('../helpers/replace-sensitive-values')
 
@@ -8,7 +8,7 @@ const updateManagedUsers = async (argv) => {
   const { FIDC_URL, AUTH_TREE_PASSWORD, ADMIN_CLIENT_TEST_PASSWORD } = process.env
 
   try {
-    const accessToken = await getAccessToken(argv)
+    const accessToken = await getServiceAccountToken()
 
     // Combine managed object JSON files
     const dir = path.resolve(__dirname, '../config/managed-users')

--- a/scripts/update-secrets.js
+++ b/scripts/update-secrets.js
@@ -1,4 +1,4 @@
-const getAccessToken = require('../helpers/get-access-token')
+const getServiceAccountToken = require('../helpers/get-service-account-token')
 const fidcGet = require('../helpers/fidc-get')
 const fidcRequest = require('../helpers/fidc-request')
 const fidcPost = require('../helpers/fidc-post')
@@ -34,11 +34,11 @@ async function alreadyExists (secretName, valueBase64, requestUrl, scriptUrl, ac
   return ret
 }
 
-const updateSecrets = async (argv) => {
+const updateSecrets = async () => {
   const { FIDC_URL } = process.env
 
   try {
-    const accessToken = await getAccessToken(argv)
+    const accessToken = await getServiceAccountToken()
     const secrets = []
     const secretsPath = path.resolve(__dirname, '../config/variables-secrets/secrets.json')
 

--- a/scripts/update-user-roles.js
+++ b/scripts/update-user-roles.js
@@ -1,13 +1,13 @@
 const fs = require('fs')
 const path = require('path')
-const getAccessToken = require('../helpers/get-access-token')
+const getServiceAccountToken = require('../helpers/get-service-account-token')
 const fidcRequest = require('../helpers/fidc-request')
 
 const updateUserRoles = async (argv) => {
   const { FIDC_URL } = process.env
 
   try {
-    const accessToken = await getAccessToken(argv)
+    const accessToken = await getServiceAccountToken()
 
     // Combine managed object JSON files
     const dir = path.resolve(__dirname, '../config/user-roles')

--- a/scripts/update-variables.js
+++ b/scripts/update-variables.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const getAccessToken = require('../helpers/get-access-token')
+const getServiceAccountToken = require('../helpers/get-service-account-token')
 const fidcRequest = require('../helpers/fidc-request')
 const fidcGet = require('../helpers/fidc-get')
 const fidcPost = require('../helpers/fidc-post')
@@ -34,11 +34,11 @@ async function alreadyExists (variableName, valueBase64, requestUrl, scriptUrl, 
   return ret
 }
 
-const updateVariables = async (argv) => {
+const updateVariables = async () => {
   const { FIDC_URL } = process.env
 
   try {
-    const accessToken = await getAccessToken(argv)
+    const accessToken = await getServiceAccountToken()
     const variables = []
     const varsPath = path.resolve(__dirname, '../config/variables-secrets/variables.json')
 

--- a/tests/scripts/update-agents.test.js
+++ b/tests/scripts/update-agents.test.js
@@ -2,8 +2,8 @@ describe('update-agents', () => {
   jest.mock('fs')
   const fs = require('fs')
   const path = require('path')
-  jest.mock('../../helpers/get-session-token')
-  const getSessionToken = require('../../helpers/get-session-token')
+  jest.mock('../../helpers/get-service-account-token')
+  const getServiceAccountToken = require('../../helpers/get-service-account-token')
   jest.mock('../../helpers/fidc-request')
   const fidcRequest = require('../../helpers/fidc-request')
   jest.mock('../../helpers/replace-sensitive-values')
@@ -16,7 +16,7 @@ describe('update-agents', () => {
 
   const mockValues = {
     fidcUrl: 'https://fidc-test.forgerock.com',
-    sessionToken: 'session=1234',
+    accessToken: 'forgerock-token',
     realm: 'alpha'
   }
 
@@ -53,7 +53,7 @@ describe('update-agents', () => {
   // }
 
   beforeEach(() => {
-    getSessionToken.mockImplementation(() =>
+    getServiceAccountToken.mockImplementation(() =>
       Promise.resolve(mockValues.sessionToken)
     )
     fidcRequest.mockImplementation(() => Promise.resolve())
@@ -77,10 +77,10 @@ describe('update-agents', () => {
     process.exit.mockRestore()
   })
 
-  it('should error if getSessionToken functions fails', async () => {
+  it('should error if getServiceAccountToken functions fails', async () => {
     expect.assertions(2)
     const errorMessage = 'Invalid user'
-    getSessionToken.mockImplementation(() =>
+    getServiceAccountToken.mockImplementation(() =>
       Promise.reject(new Error(errorMessage))
     )
     await updateAgents(mockValues)

--- a/tests/scripts/update-applications.test.js
+++ b/tests/scripts/update-applications.test.js
@@ -2,8 +2,8 @@ describe('update-applications', () => {
   jest.mock('fs')
   const fs = require('fs')
   const path = require('path')
-  jest.mock('../../helpers/get-session-token')
-  const getSessionToken = require('../../helpers/get-session-token')
+  jest.mock('../../helpers/get-service-account-token')
+  const getServiceAccountToken = require('../../helpers/get-service-account-token')
   jest.mock('../../helpers/fidc-request')
   const fidcRequest = require('../../helpers/fidc-request')
   jest.mock('../../helpers/replace-sensitive-values')
@@ -18,7 +18,7 @@ describe('update-applications', () => {
     fidcUrl: 'https://fidc-test.forgerock.com',
     uiUrl: 'https://idam-ui.companieshouse.gov.uk',
     ewfUrl: 'https://ewf.companieshouse.gov.uk',
-    sessionToken: 'session=1234',
+    accessToken: 'forgerock-token',
     realm: 'alpha'
   }
 
@@ -56,8 +56,8 @@ describe('update-applications', () => {
   }
 
   beforeEach(() => {
-    getSessionToken.mockImplementation(() =>
-      Promise.resolve(mockValues.sessionToken)
+    getServiceAccountToken.mockImplementation(() =>
+      Promise.resolve(mockValues.accessToken)
     )
     fidcRequest.mockImplementation(() => Promise.resolve())
     replaceSensitiveValues.mockImplementation(() => Promise.resolve())
@@ -91,10 +91,10 @@ describe('update-applications', () => {
     expect(process.exit).toHaveBeenCalledWith(1)
   })
 
-  it('should error if getSessionToken functions fails', async () => {
+  it('should error if getServiceAccountToken functions fails', async () => {
     expect.assertions(2)
     const errorMessage = 'Invalid user'
-    getSessionToken.mockImplementation(() =>
+    getServiceAccountToken.mockImplementation(() =>
       Promise.reject(new Error(errorMessage))
     )
     await updateApplications(mockValues)
@@ -132,8 +132,8 @@ describe('update-applications', () => {
     expect(fidcRequest.mock.calls[0]).toEqual([
       expectedUrl,
       mockConfig,
-      mockValues.sessionToken,
-      true
+      mockValues.accessToken,
+      false
     ])
   })
 
@@ -147,8 +147,8 @@ describe('update-applications', () => {
     expect(fidcRequest.mock.calls[0]).toEqual([
       expectedUrl,
       mockConfig,
-      mockValues.sessionToken,
-      true
+      mockValues.accessToken,
+      false
     ])
   })
 })

--- a/tests/scripts/update-internal-roles.test.js
+++ b/tests/scripts/update-internal-roles.test.js
@@ -2,8 +2,8 @@ describe('update-internal-roles', () => {
   jest.mock('fs')
   const fs = require('fs')
   const path = require('path')
-  jest.mock('../../helpers/get-access-token')
-  const getAccessToken = require('../../helpers/get-access-token')
+  jest.mock('../../helpers/get-service-account-token')
+  const getServiceAccountToken = require('../../helpers/get-service-account-token')
   jest.mock('../../helpers/fidc-request')
   const fidcRequest = require('../../helpers/fidc-request')
   jest.spyOn(console, 'log').mockImplementation(() => {})
@@ -37,7 +37,7 @@ describe('update-internal-roles', () => {
 
   beforeEach(() => {
     fidcRequest.mockImplementation(() => Promise.resolve())
-    getAccessToken.mockImplementation(() =>
+    getServiceAccountToken.mockImplementation(() =>
       Promise.resolve(mockValues.accessToken)
     )
     process.env.FIDC_URL = mockValues.fidcUrl
@@ -58,10 +58,10 @@ describe('update-internal-roles', () => {
     process.exit.mockRestore()
   })
 
-  it('should error if getAccessToken functions fails', async () => {
+  it('should error if getServiceAccountToken functions fails', async () => {
     expect.assertions(2)
     const errorMessage = 'Invalid user'
-    getAccessToken.mockImplementation(() =>
+    getServiceAccountToken.mockImplementation(() =>
       Promise.reject(new Error(errorMessage))
     )
     await updateUserRoles(mockValues)

--- a/tests/scripts/update-managed-users.test.js
+++ b/tests/scripts/update-managed-users.test.js
@@ -2,8 +2,8 @@ describe('update-managed-users', () => {
   jest.mock('fs')
   const fs = require('fs')
   const path = require('path')
-  jest.mock('../../helpers/get-access-token')
-  const getAccessToken = require('../../helpers/get-access-token')
+  jest.mock('../../helpers/get-service-account-token')
+  const getServiceAccountToken = require('../../helpers/get-service-account-token')
   jest.mock('../../helpers/fidc-request')
   const fidcRequest = require('../../helpers/fidc-request')
   jest.spyOn(console, 'log').mockImplementation(() => {})
@@ -97,7 +97,7 @@ describe('update-managed-users', () => {
 
   beforeEach(() => {
     fidcRequest.mockImplementation(() => Promise.resolve())
-    getAccessToken.mockImplementation(() =>
+    getServiceAccountToken.mockImplementation(() =>
       Promise.resolve(mockValues.accessToken)
     )
     process.env.FIDC_URL = mockValues.fidcUrl
@@ -118,10 +118,10 @@ describe('update-managed-users', () => {
     process.exit.mockRestore()
   })
 
-  it('should error if getAccessToken functions fails', async () => {
+  it('should error if getServiceAccountToken functions fails', async () => {
     expect.assertions(2)
     const errorMessage = 'Invalid user'
-    getAccessToken.mockImplementation(() =>
+    getServiceAccountToken.mockImplementation(() =>
       Promise.reject(new Error(errorMessage))
     )
     await updateManagedUsers(mockValues)

--- a/tests/scripts/update-user-roles.test.js
+++ b/tests/scripts/update-user-roles.test.js
@@ -2,8 +2,8 @@ describe('update-user-roles', () => {
   jest.mock('fs')
   const fs = require('fs')
   const path = require('path')
-  jest.mock('../../helpers/get-access-token')
-  const getAccessToken = require('../../helpers/get-access-token')
+  jest.mock('../../helpers/get-service-account-token')
+  const getServiceAccountToken = require('../../helpers/get-service-account-token')
   jest.mock('../../helpers/fidc-request')
   const fidcRequest = require('../../helpers/fidc-request')
   jest.spyOn(console, 'log').mockImplementation(() => {})
@@ -31,7 +31,7 @@ describe('update-user-roles', () => {
 
   beforeEach(() => {
     fidcRequest.mockImplementation(() => Promise.resolve())
-    getAccessToken.mockImplementation(() =>
+    getServiceAccountToken.mockImplementation(() =>
       Promise.resolve(mockValues.accessToken)
     )
     process.env.FIDC_URL = mockValues.fidcUrl
@@ -52,10 +52,10 @@ describe('update-user-roles', () => {
     process.exit.mockRestore()
   })
 
-  it('should error if getAccessToken functions fails', async () => {
+  it('should error if getServiceAccountToken functions fails', async () => {
     expect.assertions(2)
     const errorMessage = 'Invalid user'
-    getAccessToken.mockImplementation(() =>
+    getServiceAccountToken.mockImplementation(() =>
       Promise.reject(new Error(errorMessage))
     )
     await updateUserRoles(mockValues)


### PR DESCRIPTION
# Description

The pipeline is getting a 403 error when attempting to update the dynamic config for Staging. To resolve this I have changed the dynamic config to use a Service Account for authentication. 

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [x] agents (AM)
- [x] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [x] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [x] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [x] managed-users (IDM)
- [ ] password-policy (IDM)
- [x] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [x] variables
