### PR TITLE
Update service account esv using multiple json inputs

### DIFF
--- a/config/variables-secrets/secrets.json
+++ b/config/variables-secrets/secrets.json
@@ -116,7 +116,12 @@
     "description": "am-access service account private key",
     "encoding": "generic",
     "useInPlaceholders": true,
-    "valueBase64": "%ESV_SERVICE_ACCOUNT_PRIVATEKEY%"
+    "valueBase64": "%ESV_SERVICE_ACCOUNT_PRIVATEKEY%",
+    "mergeJsonVariables": [
+      "ESV_SERVICE_ACCOUNT_PRIVATEKEY_PART_1",
+      "ESV_SERVICE_ACCOUNT_PRIVATEKEY_PART_2"
+
+    ]
   },
   {
     "_id": "esv-mongodb-forgerock-connection-uri",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "standard": "^16.0.3"
   },
   "standard": {
+    "globals": [
+      "btoa"
+    ],
     "env": [
       "jest"
     ],


### PR DESCRIPTION
# Description

Service Account JSON is too large for AWS parameter store so cannot be set in the pipeline easily. This change allows setting multiple JSON environment variables that will be merged for the final secret.

<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [ ] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [x] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
