### PR TITLE
Mapping transformation for uppercase emails

### DIFF
--- a/config/connectors/mappings/webfilingUser_alphaUser.json
+++ b/config/connectors/mappings/webfilingUser_alphaUser.json
@@ -7,15 +7,27 @@
   "properties": [
     {
       "target": "mail",
-      "source": "EMAIL"
+      "source": "EMAIL",
+      "transform": {
+        "type": "text/javascript",
+        "source": "source.toLowerCase();"
+      }
     },
     {
       "target": "sn",
-      "source": "EMAIL"
+      "source": "EMAIL",
+      "transform": {
+        "type": "text/javascript",
+        "source": "source.toLowerCase();"
+      }
     },
     {
       "target": "userName",
-      "source": "EMAIL"
+      "source": "EMAIL",
+      "transform": {
+        "type": "text/javascript",
+        "source": "source.toLowerCase();"
+      }
     },
     {
       "target": "frIndexedString2",


### PR DESCRIPTION
# Description
Add a transformation step to the mapping `webfilingUser_alphaUser` to lowercase the value for `EMAIL`.

**FIDC Update Required:**
- [X] connectors / mappings / scheduled recons (IDM)