### PR TITLE
Revert connection timeout settings

### DIFF
--- a/config/connectors/definitions/mongodb-companies.json
+++ b/config/connectors/definitions/mongodb-companies.json
@@ -22,19 +22,19 @@
 		"enableAttributesToGetSearchResultsHandler": true
 	},
 	"operationTimeout": {
-		"AUTHENTICATE": 10000,
-		"CREATE": 30000,
-		"DELETE": 30000,
-		"GET": 30000,
-		"RESOLVEUSERNAME": 15000,
-		"SCHEMA": 15000,
-		"SCRIPT_ON_CONNECTOR": 15000,
-		"SCRIPT_ON_RESOURCE": 15000,
-		"SEARCH": 180000,
-		"SYNC": 180000,
-		"TEST": 10000,
-		"UPDATE": 30000,
-		"VALIDATE": -15000
+		"AUTHENTICATE": -1,
+		"CREATE": -1,
+		"DELETE": -1,
+		"GET": -1,
+		"RESOLVEUSERNAME": -1,
+		"SCHEMA": -1,
+		"SCRIPT_ON_CONNECTOR": -1,
+		"SCRIPT_ON_RESOURCE": -1,
+		"SEARCH": -1,
+		"SYNC": -1,
+		"TEST": -1,
+		"UPDATE": -1,
+		"VALIDATE": -1
 	  },
 	"configurationProperties": {
 		"customSensitiveConfiguration": null,

--- a/config/connectors/definitions/mongodb-forgerock-data.json
+++ b/config/connectors/definitions/mongodb-forgerock-data.json
@@ -22,19 +22,19 @@
 		"enableAttributesToGetSearchResultsHandler": true
 	},
 	"operationTimeout": {
-		"AUTHENTICATE": 10000,
-		"CREATE": 30000,
-		"DELETE": 30000,
-		"GET": 30000,
-		"RESOLVEUSERNAME": 15000,
-		"SCHEMA": 15000,
-		"SCRIPT_ON_CONNECTOR": 15000,
-		"SCRIPT_ON_RESOURCE": 15000,
-		"SEARCH": 180000,
-		"SYNC": 180000,
-		"TEST": 10000,
-		"UPDATE": 30000,
-		"VALIDATE": -15000
+		"AUTHENTICATE": -1,
+		"CREATE": -1,
+		"DELETE": -1,
+		"GET": -1,
+		"RESOLVEUSERNAME": -1,
+		"SCHEMA": -1,
+		"SCRIPT_ON_CONNECTOR": -1,
+		"SCRIPT_ON_RESOURCE": -1,
+		"SEARCH": -1,
+		"SYNC": -1,
+		"TEST": -1,
+		"UPDATE": -1,
+		"VALIDATE": -1
 	  },
 	"configurationProperties": {
 		"customSensitiveConfiguration": null,

--- a/config/connectors/definitions/webfiling-auth-code.json
+++ b/config/connectors/definitions/webfiling-auth-code.json
@@ -107,19 +107,19 @@
 		}
 	},
 	"operationTimeout": {
-		"AUTHENTICATE": 10000,
-		"CREATE": 30000,
-		"DELETE": 30000,
-		"GET": 30000,
-		"RESOLVEUSERNAME": 15000,
-		"SCHEMA": 15000,
-		"SCRIPT_ON_CONNECTOR": 15000,
-		"SCRIPT_ON_RESOURCE": 15000,
-		"SEARCH": 180000,
-		"SYNC": 180000,
-		"TEST": 10000,
-		"UPDATE": 30000,
-		"VALIDATE": -15000
+		"AUTHENTICATE": -1,
+		"CREATE": -1,
+		"DELETE": -1,
+		"GET": -1,
+		"RESOLVEUSERNAME": -1,
+		"SCHEMA": -1,
+		"SCRIPT_ON_CONNECTOR": -1,
+		"SCRIPT_ON_RESOURCE": -1,
+		"SEARCH": -1,
+		"SYNC": -1,
+		"TEST": -1,
+		"UPDATE": -1,
+		"VALIDATE": -1
 	  },
 	"poolConfigOption": {
 		"maxIdle": 2,

--- a/config/connectors/definitions/webfiling-users.json
+++ b/config/connectors/definitions/webfiling-users.json
@@ -26,19 +26,19 @@
 		"enableAttributesToGetSearchResultsHandler": true
 	},
 	"operationTimeout": {
-		"AUTHENTICATE": 10000,
-		"CREATE": 30000,
-		"DELETE": 30000,
-		"GET": 30000,
-		"RESOLVEUSERNAME": 15000,
-		"SCHEMA": 15000,
-		"SCRIPT_ON_CONNECTOR": 15000,
-		"SCRIPT_ON_RESOURCE": 15000,
-		"SEARCH": 180000,
-		"SYNC": 180000,
-		"TEST": 10000,
-		"UPDATE": 30000,
-		"VALIDATE": -15000
+		"AUTHENTICATE": -1,
+		"CREATE": -1,
+		"DELETE": -1,
+		"GET": -1,
+		"RESOLVEUSERNAME": -1,
+		"SCHEMA": -1,
+		"SCRIPT_ON_CONNECTOR": -1,
+		"SCRIPT_ON_RESOURCE": -1,
+		"SEARCH": -1,
+		"SYNC": -1,
+		"TEST": -1,
+		"UPDATE": -1,
+		"VALIDATE": -1
 	  },
 	"configurationProperties": {
 		"connectionProperties": null,


### PR DESCRIPTION
# Description

Set RCS connector timeout settings back to previous values as connectors are timing out:
```
Mar 05, 2025 11:54:03 AM INFO  org.mongodb.driver.cluster: No server chosen by ReadPreferenceServerSelector{readPreference=primary} from cluster description ClusterDescription{type=REPLICA_SET, connectionMode=MULTIPLE, serverDescriptions=[ServerDescription{address=pl-0-eu-west-2.ueium.mongodb.net:1029, type=UNKNOWN, state=CONNECTING, exception={com.mongodb.MongoSocketOpenException: Exception opening socket}, caused by {java.net.SocketTimeoutException: Connect timed out}}, ServerDescription{address=pl-0-eu-west-2.ueium.mongodb.net:1028, type=UNKNOWN, state=CONNECTING, exception={com.mongodb.MongoSocketOpenException: Exception opening socket}, caused by {java.net.SocketTimeoutException: Connect timed out}}, ServerDescription{address=pl-0-eu-west-2.ueium.mongodb.net:1027, type=UNKNOWN, state=CONNECTING, exception={com.mongodb.MongoSocketOpenException: Exception opening socket}, caused by {java.net.SocketTimeoutException: Connect timed out}}]}. Waiting for 30000 ms before timing out 
Mar 05, 2025 11:54:13 AM WARN  o.f.o.f.r.r.LocalOperationProcessor: Operation failed 
org.identityconnectors.framework.common.exceptions.OperationTimeoutException: java.util.concurrent.TimeoutException
```

**FIDC Update Required:**
- [X] connectors / mappings / scheduled recons (IDM)
