### PR TITLE
revert connector timeout settings for rollback

### DIFF
--- a/config/connectors/definitions/webfiling-auth-code.json
+++ b/config/connectors/definitions/webfiling-auth-code.json
@@ -107,18 +107,19 @@
 		}
 	},
 	"operationTimeout": {
-		"AUTHENTICATE": 30000,       
-		"CREATE": 240000,            
-		"DELETE": 240000,             
-		"GET": 30000,                  
-		"SCHEMA": 240000,              
-		"SCRIPT_ON_CONNECTOR": 240000, 
-		"SCRIPT_ON_RESOURCE": 240000,  
-		"SEARCH": 240000,             
-		"SYNC": 240000,                
-		"TEST": 30000,                 
-		"UPDATE": 240000,              
-		"VALIDATE": 240000 
+		"AUTHENTICATE": -1,
+		"CREATE": -1,
+		"DELETE": -1,
+		"GET": -1,
+		"RESOLVEUSERNAME": -1,
+		"SCHEMA": -1,
+		"SCRIPT_ON_CONNECTOR": -1,
+		"SCRIPT_ON_RESOURCE": -1,
+		"SEARCH": -1,
+		"SYNC": -1,
+		"TEST": -1,
+		"UPDATE": -1,
+		"VALIDATE": -1
 	  },
 	"poolConfigOption": {
 		"maxIdle": 2,

--- a/config/connectors/definitions/webfiling-users.json
+++ b/config/connectors/definitions/webfiling-users.json
@@ -26,18 +26,19 @@
 		"enableAttributesToGetSearchResultsHandler": true
 	},
 	"operationTimeout": {
-		"AUTHENTICATE": 30000,       
-		"CREATE": 240000,            
-		"DELETE": 240000,             
-		"GET": 30000,                  
-		"SCHEMA": 240000,              
-		"SCRIPT_ON_CONNECTOR": 240000, 
-		"SCRIPT_ON_RESOURCE": 240000,  
-		"SEARCH": 240000,             
-		"SYNC": 240000,                
-		"TEST": 30000,                 
-		"UPDATE": 240000,              
-		"VALIDATE": 240000 
+		"AUTHENTICATE": -1,
+		"CREATE": -1,
+		"DELETE": -1,
+		"GET": -1,
+		"RESOLVEUSERNAME": -1,
+		"SCHEMA": -1,
+		"SCRIPT_ON_CONNECTOR": -1,
+		"SCRIPT_ON_RESOURCE": -1,
+		"SEARCH": -1,
+		"SYNC": -1,
+		"TEST": -1,
+		"UPDATE": -1,
+		"VALIDATE": -1 
 	  },
 	"configurationProperties": {
 		"connectionProperties": null,


### PR DESCRIPTION
# Description

This PR rolls back RCS server timeout configuration in the event that we need to roll back the production release on 10/04/2025


<!--
Please tick any config items changed 
that will require FR to update FIDC
environment specific variables.
-->
**FIDC Update Required:**
- [ ] access config (IDM)
- [ ] agents (AM)
- [ ] applications (AM)
- [ ] auth trees (AM)
- [ ] bash scripts
- [X] connectors / mappings / scheduled recons (IDM)
- [ ] cors (AM/IDM)
- [ ] custom endpoints / scheduled scripts or tasks (IDM)
- [ ] internal-roles (IDM)
- [ ] journey scripts (AM)
- [ ] managed-objects (IDM)
- [ ] managed-users (IDM)
- [ ] password-policy (IDM)
- [ ] secrets
- [ ] services (AM)
- [ ] terms and conditions (IDM)
- [ ] ui (IDM)
- [ ] variables
