### PR TITLE
Add a correlation query to webfilingUser_alphaUser mapping

### DIFF
--- a/config/connectors/mappings/webfilingUser_alphaUser.json
+++ b/config/connectors/mappings/webfilingUser_alphaUser.json
@@ -86,7 +86,19 @@
   },
   "sourceQueryFullEntry": true,
   "taskThreads": 20,
-  "correlationQuery": [],
+  "correlationQuery": [
+    {
+      "linkQualifier": "default",
+      "expressionTree": {
+        "all": [
+          "frIndexedString1"
+        ]
+      },
+      "mapping": "webfilingUser_alphaUser",
+      "type": "text/javascript",
+      "file": "ui/correlateTreeToQueryFilter.js"
+    }
+  ],
   "onCreate": {
     "type": "text/javascript",
     "globals": {},


### PR DESCRIPTION
# Description
Add a correlation query to the webfilingUser_alphaUser mapping. If any users are missing a link to an existing EWF record, they will identified by the correlation query, and a new link will be created.

**FIDC Update Required:**
- [X] connectors / mappings / scheduled recons (IDM)
