### PR TITLE
Set recoverable=true for all schedules

### DIFF
--- a/config/connectors/schedules/auth-codes.json
+++ b/config/connectors/schedules/auth-codes.json
@@ -4,7 +4,7 @@
         "$bool": "&{esv.2bb35d546a.reconscheduleauthcodesenabled}"
     },
     "persisted": true,
-    "recoverable": false,
+    "recoverable": true,
     "misfirePolicy": "fireAndProceed",
     "schedule": "&{esv.9db15a3625.reconscheduleauthcodescronexp}",
     "repeatInterval": 0,

--- a/config/connectors/schedules/companies.json
+++ b/config/connectors/schedules/companies.json
@@ -4,7 +4,7 @@
         "$bool": "&{esv.b1ea4bdc4a.reconscheduleucompaniesenabled}"
     },
     "persisted": true,
-    "recoverable": false,
+    "recoverable": true,
     "misfirePolicy": "fireAndProceed",
     "schedule": "&{esv.c827402089.reconscheduleucompaniescronexp}",
     "repeatInterval": 0,

--- a/config/connectors/schedules/ds-backup.json
+++ b/config/connectors/schedules/ds-backup.json
@@ -2,7 +2,7 @@
   "_id": "DR: alpha_user to DS Backup",
   "enabled": false,
 	"persisted": true,
-	"recoverable": false,
+	"recoverable": true,
 	"misfirePolicy": "fireAndProceed",
 	"schedule": "0 0 */5 * * ?",
 	"repeatInterval": 0,

--- a/config/connectors/schedules/users.json
+++ b/config/connectors/schedules/users.json
@@ -4,7 +4,7 @@
         "$bool": "&{esv.566930381b.reconscheduleusersenabled}"
     },
     "persisted": true,
-    "recoverable": false,
+    "recoverable": true,
     "misfirePolicy": "fireAndProceed",
     "schedule": "&{esv.1dc20f579c.reconscheduleuserscronexp}",
     "repeatInterval": 0,


### PR DESCRIPTION
# Description

Set `recoverable=true` for all reconciliation schedules. This parameter specifies whether jobs that have failed mid-execution should be recovered. It is false by default. We can enable this to improve the performance of our reconciliations, as we are seeing random database connection failures that are affecting overnight runs.

**FIDC Update Required:**
- [X] connectors / mappings / scheduled recons (IDM)