### PR TITLE
fix: revert back mongo connector incident CS002523005

### DIFF
--- a/config/connectors/definitions/archived/mongodb-api-client-keys
+++ b/config/connectors/definitions/archived/mongodb-api-client-keys
@@ -3,7 +3,7 @@
     "connectorRef": {
         "connectorHostRef": "chs-group",
         "displayName": "MongoDB Connector",
-        "bundleVersion": "1.5.20.22",
+        "bundleVersion": "1.5.20.0",
         "systemType": "provisioner.openicf",
         "bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
         "connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -49,7 +49,7 @@
         "deleteScriptFileName": "DeleteMongoDB.groovy",
         "scriptBaseClass": null,
         "scriptRoots": [
-            "jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+            "jar:file:connectors/mongodb-connector-1.5.20.0.jar!/scripts/mongodb/"
         ],
         "customConfiguration": null,
         "resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/archived/mongodb-auth-code.json
+++ b/config/connectors/definitions/archived/mongodb-auth-code.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "1.5.20.0",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.0.jar!/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/archived/mongodb-roles.json
+++ b/config/connectors/definitions/archived/mongodb-roles.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "1.5.20.0",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.0.jar!/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/archived/mongodb-users.json
+++ b/config/connectors/definitions/archived/mongodb-users.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "CHS User Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "1.5.20.0",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar\u0021/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.0.jar\u0021/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/mongodb-companies.json
+++ b/config/connectors/definitions/mongodb-companies.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "1.5.20.0",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.0.jar!/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/mongodb-forgerock-data.json
+++ b/config/connectors/definitions/mongodb-forgerock-data.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "forgerock-export",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "1.5.20.0",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.0.jar!/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,


### PR DESCRIPTION
# Description

Fix incident CS002523005


**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [x] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
