### PR TITLE
Upgrade RCS connectors to 1.5.20.27

### DIFF
--- a/config/connectors/definitions/archived/mongodb-auth-code.json
+++ b/config/connectors/definitions/archived/mongodb-auth-code.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "[1.5.0.0,1.6.0.0]",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.27.jar!/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/archived/mongodb-auth-code.json
+++ b/config/connectors/definitions/archived/mongodb-auth-code.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "[1.5.0.0,1.6.0.0]",
+		"bundleVersion": "[1.5.0.0,1.6.0.0)",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"

--- a/config/connectors/definitions/archived/mongodb-roles.json
+++ b/config/connectors/definitions/archived/mongodb-roles.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "[1.5.0.0,1.6.0.0]",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.27.jar!/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/archived/mongodb-roles.json
+++ b/config/connectors/definitions/archived/mongodb-roles.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "[1.5.0.0,1.6.0.0]",
+		"bundleVersion": "[1.5.0.0,1.6.0.0)",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"

--- a/config/connectors/definitions/archived/mongodb-users.json
+++ b/config/connectors/definitions/archived/mongodb-users.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "CHS User Connector",
-		"bundleVersion": "[1.5.0.0,1.6.0.0]",
+		"bundleVersion": "[1.5.0.0,1.6.0.0)",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"

--- a/config/connectors/definitions/archived/mongodb-users.json
+++ b/config/connectors/definitions/archived/mongodb-users.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "CHS User Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "[1.5.0.0,1.6.0.0]",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.27.jar!/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/archived/webfiling-auth.json
+++ b/config/connectors/definitions/archived/webfiling-auth.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "ewf-group",
 		"displayName": "Database Table Connector",
-		"bundleVersion": "[1.5.0.0,1.6.0.0]",
+		"bundleVersion": "[1.5.0.0,1.6.0.0)",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.databasetable-connector",
 		"connectorName": "org.identityconnectors.databasetable.DatabaseTableConnector"

--- a/config/connectors/definitions/archived/webfiling-auth.json
+++ b/config/connectors/definitions/archived/webfiling-auth.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "ewf-group",
 		"displayName": "Database Table Connector",
-		"bundleVersion": "1.5.20.3-SNAPSHOT",
+		"bundleVersion": "[1.5.0.0,1.6.0.0]",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.databasetable-connector",
 		"connectorName": "org.identityconnectors.databasetable.DatabaseTableConnector"

--- a/config/connectors/definitions/mongodb-companies.json
+++ b/config/connectors/definitions/mongodb-companies.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "[1.5.0.0,1.6.0.0]",
+		"bundleVersion": "[1.5.0.0,1.6.0.0)",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"

--- a/config/connectors/definitions/mongodb-companies.json
+++ b/config/connectors/definitions/mongodb-companies.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "chs-group",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "[1.5.0.0,1.6.0.0]",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -22,20 +22,20 @@
 		"enableAttributesToGetSearchResultsHandler": true
 	},
 	"operationTimeout": {
-		"CREATE": -1,
-		"UPDATE": -1,
-		"DELETE": -1,
-		"TEST": -1,
-		"SCRIPT_ON_CONNECTOR": -1,
-		"SCRIPT_ON_RESOURCE": -1,
-		"GET": -1,
-		"RESOLVEUSERNAME": -1,
-		"AUTHENTICATE": -1,
-		"SEARCH": -1,
-		"VALIDATE": -1,
-		"SYNC": -1,
-		"SCHEMA": -1
-	},
+		"AUTHENTICATE": 10000,
+		"CREATE": 30000,
+		"DELETE": 30000,
+		"GET": 30000,
+		"RESOLVEUSERNAME": 15000,
+		"SCHEMA": 15000,
+		"SCRIPT_ON_CONNECTOR": 15000,
+		"SCRIPT_ON_RESOURCE": 15000,
+		"SEARCH": 180000,
+		"SYNC": 180000,
+		"TEST": 10000,
+		"UPDATE": 30000,
+		"VALIDATE": -15000
+	  },
 	"configurationProperties": {
 		"customSensitiveConfiguration": null,
 		"createScriptFileName": "CreateMongoDB.groovy",
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.27.jar!/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/mongodb-forgerock-data.json
+++ b/config/connectors/definitions/mongodb-forgerock-data.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "forgerock-export",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "1.5.20.22",
+		"bundleVersion": "[1.5.0.0,1.6.0.0]",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"
@@ -22,20 +22,20 @@
 		"enableAttributesToGetSearchResultsHandler": true
 	},
 	"operationTimeout": {
-		"CREATE": -1,
-		"UPDATE": -1,
-		"DELETE": -1,
-		"TEST": -1,
-		"SCRIPT_ON_CONNECTOR": -1,
-		"SCRIPT_ON_RESOURCE": -1,
-		"GET": -1,
-		"RESOLVEUSERNAME": -1,
-		"AUTHENTICATE": -1,
-		"SEARCH": -1,
-		"VALIDATE": -1,
-		"SYNC": -1,
-		"SCHEMA": -1
-	},
+		"AUTHENTICATE": 10000,
+		"CREATE": 30000,
+		"DELETE": 30000,
+		"GET": 30000,
+		"RESOLVEUSERNAME": 15000,
+		"SCHEMA": 15000,
+		"SCRIPT_ON_CONNECTOR": 15000,
+		"SCRIPT_ON_RESOURCE": 15000,
+		"SEARCH": 180000,
+		"SYNC": 180000,
+		"TEST": 10000,
+		"UPDATE": 30000,
+		"VALIDATE": -15000
+	  },
 	"configurationProperties": {
 		"customSensitiveConfiguration": null,
 		"createScriptFileName": "CreateMongoDB.groovy",
@@ -49,7 +49,7 @@
 		"deleteScriptFileName": "DeleteMongoDB.groovy",
 		"scriptBaseClass": null,
 		"scriptRoots": [
-			"jar:file:connectors/mongodb-connector-1.5.20.22.jar!/scripts/mongodb/"
+			"jar:file:connectors/mongodb-connector-1.5.20.27.jar!/scripts/mongodb/"
 		],
 		"customConfiguration": null,
 		"resolveUsernameScriptFileName": null,

--- a/config/connectors/definitions/mongodb-forgerock-data.json
+++ b/config/connectors/definitions/mongodb-forgerock-data.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "forgerock-export",
 		"displayName": "MongoDB Connector",
-		"bundleVersion": "[1.5.0.0,1.6.0.0]",
+		"bundleVersion": "[1.5.0.0,1.6.0.0)",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.mongodb-connector",
 		"connectorName": "org.forgerock.openicf.connectors.mongodb.MongoDBConnector"

--- a/config/connectors/definitions/webfiling-auth-code.json
+++ b/config/connectors/definitions/webfiling-auth-code.json
@@ -63,7 +63,7 @@
 	},
 	"connectorRef": {
 		"bundleName": "org.forgerock.openicf.connectors.databasetable-connector",
-		"bundleVersion": "1.5.20.3-SNAPSHOT",
+		"bundleVersion": "[1.5.0.0,1.6.0.0]",
 		"connectorHostRef": "ewf-group",
 		"connectorName": "org.identityconnectors.databasetable.DatabaseTableConnector",
 		"displayName": "Database Table Connector",
@@ -107,20 +107,20 @@
 		}
 	},
 	"operationTimeout": {
-		"AUTHENTICATE": -1,
-		"CREATE": -1,
-		"DELETE": -1,
-		"GET": -1,
-		"RESOLVEUSERNAME": -1,
-		"SCHEMA": -1,
-		"SCRIPT_ON_CONNECTOR": -1,
-		"SCRIPT_ON_RESOURCE": -1,
-		"SEARCH": -1,
-		"SYNC": -1,
-		"TEST": -1,
-		"UPDATE": -1,
-		"VALIDATE": -1
-	},
+		"AUTHENTICATE": 10000,
+		"CREATE": 30000,
+		"DELETE": 30000,
+		"GET": 30000,
+		"RESOLVEUSERNAME": 15000,
+		"SCHEMA": 15000,
+		"SCRIPT_ON_CONNECTOR": 15000,
+		"SCRIPT_ON_RESOURCE": 15000,
+		"SEARCH": 180000,
+		"SYNC": 180000,
+		"TEST": 10000,
+		"UPDATE": 30000,
+		"VALIDATE": -15000
+	  },
 	"poolConfigOption": {
 		"maxIdle": 2,
 		"maxObjects": 2,

--- a/config/connectors/definitions/webfiling-auth-code.json
+++ b/config/connectors/definitions/webfiling-auth-code.json
@@ -63,7 +63,7 @@
 	},
 	"connectorRef": {
 		"bundleName": "org.forgerock.openicf.connectors.databasetable-connector",
-		"bundleVersion": "[1.5.0.0,1.6.0.0]",
+		"bundleVersion": "[1.5.0.0,1.6.0.0)",
 		"connectorHostRef": "ewf-group",
 		"connectorName": "org.identityconnectors.databasetable.DatabaseTableConnector",
 		"displayName": "Database Table Connector",

--- a/config/connectors/definitions/webfiling-users.json
+++ b/config/connectors/definitions/webfiling-users.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "ewf-group",
 		"displayName": "Database Table Connector",
-		"bundleVersion": "[1.5.0.0,1.6.0.0]",
+		"bundleVersion": "[1.5.0.0,1.6.0.0)",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.databasetable-connector",
 		"connectorName": "org.identityconnectors.databasetable.DatabaseTableConnector"

--- a/config/connectors/definitions/webfiling-users.json
+++ b/config/connectors/definitions/webfiling-users.json
@@ -3,7 +3,7 @@
 	"connectorRef": {
 		"connectorHostRef": "ewf-group",
 		"displayName": "Database Table Connector",
-		"bundleVersion": "1.5.20.3-SNAPSHOT",
+		"bundleVersion": "[1.5.0.0,1.6.0.0]",
 		"systemType": "provisioner.openicf",
 		"bundleName": "org.forgerock.openicf.connectors.databasetable-connector",
 		"connectorName": "org.identityconnectors.databasetable.DatabaseTableConnector"
@@ -26,20 +26,20 @@
 		"enableAttributesToGetSearchResultsHandler": true
 	},
 	"operationTimeout": {
-		"CREATE": -1,
-		"UPDATE": -1,
-		"DELETE": -1,
-		"TEST": -1,
-		"SCRIPT_ON_CONNECTOR": -1,
-		"SCRIPT_ON_RESOURCE": -1,
-		"GET": -1,
-		"RESOLVEUSERNAME": -1,
-		"AUTHENTICATE": -1,
-		"SEARCH": -1,
-		"VALIDATE": -1,
-		"SYNC": -1,
-		"SCHEMA": -1
-	},
+		"AUTHENTICATE": 10000,
+		"CREATE": 30000,
+		"DELETE": 30000,
+		"GET": 30000,
+		"RESOLVEUSERNAME": 15000,
+		"SCHEMA": 15000,
+		"SCRIPT_ON_CONNECTOR": 15000,
+		"SCRIPT_ON_RESOURCE": 15000,
+		"SEARCH": 180000,
+		"SYNC": 180000,
+		"TEST": 10000,
+		"UPDATE": 30000,
+		"VALIDATE": -15000
+	  },
 	"configurationProperties": {
 		"connectionProperties": null,
 		"propagateInterruptState": false,


### PR DESCRIPTION
# Description

- Upgrade WebfilingAuthCode Table Connector to 1.5.20.27
- Upgrade WebfilingUser Table Connector to 1.5.20.27
- Upgrade WebfilingAuth Table Connector to 1.5.20.27
- Upgrade CHSAuthCode MongoDB Connector to 1.5.20.27
- Upgrade CHSRoles MongoDB Connector to 1.5.20.27
- Upgrade CHSUser MongoDB Connector to 1.5.20.27

**FIDC Update Required:**
- [X] connectors / mappings / scheduled recons (IDM)
