### PR TITLE
Change SQL query to use function-based indexing

### DIFF
--- a/config/am-scripts/scripts-content/ch-check-user-source.js
+++ b/config/am-scripts/scripts-content/ch-check-user-source.js
@@ -227,13 +227,13 @@ function createOrUpdateUser (accessToken, email) {
 }
 
 function fetchUserFromEWFByParentUsername (parentUsername) {
-  var searchTerm = '?_queryFilter=_id+eq+%22' + parentUsername + '%22';
+  var searchTerm = '?_queryFilter=_id+ci+%22' + parentUsername + '%22';
   return fetchUserFromEWFBySearchTerm(accessToken, searchTerm);
 }
 
 function fetchUserFromEWFByEmail (email) {
   var emailEncoded = encodeURIComponent(email.trim());
-  var searchTerm = '?_queryFilter=EMAIL+eq+%22' + emailEncoded + '%22';
+  var searchTerm = '?_queryFilter=EMAIL+ci+%22' + emailEncoded + '%22';
   return fetchUserFromEWFBySearchTerm(accessToken, searchTerm);
 }
 


### PR DESCRIPTION
# Description
Use the `ci` (case-insensitive) operator instead of `eq` (equals). This will translate to the following SQL query that uses function-based indexing: 
`SELECT ... FROM CUSTOMER_VIEW WHERE LOWER(EMAIL) = LOWER(?)`

**FIDC Update Required:**
- [X] journey scripts (AM)
